### PR TITLE
Expose convenience method for exposing TLS state

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -2,6 +2,7 @@ package quic
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"io"
 	"net"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go/internal/handshake"
 	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/lucas-clemente/quic-go/internal/qtls"
 	"github.com/lucas-clemente/quic-go/logging"
 )
 
@@ -298,6 +300,10 @@ type Config struct {
 type ConnectionState struct {
 	TLS               handshake.ConnectionState
 	SupportsDatagrams bool
+}
+
+func (s *ConnectionState) ToTLSConnectionState() tls.ConnectionState {
+	return qtls.ToTLSConnectionState(s.TLS)
 }
 
 // A Listener for incoming QUIC connections


### PR DESCRIPTION
We seem to craft this manually in syncthing, which seems to break quite frequently between the releases.
I know the API is marked as not stable, but if there is a helper method to get the struct we are after, makes our life much easier.