### PR TITLE
implement greasing of the QUIC bit (RFC 9287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/lucas-clemente/quic-go)](https://pkg.go.dev/github.com/lucas-clemente/quic-go)
 [![Code Coverage](https://img.shields.io/codecov/c/github/lucas-clemente/quic-go/master.svg?style=flat-square)](https://codecov.io/gh/lucas-clemente/quic-go/)
 
-quic-go is an implementation of the QUIC protocol ([RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000), [RFC 9001](https://datatracker.ietf.org/doc/html/rfc9001), [RFC 9002](https://datatracker.ietf.org/doc/html/rfc9002)) in Go, including the Unreliable Datagram Extension ([RFC 9221](https://datatracker.ietf.org/doc/html/rfc9221)). It has support for HTTP/3 ([RFC 9114](https://datatracker.ietf.org/doc/html/rfc9114)), including QPACK ([RFC 9204](https://datatracker.ietf.org/doc/html/rfc9204)).
+quic-go is an implementation of the QUIC protocol ([RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000), [RFC 9001](https://datatracker.ietf.org/doc/html/rfc9001), [RFC 9002](https://datatracker.ietf.org/doc/html/rfc9002)) in Go, including the Unreliable Datagram Extension ([RFC 9221](https://datatracker.ietf.org/doc/html/rfc9221)) and Greasing of the QUIC Bit ([RFC 9287](https://datatracker.ietf.org/doc/html/rfc9287)). It has support for HTTP/3 ([RFC 9114](https://datatracker.ietf.org/doc/html/rfc9114)), including QPACK ([RFC 9204](https://datatracker.ietf.org/doc/html/rfc9204)).
 
 In addition to the RFCs listed above, it currently implements the [IETF QUIC draft-29](https://tools.ietf.org/html/draft-ietf-quic-transport-29). Support for draft-29 will eventually be dropped, as it is phased out of the ecosystem.
 

--- a/config.go
+++ b/config.go
@@ -135,6 +135,7 @@ func populateConfig(config *Config, defaultConnIDLen int) *Config {
 		EnableDatagrams:                  config.EnableDatagrams,
 		DisablePathMTUDiscovery:          config.DisablePathMTUDiscovery,
 		DisableVersionNegotiationPackets: config.DisableVersionNegotiationPackets,
+		DisableQUICBitGreasing:           config.DisableQUICBitGreasing,
 		Tracer:                           config.Tracer,
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -85,6 +85,8 @@ var _ = Describe("Config", func() {
 				f.Set(reflect.ValueOf(true))
 			case "DisablePathMTUDiscovery":
 				f.Set(reflect.ValueOf(true))
+			case "DisableQUICBitGreasing":
+				f.Set(reflect.ValueOf(true))
 			case "Tracer":
 				f.Set(reflect.ValueOf(mocklogging.NewMockTracer(mockCtrl)))
 			default:
@@ -164,6 +166,7 @@ var _ = Describe("Config", func() {
 			Expect(c.MaxIncomingUniStreams).To(BeEquivalentTo(protocol.DefaultMaxIncomingUniStreams))
 			Expect(c.DisableVersionNegotiationPackets).To(BeFalse())
 			Expect(c.DisablePathMTUDiscovery).To(BeFalse())
+			Expect(c.DisableQUICBitGreasing).To(BeFalse())
 		})
 
 		It("populates empty fields with default values, for the server", func() {

--- a/connection.go
+++ b/connection.go
@@ -869,7 +869,7 @@ func (s *connection) handlePacketImpl(rp *receivedPacket) bool {
 			p.data = data
 		}
 
-		hdr, packetData, rest, err := wire.ParsePacket(p.data, s.srcConnIDLen, false)
+		hdr, packetData, rest, err := wire.ParsePacket(p.data, s.srcConnIDLen, s.quicBitGreasingEnabled)
 		if err != nil {
 			if s.tracer != nil {
 				dropReason := logging.PacketDropHeaderParseError

--- a/connection.go
+++ b/connection.go
@@ -314,6 +314,7 @@ var newConnection = func(
 		ActiveConnectionIDLimit:         protocol.MaxActiveConnectionIDs,
 		InitialSourceConnectionID:       srcConnID,
 		RetrySourceConnectionID:         retrySrcConnID,
+		GreaseQuicBit:                   !s.config.DisableQUICBitGreasing,
 	}
 	if s.config.EnableDatagrams {
 		params.MaxDatagramFrameSize = protocol.MaxDatagramFrameSize
@@ -442,6 +443,7 @@ var newClientConnection = func(
 		DisableActiveMigration:         true,
 		ActiveConnectionIDLimit:        protocol.MaxActiveConnectionIDs,
 		InitialSourceConnectionID:      srcConnID,
+		GreaseQuicBit:                  !s.config.DisableQUICBitGreasing,
 	}
 	if s.config.EnableDatagrams {
 		params.MaxDatagramFrameSize = protocol.MaxDatagramFrameSize

--- a/connection.go
+++ b/connection.go
@@ -862,7 +862,7 @@ func (s *connection) handlePacketImpl(rp *receivedPacket) bool {
 			p.data = data
 		}
 
-		hdr, packetData, rest, err := wire.ParsePacket(p.data, s.srcConnIDLen)
+		hdr, packetData, rest, err := wire.ParsePacket(p.data, s.srcConnIDLen, false)
 		if err != nil {
 			if s.tracer != nil {
 				dropReason := logging.PacketDropHeaderParseError

--- a/connection_test.go
+++ b/connection_test.go
@@ -672,6 +672,7 @@ var _ = Describe("Connection", func() {
 		})
 
 		It("drops packets for which header decryption fails", func() {
+			conn.quicBitGreasingEnabled = false
 			p := getPacket(&wire.ExtendedHeader{
 				Header: wire.Header{
 					IsLongHeader: true,

--- a/connection_test.go
+++ b/connection_test.go
@@ -559,7 +559,7 @@ var _ = Describe("Connection", func() {
 				Header:          wire.Header{DestConnectionID: srcConnID},
 				PacketNumberLen: protocol.PacketNumberLen2,
 			}
-			Expect(hdr.Write(buf, conn.version)).To(Succeed())
+			Expect(hdr.Write(buf, true, conn.version)).To(Succeed())
 			unpacker.EXPECT().Unpack(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(*wire.Header, time.Time, []byte) (*unpackedPacket, error) {
 				buf := &bytes.Buffer{}
 				Expect((&wire.ConnectionCloseFrame{ErrorCode: uint64(qerr.StreamLimitError)}).Write(buf, conn.version)).To(Succeed())
@@ -641,7 +641,7 @@ var _ = Describe("Connection", func() {
 
 		getPacket := func(extHdr *wire.ExtendedHeader, data []byte) *receivedPacket {
 			buf := &bytes.Buffer{}
-			Expect(extHdr.Write(buf, conn.version)).To(Succeed())
+			Expect(extHdr.Write(buf, true, conn.version)).To(Succeed())
 			return &receivedPacket{
 				data:    append(buf.Bytes(), data...),
 				buffer:  getPacketBuffer(),
@@ -2413,7 +2413,7 @@ var _ = Describe("Client Connection", func() {
 
 	getPacket := func(hdr *wire.ExtendedHeader, data []byte) *receivedPacket {
 		buf := &bytes.Buffer{}
-		Expect(hdr.Write(buf, conn.version)).To(Succeed())
+		Expect(hdr.Write(buf, true, conn.version)).To(Succeed())
 		return &receivedPacket{
 			data:   append(buf.Bytes(), data...),
 			buffer: getPacketBuffer(),
@@ -2691,7 +2691,7 @@ var _ = Describe("Client Connection", func() {
 
 		getRetryTag := func(hdr *wire.ExtendedHeader) []byte {
 			buf := &bytes.Buffer{}
-			hdr.Write(buf, conn.version)
+			hdr.Write(buf, true, conn.version)
 			return handshake.GetRetryIntegrityTag(buf.Bytes(), origDestConnID, hdr.Version)[:]
 		}
 
@@ -2902,7 +2902,7 @@ var _ = Describe("Client Connection", func() {
 
 		getPacket := func(extHdr *wire.ExtendedHeader, data []byte) *receivedPacket {
 			buf := &bytes.Buffer{}
-			Expect(extHdr.Write(buf, conn.version)).To(Succeed())
+			Expect(extHdr.Write(buf, true, conn.version)).To(Succeed())
 			return &receivedPacket{
 				data:   append(buf.Bytes(), data...),
 				buffer: getPacketBuffer(),

--- a/fuzzing/header/cmd/corpus.go
+++ b/fuzzing/header/cmd/corpus.go
@@ -96,7 +96,7 @@ func main() {
 			PacketNumber:    protocol.PacketNumber(rand.Uint64()),
 		}
 		b := &bytes.Buffer{}
-		if err := extHdr.Write(b, version); err != nil {
+		if err := extHdr.Write(b, true, version); err != nil {
 			log.Fatal(err)
 		}
 		if h.Type == protocol.PacketTypeRetry {

--- a/fuzzing/header/fuzz.go
+++ b/fuzzing/header/fuzz.go
@@ -59,7 +59,7 @@ func Fuzz(data []byte) int {
 		return 1
 	}
 	b := &bytes.Buffer{}
-	if err := extHdr.Write(b, version); err != nil {
+	if err := extHdr.Write(b, true, version); err != nil {
 		// We are able to parse packets with connection IDs longer than 20 bytes,
 		// but in QUIC version 1, we don't write headers with longer connection IDs.
 		if hdr.DestConnectionID.Len() <= protocol.MaxConnIDLen &&

--- a/fuzzing/header/fuzz.go
+++ b/fuzzing/header/fuzz.go
@@ -31,7 +31,7 @@ func Fuzz(data []byte) int {
 		return 0
 	}
 	is0RTTPacket := wire.Is0RTTPacket(data)
-	hdr, _, _, err := wire.ParsePacket(data, connIDLen)
+	hdr, _, _, err := wire.ParsePacket(data, connIDLen, false)
 	if err != nil {
 		return 0
 	}

--- a/integrationtests/self/grease_quic_bit_test.go
+++ b/integrationtests/self/grease_quic_bit_test.go
@@ -1,0 +1,158 @@
+package self_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+
+	"github.com/lucas-clemente/quic-go"
+	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("QUIC Bit Greasing", func() {
+	type counter struct {
+		incomingQUICBitSet, outgoingQUICBitSet       uint32
+		incomingQUICBitNotSet, outgoingQUICBitNotSet uint32
+	}
+
+	runProxy := func(serverAddr string) (*counter, *quicproxy.QuicProxy) {
+		var c counter
+		proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
+			RemoteAddr: serverAddr,
+			DropPacket: func(dir quicproxy.Direction, packet []byte) bool {
+				set := packet[0]&0x40 > 0
+				switch {
+				case dir == quicproxy.DirectionIncoming && set:
+					atomic.AddUint32(&c.incomingQUICBitSet, 1)
+				case dir == quicproxy.DirectionIncoming && !set:
+					atomic.AddUint32(&c.incomingQUICBitNotSet, 1)
+				case dir == quicproxy.DirectionOutgoing && set:
+					atomic.AddUint32(&c.outgoingQUICBitSet, 1)
+				case dir == quicproxy.DirectionOutgoing && !set:
+					atomic.AddUint32(&c.outgoingQUICBitNotSet, 1)
+				}
+				return false
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		return &c, proxy
+	}
+
+	runTransfer := func(ln quic.Listener, clientConf *quic.Config, proxyPort int) {
+		go func() {
+			defer GinkgoRecover()
+			conn, err := ln.Accept(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			str, err := conn.AcceptStream(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			defer str.Close()
+			_, err = io.Copy(str, str)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		conn, err := quic.DialAddr(fmt.Sprintf("localhost:%d", proxyPort), tlsClientConfig, clientConf)
+		Expect(err).ToNot(HaveOccurred())
+		str, err := conn.OpenStream()
+		Expect(err).ToNot(HaveOccurred())
+		_, err = str.Write(PRData)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(str.Close()).To(Succeed())
+		_, err = io.Copy(io.Discard, str)
+		Expect(err).ToNot(HaveOccurred())
+		conn.CloseWithError(0, "")
+	}
+
+	for _, v := range protocol.SupportedVersions {
+		version := v
+
+		Context(fmt.Sprintf("with QUIC version %s", version), func() {
+			It("disables QUIC bit greasing on both sides", func() {
+				ln, err := quic.ListenAddr(
+					"localhost:0",
+					tlsConfig,
+					getQuicConfig(&quic.Config{
+						DisableQUICBitGreasing: true,
+						Versions:               []protocol.VersionNumber{version},
+					}),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer ln.Close()
+				c, proxy := runProxy(fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port))
+				defer proxy.Close()
+				runTransfer(
+					ln,
+					getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{version}, DisableQUICBitGreasing: true}),
+					proxy.LocalPort(),
+				)
+
+				Expect(atomic.LoadUint32(&c.incomingQUICBitSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.outgoingQUICBitSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.incomingQUICBitNotSet)).To(BeZero())
+				Expect(atomic.LoadUint32(&c.outgoingQUICBitNotSet)).To(BeZero())
+			})
+
+			It("enables QUIC bit greasing on the server side", func() {
+				ln, err := quic.ListenAddr(
+					"localhost:0",
+					tlsConfig,
+					getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{version}}),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer ln.Close()
+				c, proxy := runProxy(fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port))
+				defer proxy.Close()
+
+				// When greasing is enabled by the quic.Config, we occasionally disable it to grease the greasing mechanism.
+				// If we hit one of those cases, just rerun the transfer.
+				for i := 0; i < 10; i++ {
+					runTransfer(
+						ln,
+						getQuicConfig(&quic.Config{
+							DisableQUICBitGreasing: true,
+							Versions:               []protocol.VersionNumber{version},
+						}),
+						proxy.LocalPort(),
+					)
+					if atomic.LoadUint32(&c.incomingQUICBitNotSet) > 0 {
+						break
+					}
+				}
+
+				Expect(atomic.LoadUint32(&c.outgoingQUICBitSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.incomingQUICBitNotSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.outgoingQUICBitNotSet)).To(BeZero())
+			})
+
+			It("enables QUIC bit greasing on the client side", func() {
+				ln, err := quic.ListenAddr(
+					"localhost:0",
+					tlsConfig,
+					getQuicConfig(&quic.Config{DisableQUICBitGreasing: true}),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer ln.Close()
+				c, proxy := runProxy(fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port))
+				defer proxy.Close()
+
+				// When greasing is enabled by the quic.Config, we occasionally disable it to grease the greasing mechanism.
+				// If we hit one of those cases, just rerun the transfer.
+				for i := 0; i < 10; i++ {
+					runTransfer(ln, getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{version}}), proxy.LocalPort())
+					if atomic.LoadUint32(&c.outgoingQUICBitNotSet) > 0 {
+						break
+					}
+				}
+
+				Expect(atomic.LoadUint32(&c.outgoingQUICBitNotSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.incomingQUICBitSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.incomingQUICBitNotSet)).To(BeZero())
+			})
+		})
+	}
+})

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -95,7 +95,7 @@ var _ = Describe("MITM test", func() {
 
 					sendRandomPacketsOfSameType := func(conn net.PacketConn, remoteAddr net.Addr, raw []byte) {
 						defer GinkgoRecover()
-						hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false)
+						hdr, _, _, err := wire.ParsePacket(raw, connIDLen, true)
 						Expect(err).ToNot(HaveOccurred())
 						replyHdr := &wire.ExtendedHeader{
 							Header: wire.Header{
@@ -317,7 +317,7 @@ var _ = Describe("MITM test", func() {
 						if dir == quicproxy.DirectionIncoming {
 							defer GinkgoRecover()
 
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, true)
 							Expect(err).ToNot(HaveOccurred())
 
 							if hdr.Type != protocol.PacketTypeInitial {
@@ -355,7 +355,7 @@ var _ = Describe("MITM test", func() {
 							defer GinkgoRecover()
 							defer close(done)
 
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, true)
 							Expect(err).ToNot(HaveOccurred())
 
 							if hdr.Type != protocol.PacketTypeInitial {
@@ -388,7 +388,7 @@ var _ = Describe("MITM test", func() {
 						if dir == quicproxy.DirectionIncoming {
 							defer GinkgoRecover()
 
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, true)
 							Expect(err).ToNot(HaveOccurred())
 							if hdr.Type != protocol.PacketTypeInitial || injected {
 								return 0
@@ -415,7 +415,7 @@ var _ = Describe("MITM test", func() {
 					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
 						if dir == quicproxy.DirectionIncoming {
 							defer GinkgoRecover()
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, true)
 							Expect(err).ToNot(HaveOccurred())
 							if hdr.Type != protocol.PacketTypeInitial || injected {
 								return 0

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -115,7 +115,7 @@ var _ = Describe("MITM test", func() {
 							payloadLen := mrand.Int31n(100)
 							replyHdr.Length = protocol.ByteCount(mrand.Int31n(payloadLen + 1))
 							buf := &bytes.Buffer{}
-							Expect(replyHdr.Write(buf, version)).To(Succeed())
+							Expect(replyHdr.Write(buf, true, version)).To(Succeed())
 							b := make([]byte, payloadLen)
 							mrand.Read(b)
 							buf.Write(b)

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -95,7 +95,7 @@ var _ = Describe("MITM test", func() {
 
 					sendRandomPacketsOfSameType := func(conn net.PacketConn, remoteAddr net.Addr, raw []byte) {
 						defer GinkgoRecover()
-						hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+						hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false)
 						Expect(err).ToNot(HaveOccurred())
 						replyHdr := &wire.ExtendedHeader{
 							Header: wire.Header{
@@ -317,7 +317,7 @@ var _ = Describe("MITM test", func() {
 						if dir == quicproxy.DirectionIncoming {
 							defer GinkgoRecover()
 
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false)
 							Expect(err).ToNot(HaveOccurred())
 
 							if hdr.Type != protocol.PacketTypeInitial {
@@ -355,7 +355,7 @@ var _ = Describe("MITM test", func() {
 							defer GinkgoRecover()
 							defer close(done)
 
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false)
 							Expect(err).ToNot(HaveOccurred())
 
 							if hdr.Type != protocol.PacketTypeInitial {
@@ -388,7 +388,7 @@ var _ = Describe("MITM test", func() {
 						if dir == quicproxy.DirectionIncoming {
 							defer GinkgoRecover()
 
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false)
 							Expect(err).ToNot(HaveOccurred())
 							if hdr.Type != protocol.PacketTypeInitial || injected {
 								return 0
@@ -415,8 +415,7 @@ var _ = Describe("MITM test", func() {
 					delayCb := func(dir quicproxy.Direction, raw []byte) time.Duration {
 						if dir == quicproxy.DirectionIncoming {
 							defer GinkgoRecover()
-
-							hdr, _, _, err := wire.ParsePacket(raw, connIDLen)
+							hdr, _, _, err := wire.ParsePacket(raw, connIDLen, false)
 							Expect(err).ToNot(HaveOccurred())
 							if hdr.Type != protocol.PacketTypeInitial || injected {
 								return 0

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -36,7 +36,7 @@ var _ = Describe("0-RTT", func() {
 					RemoteAddr: fmt.Sprintf("localhost:%d", serverPort),
 					DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
 						for len(data) > 0 {
-							hdr, _, rest, err := wire.ParsePacket(data, 0, false)
+							hdr, _, rest, err := wire.ParsePacket(data, 0, true)
 							Expect(err).ToNot(HaveOccurred())
 							if hdr.Type == protocol.PacketType0RTT {
 								atomic.AddUint32(&num0RTTPackets, 1)
@@ -336,7 +336,7 @@ var _ = Describe("0-RTT", func() {
 				proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
 					RemoteAddr: fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port),
 					DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
-						hdr, _, _, err := wire.ParsePacket(data, 0, false)
+						hdr, _, _, err := wire.ParsePacket(data, 0, true)
 						Expect(err).ToNot(HaveOccurred())
 						if hdr.Type == protocol.PacketType0RTT {
 							atomic.AddUint32(&num0RTTPackets, 1)
@@ -344,7 +344,7 @@ var _ = Describe("0-RTT", func() {
 						return rtt / 2
 					},
 					DropPacket: func(_ quicproxy.Direction, data []byte) bool {
-						hdr, _, _, err := wire.ParsePacket(data, 0, false)
+						hdr, _, _, err := wire.ParsePacket(data, 0, true)
 						Expect(err).ToNot(HaveOccurred())
 						if hdr.Type == protocol.PacketType0RTT {
 							// drop 25% of the 0-RTT packets
@@ -379,7 +379,7 @@ var _ = Describe("0-RTT", func() {
 
 				countZeroRTTBytes := func(data []byte) (n protocol.ByteCount) {
 					for len(data) > 0 {
-						hdr, _, rest, err := wire.ParsePacket(data, 0, false)
+						hdr, _, rest, err := wire.ParsePacket(data, 0, true)
 						if err != nil {
 							return
 						}

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -36,7 +36,7 @@ var _ = Describe("0-RTT", func() {
 					RemoteAddr: fmt.Sprintf("localhost:%d", serverPort),
 					DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
 						for len(data) > 0 {
-							hdr, _, rest, err := wire.ParsePacket(data, 0)
+							hdr, _, rest, err := wire.ParsePacket(data, 0, false)
 							Expect(err).ToNot(HaveOccurred())
 							if hdr.Type == protocol.PacketType0RTT {
 								atomic.AddUint32(&num0RTTPackets, 1)
@@ -336,7 +336,7 @@ var _ = Describe("0-RTT", func() {
 				proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
 					RemoteAddr: fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port),
 					DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
-						hdr, _, _, err := wire.ParsePacket(data, 0)
+						hdr, _, _, err := wire.ParsePacket(data, 0, false)
 						Expect(err).ToNot(HaveOccurred())
 						if hdr.Type == protocol.PacketType0RTT {
 							atomic.AddUint32(&num0RTTPackets, 1)
@@ -344,7 +344,7 @@ var _ = Describe("0-RTT", func() {
 						return rtt / 2
 					},
 					DropPacket: func(_ quicproxy.Direction, data []byte) bool {
-						hdr, _, _, err := wire.ParsePacket(data, 0)
+						hdr, _, _, err := wire.ParsePacket(data, 0, false)
 						Expect(err).ToNot(HaveOccurred())
 						if hdr.Type == protocol.PacketType0RTT {
 							// drop 25% of the 0-RTT packets
@@ -379,7 +379,7 @@ var _ = Describe("0-RTT", func() {
 
 				countZeroRTTBytes := func(data []byte) (n protocol.ByteCount) {
 					for len(data) > 0 {
-						hdr, _, rest, err := wire.ParsePacket(data, 0)
+						hdr, _, rest, err := wire.ParsePacket(data, 0, false)
 						if err != nil {
 							return
 						}

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -48,7 +48,7 @@ var _ = Describe("QUIC Proxy", func() {
 	}
 
 	readPacketNumber := func(b []byte) protocol.PacketNumber {
-		hdr, data, _, err := wire.ParsePacket(b, 0)
+		hdr, data, _, err := wire.ParsePacket(b, 0, false)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		Expect(hdr.Type).To(Equal(protocol.PacketTypeInitial))
 		extHdr, err := hdr.ParseExtended(bytes.NewReader(data), protocol.VersionTLS)

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -41,7 +41,7 @@ var _ = Describe("QUIC Proxy", func() {
 			PacketNumber:    p,
 			PacketNumberLen: protocol.PacketNumberLen4,
 		}
-		Expect(hdr.Write(b, protocol.VersionWhatever)).To(Succeed())
+		Expect(hdr.Write(b, true, protocol.VersionWhatever)).To(Succeed())
 		raw := b.Bytes()
 		raw = append(raw, payload...)
 		return raw

--- a/interface.go
+++ b/interface.go
@@ -311,6 +311,9 @@ type Config struct {
 	// This can be useful if version information is exchanged out-of-band.
 	// It has no effect for a client.
 	DisableVersionNegotiationPackets bool
+	// DisableQUICBitGreasing disables greasing of the QUIC bit.
+	// By default, greasing is enabled according to RFC 9287.
+	DisableQUICBitGreasing bool
 	// See https://datatracker.ietf.org/doc/draft-ietf-quic-datagram/.
 	// Datagrams will only be available when both peers enable datagram support.
 	EnableDatagrams bool

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -14,7 +14,7 @@ import (
 // writePacket returns a new raw packet with the specified header and payload
 func writePacket(hdr *wire.ExtendedHeader, data []byte) []byte {
 	buf := &bytes.Buffer{}
-	hdr.Write(buf, hdr.Version)
+	hdr.Write(buf, true, hdr.Version)
 	return append(buf.Bytes(), data...)
 }
 

--- a/internal/wire/extended_header.go
+++ b/internal/wire/extended_header.go
@@ -114,7 +114,7 @@ func (h *ExtendedHeader) readPacketNumber(b *bytes.Reader) error {
 }
 
 // Write writes the Header.
-func (h *ExtendedHeader) Write(b *bytes.Buffer, ver protocol.VersionNumber) error {
+func (h *ExtendedHeader) Write(b *bytes.Buffer, quicBit bool, ver protocol.VersionNumber) error {
 	if h.DestConnectionID.Len() > protocol.MaxConnIDLen {
 		return fmt.Errorf("invalid connection ID length: %d bytes", h.DestConnectionID.Len())
 	}
@@ -122,12 +122,12 @@ func (h *ExtendedHeader) Write(b *bytes.Buffer, ver protocol.VersionNumber) erro
 		return fmt.Errorf("invalid connection ID length: %d bytes", h.SrcConnectionID.Len())
 	}
 	if h.IsLongHeader {
-		return h.writeLongHeader(b, ver)
+		return h.writeLongHeader(b, quicBit, ver)
 	}
-	return h.writeShortHeader(b, ver)
+	return h.writeShortHeader(b, quicBit, ver)
 }
 
-func (h *ExtendedHeader) writeLongHeader(b *bytes.Buffer, version protocol.VersionNumber) error {
+func (h *ExtendedHeader) writeLongHeader(b *bytes.Buffer, quicBit bool, version protocol.VersionNumber) error {
 	var packetType uint8
 	if version == protocol.Version2 {
 		//nolint:exhaustive
@@ -155,6 +155,9 @@ func (h *ExtendedHeader) writeLongHeader(b *bytes.Buffer, version protocol.Versi
 		}
 	}
 	firstByte := 0xc0 | packetType<<4
+	if !quicBit { // unset the quic bit
+		firstByte ^= 0x40
+	}
 	if h.Type != protocol.PacketTypeRetry {
 		// Retry packets don't have a packet number
 		firstByte |= uint8(h.PacketNumberLen - 1)
@@ -180,8 +183,11 @@ func (h *ExtendedHeader) writeLongHeader(b *bytes.Buffer, version protocol.Versi
 	return h.writePacketNumber(b)
 }
 
-func (h *ExtendedHeader) writeShortHeader(b *bytes.Buffer, _ protocol.VersionNumber) error {
+func (h *ExtendedHeader) writeShortHeader(b *bytes.Buffer, quicBit bool, _ protocol.VersionNumber) error {
 	typeByte := 0x40 | uint8(h.PacketNumberLen-1)
+	if !quicBit { // unset the quic bit
+		typeByte ^= 0x40
+	}
 	if h.KeyPhase == protocol.KeyPhaseOne {
 		typeByte |= byte(1 << 2)
 	}

--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -90,8 +90,8 @@ type Header struct {
 // If the packet has a long header, the packet is cut according to the length field.
 // If we understand the version, the packet is header up unto the packet number.
 // Otherwise, only the invariant part of the header is parsed.
-func ParsePacket(data []byte, shortHeaderConnIDLen int) (*Header, []byte /* packet data */, []byte /* rest */, error) {
-	hdr, err := parseHeader(bytes.NewReader(data), shortHeaderConnIDLen)
+func ParsePacket(data []byte, shortHeaderConnIDLen int, ignoreQuicBit bool) (*Header, []byte, []byte, error) {
+	hdr, err := parseHeader(bytes.NewReader(data), shortHeaderConnIDLen, ignoreQuicBit)
 	if err != nil {
 		if err == ErrUnsupportedVersion {
 			return hdr, nil, nil, ErrUnsupportedVersion
@@ -115,9 +115,9 @@ func ParsePacket(data []byte, shortHeaderConnIDLen int) (*Header, []byte /* pack
 // For long header packets:
 // * if we understand the version: up to the packet number
 // * if not, only the invariant part of the header
-func parseHeader(b *bytes.Reader, shortHeaderConnIDLen int) (*Header, error) {
+func parseHeader(b *bytes.Reader, shortHeaderConnIDLen int, ignoreQuicBit bool) (*Header, error) {
 	startLen := b.Len()
-	h, err := parseHeaderImpl(b, shortHeaderConnIDLen)
+	h, err := parseHeaderImpl(b, shortHeaderConnIDLen, ignoreQuicBit)
 	if err != nil {
 		return h, err
 	}
@@ -125,7 +125,7 @@ func parseHeader(b *bytes.Reader, shortHeaderConnIDLen int) (*Header, error) {
 	return h, err
 }
 
-func parseHeaderImpl(b *bytes.Reader, shortHeaderConnIDLen int) (*Header, error) {
+func parseHeaderImpl(b *bytes.Reader, shortHeaderConnIDLen int, ignoreQuicBit bool) (*Header, error) {
 	typeByte, err := b.ReadByte()
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ func parseHeaderImpl(b *bytes.Reader, shortHeaderConnIDLen int) (*Header, error)
 	}
 
 	if !h.IsLongHeader {
-		if h.typeByte&0x40 == 0 {
+		if h.typeByte&0x40 == 0 && !ignoreQuicBit {
 			return nil, errors.New("not a QUIC packet")
 		}
 		if err := h.parseShortHeader(b, shortHeaderConnIDLen); err != nil {
@@ -145,7 +145,7 @@ func parseHeaderImpl(b *bytes.Reader, shortHeaderConnIDLen int) (*Header, error)
 		}
 		return h, nil
 	}
-	return h, h.parseLongHeader(b)
+	return h, h.parseLongHeader(b, ignoreQuicBit)
 }
 
 func (h *Header) parseShortHeader(b *bytes.Reader, shortHeaderConnIDLen int) error {
@@ -154,13 +154,13 @@ func (h *Header) parseShortHeader(b *bytes.Reader, shortHeaderConnIDLen int) err
 	return err
 }
 
-func (h *Header) parseLongHeader(b *bytes.Reader) error {
+func (h *Header) parseLongHeader(b *bytes.Reader, ignoreQuicBit bool) error {
 	v, err := utils.BigEndian.ReadUint32(b)
 	if err != nil {
 		return err
 	}
 	h.Version = protocol.VersionNumber(v)
-	if h.Version != 0 && h.typeByte&0x40 == 0 {
+	if h.typeByte&0x40 == 0 && !ignoreQuicBit {
 		return errors.New("not a QUIC packet")
 	}
 	destConnIDLen, err := b.ReadByte()

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Header Parsing", func() {
 					Version:          protocol.Version1,
 				},
 				PacketNumberLen: 2,
-			}).Write(buf, protocol.Version1)).To(Succeed())
+			}).Write(buf, true, protocol.Version1)).To(Succeed())
 			connID, err := ParseConnectionID(buf.Bytes(), 8)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(connID).To(Equal(protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad}))
@@ -36,7 +36,7 @@ var _ = Describe("Header Parsing", func() {
 					DestConnectionID: protocol.ConnectionID{0xde, 0xca, 0xfb, 0xad},
 				},
 				PacketNumberLen: 2,
-			}).Write(buf, protocol.Version1)).To(Succeed())
+			}).Write(buf, true, protocol.Version1)).To(Succeed())
 			buf.Write([]byte("foobar"))
 			connID, err := ParseConnectionID(buf.Bytes(), 4)
 			Expect(err).ToNot(HaveOccurred())
@@ -50,7 +50,7 @@ var _ = Describe("Header Parsing", func() {
 					DestConnectionID: protocol.ConnectionID{1, 2, 3, 4, 5, 6, 7, 8},
 				},
 				PacketNumberLen: 2,
-			}).Write(buf, protocol.Version1)).To(Succeed())
+			}).Write(buf, true, protocol.Version1)).To(Succeed())
 			data := buf.Bytes()[:buf.Len()-2] // cut the packet number
 			_, err := ParseConnectionID(data, 8)
 			Expect(err).ToNot(HaveOccurred())
@@ -73,7 +73,7 @@ var _ = Describe("Header Parsing", func() {
 					Version:          protocol.Version1,
 				},
 				PacketNumberLen: 2,
-			}).Write(buf, protocol.Version1)).To(Succeed())
+			}).Write(buf, true, protocol.Version1)).To(Succeed())
 			data := buf.Bytes()[:buf.Len()-2] // cut the packet number
 			_, err := ParseConnectionID(data, 8)
 			Expect(err).ToNot(HaveOccurred())
@@ -398,7 +398,7 @@ var _ = Describe("Header Parsing", func() {
 					Header:          hdr,
 					PacketNumber:    0x1337,
 					PacketNumberLen: 2,
-				}).Write(buf, protocol.Version1)).To(Succeed())
+				}).Write(buf, true, protocol.Version1)).To(Succeed())
 				hdrRaw := append([]byte{}, buf.Bytes()...)
 				buf.Write([]byte("foobar")) // payload of the first packet
 				buf.Write([]byte("raboof")) // second packet
@@ -422,7 +422,7 @@ var _ = Describe("Header Parsing", func() {
 					},
 					PacketNumber:    0x1337,
 					PacketNumberLen: 2,
-				}).Write(buf, protocol.Version1)).To(Succeed())
+				}).Write(buf, true, protocol.Version1)).To(Succeed())
 				_, _, _, err := ParsePacket(buf.Bytes(), 4, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("packet length (2 bytes) is smaller than the expected length (3 bytes)"))
@@ -440,7 +440,7 @@ var _ = Describe("Header Parsing", func() {
 					},
 					PacketNumber:    0x1337,
 					PacketNumberLen: 2,
-				}).Write(buf, protocol.Version1)).To(Succeed())
+				}).Write(buf, true, protocol.Version1)).To(Succeed())
 				buf.Write(make([]byte, 500-2 /* for packet number length */))
 				_, _, _, err := ParsePacket(buf.Bytes(), 4, false)
 				Expect(err).To(MatchError("packet length (500 bytes) is smaller than the expected length (1000 bytes)"))

--- a/internal/wire/version_negotiation.go
+++ b/internal/wire/version_negotiation.go
@@ -11,7 +11,7 @@ import (
 
 // ParseVersionNegotiationPacket parses a Version Negotiation packet.
 func ParseVersionNegotiationPacket(b *bytes.Reader) (*Header, []protocol.VersionNumber, error) {
-	hdr, err := parseHeader(b, 0)
+	hdr, err := parseHeader(b, 0, true)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Packet Handler Map", func() {
 				Version:          protocol.VersionTLS,
 			},
 			PacketNumberLen: protocol.PacketNumberLen2,
-		}).Write(buf, protocol.VersionWhatever)).To(Succeed())
+		}).Write(buf, true, protocol.VersionWhatever)).To(Succeed())
 		return buf.Bytes()
 	}
 

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -826,7 +826,7 @@ func (p *packetPacker) appendPacket(buffer *packetBuffer, header *wire.ExtendedH
 
 	hdrOffset := buffer.Len()
 	buf := bytes.NewBuffer(buffer.Data)
-	if err := header.Write(buf, p.version); err != nil {
+	if err := header.Write(buf, true, p.version); err != nil {
 		return nil, err
 	}
 	payloadOffset := buf.Len()

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Packet packer", func() {
 	parsePacket := func(data []byte) []*wire.ExtendedHeader {
 		var hdrs []*wire.ExtendedHeader
 		for len(data) > 0 {
-			hdr, payload, rest, err := wire.ParsePacket(data, connID.Len())
+			hdr, payload, rest, err := wire.ParsePacket(data, connID.Len(), false)
 			Expect(err).ToNot(HaveOccurred())
 			r := bytes.NewReader(data)
 			extHdr, err := hdr.ParseExtended(r, version)
@@ -616,7 +616,7 @@ var _ = Describe("Packet packer", func() {
 				Expect(packet.packets).To(HaveLen(1))
 				// cut off the tag that the mock sealer added
 				// packet.buffer.Data = packet.buffer.Data[:packet.buffer.Len()-protocol.ByteCount(sealer.Overhead())]
-				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()))
+				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()), false)
 				Expect(err).ToNot(HaveOccurred())
 				r := bytes.NewReader(packet.buffer.Data)
 				extHdr, err := hdr.ParseExtended(r, packer.version)
@@ -656,7 +656,7 @@ var _ = Describe("Packet packer", func() {
 				Expect(err).ToNot(HaveOccurred())
 				// cut off the tag that the mock sealer added
 				packet.buffer.Data = packet.buffer.Data[:packet.buffer.Len()-protocol.ByteCount(sealer.Overhead())]
-				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()))
+				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()), false)
 				Expect(err).ToNot(HaveOccurred())
 				r := bytes.NewReader(packet.buffer.Data)
 				extHdr, err := hdr.ParseExtended(r, packer.version)
@@ -1158,10 +1158,10 @@ var _ = Describe("Packet packer", func() {
 				Expect(p.packets[1].EncryptionLevel()).To(Equal(protocol.Encryption1RTT))
 				Expect(p.packets[1].frames).To(HaveLen(1))
 				Expect(p.packets[1].frames[0].Frame.(*wire.StreamFrame).Data).To(Equal([]byte("foobar")))
-				hdr, _, rest, err := wire.ParsePacket(p.buffer.Data, 0)
+				hdr, _, rest, err := wire.ParsePacket(p.buffer.Data, 0, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hdr.Type).To(Equal(protocol.PacketTypeHandshake))
-				hdr, _, rest, err = wire.ParsePacket(rest, 0)
+				hdr, _, rest, err = wire.ParsePacket(rest, 0, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hdr.IsLongHeader).To(BeFalse())
 				Expect(rest).To(BeEmpty())
@@ -1206,7 +1206,7 @@ var _ = Describe("Packet packer", func() {
 				Expect(packet.packets).To(HaveLen(1))
 				// cut off the tag that the mock sealer added
 				// packet.buffer.Data = packet.buffer.Data[:packet.buffer.Len()-protocol.ByteCount(sealer.Overhead())]
-				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()))
+				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, len(packer.getDestConnID()), false)
 				Expect(err).ToNot(HaveOccurred())
 				r := bytes.NewReader(packet.buffer.Data)
 				extHdr, err := hdr.ParseExtended(r, packer.version)

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Packet Unpacker", func() {
 
 	getHeader := func(extHdr *wire.ExtendedHeader) (*wire.Header, []byte) {
 		buf := &bytes.Buffer{}
-		ExpectWithOffset(1, extHdr.Write(buf, version)).To(Succeed())
+		ExpectWithOffset(1, extHdr.Write(buf, true, version)).To(Succeed())
 		hdrLen := buf.Len()
 		if extHdr.Length > protocol.ByteCount(extHdr.PacketNumberLen) {
 			buf.Write(make([]byte, int(extHdr.Length)-int(extHdr.PacketNumberLen)))

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Packet Unpacker", func() {
 		if extHdr.Length > protocol.ByteCount(extHdr.PacketNumberLen) {
 			buf.Write(make([]byte, int(extHdr.Length)-int(extHdr.PacketNumberLen)))
 		}
-		hdr, _, _, err := wire.ParsePacket(buf.Bytes(), connID.Len())
+		hdr, _, _, err := wire.ParsePacket(buf.Bytes(), connID.Len(), false)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return hdr, buf.Bytes()[:hdrLen]
 	}

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -395,6 +395,7 @@ type eventTransportParameters struct {
 	PreferredAddress *preferredAddress
 
 	MaxDatagramFrameSize protocol.ByteCount
+	GreaseQuicBit        bool
 }
 
 func (e eventTransportParameters) Category() category { return categoryTransport }
@@ -439,6 +440,9 @@ func (e eventTransportParameters) MarshalJSONObject(enc *gojay.Encoder) {
 	}
 	if e.MaxDatagramFrameSize != protocol.InvalidByteCount {
 		enc.Int64Key("max_datagram_frame_size", int64(e.MaxDatagramFrameSize))
+	}
+	if e.GreaseQuicBit {
+		enc.BoolKey("grease_quic_bit", true)
 	}
 }
 

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -273,6 +273,7 @@ func (t *connectionTracer) toTransportParameters(tp *wire.TransportParameters) *
 		InitialMaxStreamsUni:            int64(tp.MaxUniStreamNum),
 		PreferredAddress:                pa,
 		MaxDatagramFrameSize:            tp.MaxDatagramFrameSize,
+		GreaseQuicBit:                   tp.GreaseQuicBit,
 	}
 }
 

--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -314,6 +314,7 @@ var _ = Describe("Tracing", func() {
 				Expect(ev).To(HaveKeyWithValue("initial_max_streams_uni", float64(20)))
 				Expect(ev).ToNot(HaveKey("preferred_address"))
 				Expect(ev).ToNot(HaveKey("max_datagram_frame_size"))
+				Expect(ev).ToNot(HaveKey("quic_grease_bit"))
 			})
 
 			It("records the server's transport parameters, without a stateless reset token", func() {
@@ -375,6 +376,17 @@ var _ = Describe("Tracing", func() {
 				Expect(entry.Name).To(Equal("transport:parameters_set"))
 				ev := entry.Event
 				Expect(ev).To(HaveKeyWithValue("max_datagram_frame_size", float64(1337)))
+			})
+
+			It("records transport parameters that enable the Grease QUIC bit extension", func() {
+				tracer.SentTransportParameters(&logging.TransportParameters{
+					GreaseQuicBit: true,
+				})
+				entry := exportAndParseSingle()
+				Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+				Expect(entry.Name).To(Equal("transport:parameters_set"))
+				ev := entry.Event
+				Expect(ev).To(HaveKeyWithValue("grease_quic_bit", true))
 			})
 
 			It("records received transport parameters", func() {

--- a/server.go
+++ b/server.go
@@ -322,7 +322,7 @@ func (s *baseServer) handlePacketImpl(p *receivedPacket) bool /* is the buffer s
 	}
 	// If we're creating a new connection, the packet will be passed to the connection.
 	// The header will then be parsed again.
-	hdr, _, _, err := wire.ParsePacket(p.data, s.config.ConnectionIDGenerator.ConnectionIDLen())
+	hdr, _, _, err := wire.ParsePacket(p.data, s.config.ConnectionIDGenerator.ConnectionIDLen(), false)
 	if err != nil && err != wire.ErrUnsupportedVersion {
 		if s.config.Tracer != nil {
 			s.config.Tracer.DroppedPacket(p.remoteAddr, logging.PacketTypeNotDetermined, p.Size(), logging.PacketDropHeaderParseError)

--- a/server.go
+++ b/server.go
@@ -573,7 +573,7 @@ func (s *baseServer) sendRetry(remoteAddr net.Addr, hdr *wire.Header, info *pack
 	packetBuffer := getPacketBuffer()
 	defer packetBuffer.Release()
 	buf := bytes.NewBuffer(packetBuffer.Data)
-	if err := replyHdr.Write(buf, hdr.Version); err != nil {
+	if err := replyHdr.Write(buf, true, hdr.Version); err != nil {
 		return err
 	}
 	// append the Retry integrity tag
@@ -634,7 +634,7 @@ func (s *baseServer) sendError(remoteAddr net.Addr, hdr *wire.Header, sealer han
 	replyHdr.DestConnectionID = hdr.SrcConnectionID
 	replyHdr.PacketNumberLen = protocol.PacketNumberLen4
 	replyHdr.Length = 4 /* packet number len */ + ccf.Length(hdr.Version) + protocol.ByteCount(sealer.Overhead())
-	if err := replyHdr.Write(buf, hdr.Version); err != nil {
+	if err := replyHdr.Write(buf, true, hdr.Version); err != nil {
 		return err
 	}
 	payloadOffset := buf.Len()

--- a/server.go
+++ b/server.go
@@ -322,7 +322,11 @@ func (s *baseServer) handlePacketImpl(p *receivedPacket) bool /* is the buffer s
 	}
 	// If we're creating a new connection, the packet will be passed to the connection.
 	// The header will then be parsed again.
-	hdr, _, _, err := wire.ParsePacket(p.data, s.config.ConnectionIDGenerator.ConnectionIDLen(), false)
+	hdr, _, _, err := wire.ParsePacket(
+		p.data,
+		s.config.ConnectionIDGenerator.ConnectionIDLen(),
+		!s.config.DisableQUICBitGreasing,
+	)
 	if err != nil && err != wire.ErrUnsupportedVersion {
 		if s.config.Tracer != nil {
 			s.config.Tracer.DroppedPacket(p.remoteAddr, logging.PacketTypeNotDetermined, p.Size(), logging.PacketDropHeaderParseError)

--- a/server_test.go
+++ b/server_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Server", func() {
 	}
 
 	parseHeader := func(data []byte) *wire.Header {
-		hdr, _, _, err := wire.ParsePacket(data, 0)
+		hdr, _, _, err := wire.ParsePacket(data, 0, false)
 		Expect(err).ToNot(HaveOccurred())
 		return hdr
 	}
@@ -672,7 +672,7 @@ var _ = Describe("Server", func() {
 				}
 				wg.Wait()
 				p := getInitialWithRandomDestConnID()
-				hdr, _, _, err := wire.ParsePacket(p.data, 0)
+				hdr, _, _, err := wire.ParsePacket(p.data, 0, false)
 				Expect(err).ToNot(HaveOccurred())
 				tracer.EXPECT().SentPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				done := make(chan struct{})

--- a/server_test.go
+++ b/server_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Server", func() {
 			Header:          *hdr,
 			PacketNumber:    0x42,
 			PacketNumberLen: protocol.PacketNumberLen4,
-		}).Write(buf, protocol.VersionTLS)).To(Succeed())
+		}).Write(buf, true, protocol.VersionTLS)).To(Succeed())
 		n := buf.Len()
 		buf.Write(p)
 		data := buffer.Data[:buf.Len()]


### PR DESCRIPTION
Fixes #3133.

We don't (yet) save the value of this transport parameter. This means that we'll never grease the QUIC bit on the first Initial packet and on 0-RTT packets. Implementing this is left as an exercise for a later PR.