### PR TITLE
use IP_PMTUDISC_PROBE for setting the DF bit on Linux & Windows, add support for darwin & FreeBSD

### DIFF
--- a/sys_conn_df.go
+++ b/sys_conn_df.go
@@ -1,5 +1,5 @@
-//go:build !linux && !windows
-// +build !linux,!windows
+//go:build !linux && !windows && !darwin && !freebsd
+// +build !linux,!windows,!darwin,!freebsd
 
 package quic
 

--- a/sys_conn_df_bsd.go
+++ b/sys_conn_df_bsd.go
@@ -27,7 +27,7 @@ func setDF(rawConn syscall.RawConn) error {
 	case errDFIPv4 != nil && errDFIPv6 == nil:
 		utils.DefaultLogger.Debugf("Setting DF for IPv6.")
 	case errDFIPv4 != nil && errDFIPv6 != nil:
-		return errors.New("setting DF failed for both IPv4 and IPv6")
+		utils.DefaultLogger.Errorf("setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
 	}
 	return nil
 }

--- a/sys_conn_df_bsd.go
+++ b/sys_conn_df_bsd.go
@@ -27,7 +27,7 @@ func setDF(rawConn syscall.RawConn) error {
 	case errDFIPv4 != nil && errDFIPv6 == nil:
 		utils.DefaultLogger.Debugf("Setting DF for IPv6.")
 	case errDFIPv4 != nil && errDFIPv6 != nil:
-		utils.DefaultLogger.Errorf("setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
+		utils.DefaultLogger.Errorf("Setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
 	}
 	return nil
 }

--- a/sys_conn_df_linux.go
+++ b/sys_conn_df_linux.go
@@ -27,7 +27,7 @@ func setDF(rawConn syscall.RawConn) error {
 	case errDFIPv4 != nil && errDFIPv6 == nil:
 		utils.DefaultLogger.Debugf("Setting DF for IPv6.")
 	case errDFIPv4 != nil && errDFIPv6 != nil:
-		return errors.New("setting DF failed for both IPv4 and IPv6")
+		utils.DefaultLogger.Errorf("setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
 	}
 	return nil
 }

--- a/sys_conn_df_linux.go
+++ b/sys_conn_df_linux.go
@@ -27,7 +27,7 @@ func setDF(rawConn syscall.RawConn) error {
 	case errDFIPv4 != nil && errDFIPv6 == nil:
 		utils.DefaultLogger.Debugf("Setting DF for IPv6.")
 	case errDFIPv4 != nil && errDFIPv6 != nil:
-		utils.DefaultLogger.Errorf("setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
+		utils.DefaultLogger.Errorf("Setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
 	}
 	return nil
 }

--- a/sys_conn_df_windows.go
+++ b/sys_conn_df_windows.go
@@ -44,7 +44,7 @@ func setDF(rawConn syscall.RawConn) error {
 	case errDFIPv4 != nil && errDFIPv6 == nil:
 		utils.DefaultLogger.Debugf("Setting DF for IPv6.")
 	case errDFIPv4 != nil && errDFIPv6 != nil:
-		return errors.New("setting DF failed for both IPv4 and IPv6")
+		utils.DefaultLogger.Errorf("setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
 	}
 	return nil
 }

--- a/sys_conn_df_windows.go
+++ b/sys_conn_df_windows.go
@@ -13,17 +13,26 @@ import (
 
 const (
 	// same for both IPv4 and IPv6 on Windows
-	// https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IP_DONTFRAG.html
-	// https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IPV6_DONTFRAG.html
-	IP_DONTFRAGMENT = 14
-	IPV6_DONTFRAG   = 14
+	// https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IP_MTU_DISCOVER.html
+	// https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IPV6_MTU_DISCOVER.html
+	IP_MTU_DISCOVER   = 14
+	IPV6_MTU_DISCOVER = 14
+)
+
+// enum PMTUD_STATE from ws2ipdef.h
+const (
+	IP_PMTUDISC_NOT_SET = iota
+	IP_PMTUDISC_DO
+	IP_PMTUDISC_DONT
+	IP_PMTUDISC_PROBE
+	IP_PMTUDISC_MAX
 )
 
 func setDF(rawConn syscall.RawConn) error {
 	var errDFIPv4, errDFIPv6 error
 	if err := rawConn.Control(func(fd uintptr) {
-		errDFIPv4 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, IP_DONTFRAGMENT, 1)
-		errDFIPv6 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IPV6, IPV6_DONTFRAG, 1)
+		errDFIPv4 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, IP_MTU_DISCOVER, IP_PMTUDISC_PROBE)
+		errDFIPv6 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IPV6, IPV6_MTU_DISCOVER, IP_PMTUDISC_PROBE)
 	}); err != nil {
 		return err
 	}

--- a/sys_conn_df_windows.go
+++ b/sys_conn_df_windows.go
@@ -13,26 +13,17 @@ import (
 
 const (
 	// same for both IPv4 and IPv6 on Windows
-	// https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IP_MTU_DISCOVER.html
-	// https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IPV6_MTU_DISCOVER.html
-	IP_MTU_DISCOVER   = 71
-	IPV6_MTU_DISCOVER = 71
-)
-
-// enum PMTUD_STATE from ws2ipdef.h
-const (
-	IP_PMTUDISC_NOT_SET = iota
-	IP_PMTUDISC_DO
-	IP_PMTUDISC_DONT
-	IP_PMTUDISC_PROBE
-	IP_PMTUDISC_MAX
+	// https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IP_DONTFRAGMENT.html
+	// https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IPV6_DONTFRAG.html
+	IP_DONTFRAGMENT = 14
+	IPV6_DONTFRAG   = 14
 )
 
 func setDF(rawConn syscall.RawConn) error {
 	var errDFIPv4, errDFIPv6 error
 	if err := rawConn.Control(func(fd uintptr) {
-		errDFIPv4 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, IP_MTU_DISCOVER, IP_PMTUDISC_PROBE)
-		errDFIPv6 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IPV6, IPV6_MTU_DISCOVER, IP_PMTUDISC_PROBE)
+		errDFIPv4 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IP, IP_DONTFRAGMENT, 1)
+		errDFIPv6 = windows.SetsockoptInt(windows.Handle(fd), windows.IPPROTO_IPV6, IPV6_DONTFRAG, 1)
 	}); err != nil {
 		return err
 	}
@@ -44,7 +35,7 @@ func setDF(rawConn syscall.RawConn) error {
 	case errDFIPv4 != nil && errDFIPv6 == nil:
 		utils.DefaultLogger.Debugf("Setting DF for IPv6.")
 	case errDFIPv4 != nil && errDFIPv6 != nil:
-		utils.DefaultLogger.Errorf("setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
+		utils.DefaultLogger.Errorf("Setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
 	}
 	return nil
 }

--- a/sys_conn_df_windows.go
+++ b/sys_conn_df_windows.go
@@ -15,8 +15,8 @@ const (
 	// same for both IPv4 and IPv6 on Windows
 	// https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IP_MTU_DISCOVER.html
 	// https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Networking/WinSock/constant.IPV6_MTU_DISCOVER.html
-	IP_MTU_DISCOVER   = 14
-	IPV6_MTU_DISCOVER = 14
+	IP_MTU_DISCOVER   = 71
+	IPV6_MTU_DISCOVER = 71
 )
 
 // enum PMTUD_STATE from ws2ipdef.h


### PR DESCRIPTION
Thank @database64128

I can confirm that this (still) works on Linux & Windows. But we probably need to have someone test it under macOS and FreeBSD.