### PR TITLE
Remove a h3 client from the pool when dead

### DIFF
--- a/http3/roundtrip_test.go
+++ b/http3/roundtrip_test.go
@@ -29,6 +29,10 @@ func (m *mockClient) Close() error {
 	return nil
 }
 
+func (m *mockClient) alive() bool {
+	return !m.closed
+}
+
 var _ roundTripCloser = &mockClient{}
 
 type mockBody struct {
@@ -242,7 +246,7 @@ var _ = Describe("RoundTripper", func() {
 
 	Context("closing", func() {
 		It("closes", func() {
-			rt.clients = make(map[string]roundTripCloser)
+			rt.clients = make(map[string]roundTripAliveCloser)
 			cl := &mockClient{}
 			rt.clients["foo.bar"] = cl
 			err := rt.Close()


### PR DESCRIPTION
When the session of a client becomes invalid, all subsequent requests
with that client will fail. The RoundTripper's connection pool is not
aware of that and keep using it, which creates a dead end for the
impacted hostname.

This change make sure clients are removed from the pool when in
permanent error. A proper change should probably also retry the requests
on connection errors, but it would require a larger rearchitecture of
how the RoundTripper works. With this, the RoundTripper gives a chance
to the caller to handle errors and retry, which makes at least the
RoundTripper usable.

Fixes #765