### PR TITLE
set the ECN bits on outgoing packets

### DIFF
--- a/conn_ecn.go
+++ b/conn_ecn.go
@@ -32,11 +32,17 @@ func newConn(c *net.UDPConn) (*ecnConn, error) {
 	var errIPv4, errIPv6 error
 	if err := rawConn.Control(func(fd uintptr) {
 		errIPv4 = setRECVTOS(fd)
+		if errIPv4 == nil {
+			errIPv4 = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TOS, 2)
+		}
 	}); err != nil {
 		return nil, err
 	}
 	if err := rawConn.Control(func(fd uintptr) {
 		errIPv6 = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, syscall.IPV6_RECVTCLASS, 1)
+		if errIPv6 == nil {
+			errIPv6 = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, syscall.IPV6_TCLASS, 2)
+		}
 	}); err != nil {
 		return nil, err
 	}

--- a/conn_ecn_test.go
+++ b/conn_ecn_test.go
@@ -52,6 +52,32 @@ var _ = Describe("Basic Conn Test", func() {
 			return conn.LocalAddr()
 		}
 
+		It("sets ECT0 on outgoing packets, for IPv4", func() {
+			server, packetChan := runServer("udp4", "localhost:0")
+			cl, err := net.DialUDP("udp4", nil, server.LocalAddr().(*net.UDPAddr))
+			Expect(err).ToNot(HaveOccurred())
+			conn, err := newConn(cl)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = conn.Write([]byte("foobar"))
+			Expect(err).ToNot(HaveOccurred())
+			var p *receivedPacket
+			Eventually(packetChan).Should(Receive(&p))
+			Expect(p.ecn).To(Equal(protocol.ECT0))
+		})
+
+		It("sets ECT0 on outgoing packets, for IPv6", func() {
+			server, packetChan := runServer("udp6", "[::]:0")
+			cl, err := net.DialUDP("udp6", nil, server.LocalAddr().(*net.UDPAddr))
+			Expect(err).ToNot(HaveOccurred())
+			conn, err := newConn(cl)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = conn.Write([]byte("foobar"))
+			Expect(err).ToNot(HaveOccurred())
+			var p *receivedPacket
+			Eventually(packetChan).Should(Receive(&p))
+			Expect(p.ecn).To(Equal(protocol.ECT0))
+		})
+
 		It("reads ECN flags on IPv4", func() {
 			conn, packetChan := runServer("udp4", "localhost:0")
 			defer conn.Close()


### PR DESCRIPTION
Not sure if we already want to merge this. Currently, it will just increase the size of ACK frames, as we're not yet using the ECN signal.