### PR TITLE
Add trailers

### DIFF
--- a/http3/body.go
+++ b/http3/body.go
@@ -36,9 +36,9 @@ var _ io.ReadCloser = &body{}
 
 func newRequestBody(str quic.Stream, onFrameError func()) *body {
 	return &body{
-		str:            str,
-		onFrameError:   onFrameError,
-		isRequest:      true,
+		str:          str,
+		onFrameError: onFrameError,
+		isRequest:    true,
 	}
 }
 
@@ -93,7 +93,8 @@ func (r *body) readImpl(b []byte) (int, error) {
 					r.resp.Trailer.Add(trailer.Name, trailer.Value)
 				}
 
-				continue
+				// Trailer Frame is the last frame.
+				return 0, nil
 			case *dataFrame:
 				r.bytesRemainingInFrame = f.Length
 				break parseLoop

--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/golang/mock/gomock"
 	"github.com/lucas-clemente/quic-go"
@@ -68,7 +69,7 @@ var _ = Describe("Body", func() {
 					rb = newRequestBody(str, errorCb)
 				case bodyTypeResponse:
 					reqDone = make(chan struct{})
-					rb = newResponseBody(str, reqDone, errorCb)
+					rb = newResponseBody(str, reqDone, errorCb, &http.Response{})
 				}
 			})
 

--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/lucas-clemente/quic-go"
 	mockquic "github.com/lucas-clemente/quic-go/internal/mocks/quic"
+	"github.com/marten-seemann/qpack"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -69,7 +70,7 @@ var _ = Describe("Body", func() {
 					rb = newRequestBody(str, errorCb)
 				case bodyTypeResponse:
 					reqDone = make(chan struct{})
-					rb = newResponseBody(str, reqDone, errorCb, &http.Response{})
+					rb = newResponseBody(str, reqDone, errorCb, &http.Response{}, qpack.NewDecoder(func(f qpack.HeaderField) {}), defaultMaxResponseHeaderBytes)
 				}
 			})
 

--- a/http3/client.go
+++ b/http3/client.go
@@ -255,7 +255,7 @@ func (c *client) doRequest(
 	}
 	respBody := newResponseBody(str, reqDone, func() {
 		c.session.CloseWithError(quic.ErrorCode(errorFrameUnexpected), "")
-	})
+	}, res)
 	if requestGzip && res.Header.Get("Content-Encoding") == "gzip" {
 		res.Header.Del("Content-Encoding")
 		res.Header.Del("Content-Length")

--- a/http3/client.go
+++ b/http3/client.go
@@ -255,7 +255,7 @@ func (c *client) doRequest(
 	}
 	respBody := newResponseBody(str, reqDone, func() {
 		c.session.CloseWithError(quic.ErrorCode(errorFrameUnexpected), "")
-	}, res)
+	}, res, c.decoder, c.maxHeaderBytes())
 	if requestGzip && res.Header.Get("Content-Encoding") == "gzip" {
 		res.Header.Del("Content-Encoding")
 		res.Header.Del("Content-Length")

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -120,7 +120,7 @@ func (w *responseWriter) declareTrailer(k string) {
 	}
 }
 
-func (w *responseWriter) hasNonemptyTrailers() bool {
+func (w *responseWriter) hasNonEmptyTrailers() bool {
 	for _, trailer := range w.trailers {
 		if _, ok := w.header[trailer]; ok {
 			return true
@@ -132,7 +132,7 @@ func (w *responseWriter) hasNonemptyTrailers() bool {
 func (w *responseWriter) writeTrailers() {
 	w.promoteTrailer()
 
-	if !w.hasNonemptyTrailers() {
+	if !w.hasNonEmptyTrailers() {
 		return
 	}
 

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -16,9 +16,9 @@ import (
 type responseWriter struct {
 	stream io.Writer
 
-	header        http.Header
-	trailers      []string
-	
+	header   http.Header
+	trailers []string
+
 	status        int // status code passed to WriteHeader
 	headerWritten bool
 

--- a/http3/server.go
+++ b/http3/server.go
@@ -268,6 +268,10 @@ func (s *Server) handleRequest(sess quic.Session, str quic.Stream, decoder *qpac
 			}
 		}()
 		handler.ServeHTTP(responseWriter, req)
+
+		// Write Trailers when ServeHTTP is finished to send trailers once
+		responseWriter.writeTrailers()
+
 		// read the eof
 		if _, err = str.Read([]byte{0}); err == io.EOF {
 			readEOF = true


### PR DESCRIPTION
This PR adds Trailers support.

Fix #2266

This implementation is based on http2 trailers, so to send a trailer, you must:
- announce Trailer in the Trailer header (before `WriteHeader`) and then (after` WriteHeader`) add your Trailer value in ResponseWriter.Header ()
- or you can use TrailerPrefix, by simply adding headers (after `WriteHeader`) with the TrailerPrefix (` Trailer: `)

I could not test it with another server / client implementation.