### PR TITLE
write packets in batches

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,7 +14,7 @@ import (
 )
 
 type client struct {
-	sconn sendConn
+	sconn rawConn
 	// If the client is created with DialAddr, we create a packet conn.
 	// If it is started with Dial, we take a packet conn as a parameter.
 	createdPacketConn bool
@@ -194,7 +194,7 @@ func dialContext(
 	if err != nil {
 		return nil, err
 	}
-	c, err := newClient(pconn, remoteAddr, config, tlsConf, host, use0RTT, createdPacketConn)
+	c, err := newClient(pconn, config, tlsConf, host, use0RTT, createdPacketConn)
 	if err != nil {
 		return nil, err
 	}
@@ -209,9 +209,9 @@ func dialContext(
 		)
 	}
 	if c.tracer != nil {
-		c.tracer.StartedConnection(c.sconn.LocalAddr(), c.sconn.RemoteAddr(), c.srcConnID, c.destConnID)
+		c.tracer.StartedConnection(c.sconn.LocalAddr(), remoteAddr, c.srcConnID, c.destConnID)
 	}
-	if err := c.dial(ctx); err != nil {
+	if err := c.dial(ctx, remoteAddr); err != nil {
 		return nil, err
 	}
 	return c.conn, nil
@@ -219,7 +219,6 @@ func dialContext(
 
 func newClient(
 	pconn net.PacketConn,
-	remoteAddr net.Addr,
 	config *Config,
 	tlsConf *tls.Config,
 	host string,
@@ -261,10 +260,14 @@ func newClient(
 	if err != nil {
 		return nil, err
 	}
+	conn, err := wrapConn(pconn)
+	if err != nil {
+		return nil, err
+	}
 	c := &client{
 		srcConnID:         srcConnID,
 		destConnID:        destConnID,
-		sconn:             newSendPconn(pconn, remoteAddr),
+		sconn:             conn,
 		createdPacketConn: createdPacketConn,
 		use0RTT:           use0RTT,
 		tlsConf:           tlsConf,
@@ -276,11 +279,11 @@ func newClient(
 	return c, nil
 }
 
-func (c *client) dial(ctx context.Context) error {
-	c.logger.Infof("Starting new connection to %s (%s -> %s), source connection ID %s, destination connection ID %s, version %s", c.tlsConf.ServerName, c.sconn.LocalAddr(), c.sconn.RemoteAddr(), c.srcConnID, c.destConnID, c.version)
+func (c *client) dial(ctx context.Context, remoteAddr net.Addr) error {
+	c.logger.Infof("Starting new connection to %s (%s -> %s), source connection ID %s, destination connection ID %s, version %s", c.tlsConf.ServerName, c.sconn.LocalAddr(), remoteAddr, c.srcConnID, c.destConnID, c.version)
 
 	c.conn = newClientConnection(
-		c.sconn,
+		newSendConn(c.sconn, remoteAddr, nil),
 		c.packetHandlers,
 		c.destConnID,
 		c.srcConnID,
@@ -323,7 +326,7 @@ func (c *client) dial(ctx context.Context) error {
 			c.initialPacketNumber = recreateErr.nextPacketNumber
 			c.version = recreateErr.nextVersion
 			c.hasNegotiatedVersion = true
-			return c.dial(ctx)
+			return c.dial(ctx, remoteAddr)
 		}
 		return err
 	case <-earlyConnChan:

--- a/client_test.go
+++ b/client_test.go
@@ -60,11 +60,13 @@ var _ = Describe("Client", func() {
 		addr = &net.UDPAddr{IP: net.IPv4(192, 168, 100, 200), Port: 1337}
 		packetConn = NewMockPacketConn(mockCtrl)
 		packetConn.EXPECT().LocalAddr().Return(&net.UDPAddr{}).AnyTimes()
+		rconn, err := wrapConn(packetConn)
+		Expect(err).ToNot(HaveOccurred())
 		cl = &client{
 			srcConnID:  connID,
 			destConnID: connID,
 			version:    protocol.VersionTLS,
-			sconn:      newSendPconn(packetConn, addr),
+			sconn:      rconn,
 			tracer:     tracer,
 			logger:     utils.DefaultLogger,
 		}
@@ -520,11 +522,10 @@ var _ = Describe("Client", func() {
 
 			config := &Config{Versions: []protocol.VersionNumber{protocol.VersionTLS}, ConnectionIDGenerator: &mockConnIDGenerator{ConnID: connID}}
 			c := make(chan struct{})
-			var cconn sendConn
 			var version protocol.VersionNumber
 			var conf *Config
 			newClientConnection = func(
-				connP sendConn,
+				_ sendConn,
 				_ connRunner,
 				_ protocol.ConnectionID,
 				_ protocol.ConnectionID,
@@ -538,7 +539,6 @@ var _ = Describe("Client", func() {
 				_ utils.Logger,
 				versionP protocol.VersionNumber,
 			) quicConn {
-				cconn = connP
 				version = versionP
 				conf = configP
 				close(c)
@@ -551,7 +551,6 @@ var _ = Describe("Client", func() {
 			_, err := Dial(packetConn, addr, "localhost:1337", tlsConf, config)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(c).Should(BeClosed())
-			Expect(cconn.(*spconn).PacketConn).To(Equal(packetConn))
 			Expect(version).To(Equal(config.Versions[0]))
 			Expect(conf.Versions).To(Equal(config.Versions))
 		})

--- a/connection_test.go
+++ b/connection_test.go
@@ -586,7 +586,7 @@ var _ = Describe("Connection", func() {
 		It("closes when the sendQueue encounters an error", func() {
 			conn.handshakeConfirmed = true
 			sconn := NewMockSendConn(mockCtrl)
-			sconn.EXPECT().Write(gomock.Any()).Return(io.ErrClosedPipe).AnyTimes()
+			sconn.EXPECT().WritePackets(gomock.Any()).Return(io.ErrClosedPipe).AnyTimes()
 			conn.sendQueue = newSendQueue(sconn)
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().Return(time.Now().Add(time.Hour)).AnyTimes()
@@ -1787,7 +1787,7 @@ var _ = Describe("Connection", func() {
 		)
 
 		sent := make(chan struct{})
-		mconn.EXPECT().Write([]byte("foobar")).Do(func([]byte) { close(sent) })
+		mconn.EXPECT().WritePackets([][]byte{[]byte("foobar")}).Do(func([][]byte) { close(sent) })
 
 		go func() {
 			defer GinkgoRecover()
@@ -1919,7 +1919,7 @@ var _ = Describe("Connection", func() {
 		sph.EXPECT().HasPacingBudget().Return(true).AnyTimes()
 		sph.EXPECT().SetHandshakeConfirmed()
 		sph.EXPECT().SentPacket(gomock.Any())
-		mconn.EXPECT().Write(gomock.Any())
+		mconn.EXPECT().WritePackets(gomock.Any())
 		tracer.EXPECT().SentPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 		conn.sentPacketHandler = sph
 		done := make(chan struct{})

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,9 @@ require (
 	github.com/onsi/gomega v1.20.1
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
-	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
+	golang.org/x/net v0.0.0-20221004154528-8021a29435af
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
-golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af h1:wv66FM3rLZGPdxpYL+ApnDe2HzHcTFta3z5nsc13wI4=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -180,8 +180,8 @@ golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/integrationtests/gomodvendor/go.sum
+++ b/integrationtests/gomodvendor/go.sum
@@ -192,8 +192,9 @@ golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af h1:wv66FM3rLZGPdxpYL+ApnDe2HzHcTFta3z5nsc13wI4=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -230,8 +231,9 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/mock_batch_conn_test.go
+++ b/mock_batch_conn_test.go
@@ -48,3 +48,18 @@ func (mr *MockBatchConnMockRecorder) ReadBatch(ms, flags interface{}) *gomock.Ca
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadBatch", reflect.TypeOf((*MockBatchConn)(nil).ReadBatch), ms, flags)
 }
+
+// WriteBatch mocks base method.
+func (m *MockBatchConn) WriteBatch(ms []ipv4.Message, flags int) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteBatch", ms, flags)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WriteBatch indicates an expected call of WriteBatch.
+func (mr *MockBatchConnMockRecorder) WriteBatch(ms, flags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteBatch", reflect.TypeOf((*MockBatchConn)(nil).WriteBatch), ms, flags)
+}

--- a/mock_send_conn_test.go
+++ b/mock_send_conn_test.go
@@ -89,3 +89,17 @@ func (mr *MockSendConnMockRecorder) Write(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockSendConn)(nil).Write), arg0)
 }
+
+// WritePackets mocks base method.
+func (m *MockSendConn) WritePackets(arg0 [][]byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WritePackets", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WritePackets indicates an expected call of WritePackets.
+func (mr *MockSendConnMockRecorder) WritePackets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePackets", reflect.TypeOf((*MockSendConn)(nil).WritePackets), arg0)
+}

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -24,8 +24,25 @@ import (
 
 // rawConn is a connection that allow reading of a receivedPacket.
 type rawConn interface {
+	// ReadPacket reads a single packet from the connection.
+	// On systems that support it, this will use the optimized recvmmsg syscall.
 	ReadPacket() (*receivedPacket, error)
+	// WritePacket writes a single packet to the socket.
+	// It is safe to call this method concurrently.
 	WritePacket(b []byte, addr net.Addr, oob []byte) (int, error)
+	LocalAddr() net.Addr
+	io.Closer
+
+	newSendConn() rawSendConn
+}
+
+type rawSendConn interface {
+	// WritePacket writes a single packet to the socket.
+	// It is safe to call this method concurrently.
+	WritePacket(b []byte, addr net.Addr, oob []byte) (int, error)
+	// WritePackets writes multiple packets.
+	// On systems that support it, this will use the optimized sendmmsg syscall.
+	// This function must not be called concurrently.
 	WritePackets(b [][]byte, addr net.Addr, oob []byte) (int, error)
 	LocalAddr() net.Addr
 	io.Closer

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -26,6 +26,7 @@ import (
 type rawConn interface {
 	ReadPacket() (*receivedPacket, error)
 	WritePacket(b []byte, addr net.Addr, oob []byte) (int, error)
+	WritePackets(b [][]byte, addr net.Addr, oob []byte) (int, error)
 	LocalAddr() net.Addr
 	io.Closer
 }

--- a/send_conn.go
+++ b/send_conn.go
@@ -7,6 +7,7 @@ import (
 // A sendConn allows sending using a simple Write() on a non-connected packet conn.
 type sendConn interface {
 	Write([]byte) error
+	WritePackets([][]byte) error
 	Close() error
 	LocalAddr() net.Addr
 	RemoteAddr() net.Addr
@@ -32,7 +33,12 @@ func newSendConn(c rawConn, remote net.Addr, info *packetInfo) sendConn {
 }
 
 func (c *sconn) Write(p []byte) error {
-	_, err := c.WritePacket(p, c.remoteAddr, c.oob)
+	_, err := c.rawConn.WritePacket(p, c.remoteAddr, c.oob)
+	return err
+}
+
+func (c *sconn) WritePackets(p [][]byte) error {
+	_, err := c.rawConn.WritePackets(p, c.remoteAddr, c.oob)
 	return err
 }
 

--- a/send_conn.go
+++ b/send_conn.go
@@ -51,24 +51,3 @@ func (c *sconn) LocalAddr() net.Addr {
 	}
 	return addr
 }
-
-type spconn struct {
-	net.PacketConn
-
-	remoteAddr net.Addr
-}
-
-var _ sendConn = &spconn{}
-
-func newSendPconn(c net.PacketConn, remote net.Addr) sendConn {
-	return &spconn{PacketConn: c, remoteAddr: remote}
-}
-
-func (c *spconn) Write(p []byte) error {
-	_, err := c.WriteTo(p, c.remoteAddr)
-	return err
-}
-
-func (c *spconn) RemoteAddr() net.Addr {
-	return c.remoteAddr
-}

--- a/send_queue.go
+++ b/send_queue.go
@@ -9,16 +9,23 @@ type sender interface {
 }
 
 type sendQueue struct {
+	conn sendConn
+
 	queue       chan *packetBuffer
 	closeCalled chan struct{} // runStopped when Close() is called
 	runStopped  chan struct{} // runStopped when the run loop returns
 	available   chan struct{}
-	conn        sendConn
+
+	packetBuf []*packetBuffer
+	byteBuf   [][]byte
 }
 
 var _ sender = &sendQueue{}
 
-const sendQueueCapacity = 8
+const (
+	sendQueueCapacity = 8
+	writeBatchSize    = 8
+)
 
 func newSendQueue(conn sendConn) sender {
 	return &sendQueue{
@@ -27,6 +34,8 @@ func newSendQueue(conn sendConn) sender {
 		closeCalled: make(chan struct{}),
 		available:   make(chan struct{}, 1),
 		queue:       make(chan *packetBuffer, sendQueueCapacity),
+		packetBuf:   make([]*packetBuffer, 0, writeBatchSize),
+		byteBuf:     make([][]byte, 0, writeBatchSize),
 	}
 }
 
@@ -63,16 +72,39 @@ func (h *sendQueue) Run() error {
 			// make sure that all queued packets are actually sent out
 			shouldClose = true
 		case p := <-h.queue:
-			if err := h.conn.Write(p.Data); err != nil {
+			h.packetBuf = append(h.packetBuf, p)
+			h.byteBuf = append(h.byteBuf, p.Data)
+			for len(h.queue) > 0 {
+				select {
+				case p = <-h.queue:
+				default:
+					panic("would have blocked")
+				}
+				h.packetBuf = append(h.packetBuf, p)
+				h.byteBuf = append(h.byteBuf, p.Data)
+				if len(h.packetBuf) == cap(h.packetBuf) {
+					break
+				}
+			}
+
+			if err := h.conn.WritePackets(h.byteBuf); err != nil {
 				// This additional check enables:
 				// 1. Checking for "datagram too large" message from the kernel, as such,
 				// 2. Path MTU discovery,and
 				// 3. Eventual detection of loss PingFrame.
 				if !isMsgSizeErr(err) {
+					h.packetBuf = h.packetBuf[:0]
+					h.byteBuf = h.byteBuf[:0]
 					return err
 				}
 			}
-			p.Release()
+
+			for _, p := range h.packetBuf {
+				p.Release()
+			}
+			h.packetBuf = h.packetBuf[:0]
+			h.byteBuf = h.byteBuf[:0]
+
 			select {
 			case h.available <- struct{}{}:
 			default:

--- a/sys_conn.go
+++ b/sys_conn.go
@@ -87,3 +87,7 @@ func (c *basicConn) WritePackets(packets [][]byte, addr net.Addr, _ []byte) (int
 	}
 	return len(packets), nil
 }
+
+func (c *basicConn) newSendConn() rawSendConn {
+	return c
+}

--- a/sys_conn.go
+++ b/sys_conn.go
@@ -78,3 +78,12 @@ func (c *basicConn) ReadPacket() (*receivedPacket, error) {
 func (c *basicConn) WritePacket(b []byte, addr net.Addr, _ []byte) (n int, err error) {
 	return c.PacketConn.WriteTo(b, addr)
 }
+
+func (c *basicConn) WritePackets(packets [][]byte, addr net.Addr, _ []byte) (int, error) {
+	for i, p := range packets {
+		if _, err := c.PacketConn.WriteTo(p, addr); err != nil {
+			return i, err
+		}
+	}
+	return len(packets), nil
+}

--- a/sys_conn_helper_darwin.go
+++ b/sys_conn_helper_darwin.go
@@ -18,4 +18,4 @@ const (
 
 // ReadBatch only returns a single packet on OSX,
 // see https://godoc.org/golang.org/x/net/ipv4#PacketConn.ReadBatch.
-const batchSize = 1
+const readBatchSize = 1

--- a/sys_conn_helper_freebsd.go
+++ b/sys_conn_helper_freebsd.go
@@ -18,4 +18,4 @@ const (
 	msgTypeIPv6PKTINFO = 0x2e
 )
 
-const batchSize = 8
+const readBatchSize = 8

--- a/sys_conn_helper_linux.go
+++ b/sys_conn_helper_linux.go
@@ -16,4 +16,5 @@ const (
 	msgTypeIPv6PKTINFO = unix.IPV6_PKTINFO
 )
 
-const batchSize = 8 // needs to smaller than MaxUint8 (otherwise the type of oobConn.readPos has to be changed)
+// needs to smaller than MaxUint8 (otherwise the type of oobConn.readPos has to be changed)
+const readBatchSize = 8

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -233,7 +233,15 @@ func (c *oobConn) WritePacket(b []byte, addr net.Addr, oob []byte) (n int, err e
 	return n, err
 }
 
-func (c *oobConn) WritePackets(packets [][]byte, addr net.Addr, oob []byte) (int, error) {
+func (c *oobConn) newSendConn() rawSendConn {
+	return &oobSendConn{oobConn: *c}
+}
+
+type oobSendConn struct {
+	oobConn
+}
+
+func (c *oobSendConn) WritePackets(packets [][]byte, addr net.Addr, oob []byte) (int, error) {
 	// OSX throws sendmsg errors when using a packet conn that listening on both IPv4 and IPv6.
 	// Since WriteBatch won't send more than 1 packet on OSX anyway,
 	// there's no harm to just call WritePacket directly here.

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -209,10 +209,10 @@ var _ = Describe("OOB Conn Test", func() {
 		})
 
 		It("reads multiple messages in one batch", func() {
-			const numMsgRead = batchSize/2 + 1
+			const numMsgRead = readBatchSize/2 + 1
 			var counter int
 			batchConn.EXPECT().ReadBatch(gomock.Any(), gomock.Any()).DoAndReturn(func(ms []ipv4.Message, flags int) (int, error) {
-				Expect(ms).To(HaveLen(batchSize))
+				Expect(ms).To(HaveLen(readBatchSize))
 				for i := 0; i < numMsgRead; i++ {
 					Expect(ms[i].Buffers).To(HaveLen(1))
 					Expect(ms[i].Buffers[0]).To(HaveLen(int(protocol.MaxPacketBufferSize)))
@@ -232,7 +232,7 @@ var _ = Describe("OOB Conn Test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			oobConn.batchConn = batchConn
 
-			for i := 0; i < batchSize+1; i++ {
+			for i := 0; i < readBatchSize+1; i++ {
 				p, err := oobConn.ReadPacket()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(p.data)).To(Equal(fmt.Sprintf("message %d", i)))


### PR DESCRIPTION
Fixes #2607. Fixes #2877.

This required some work since while `recvmmsg` is only called from a single Go routine, `sendmmsg` is called concurrently if there are multiple QUIC connections running on the same socket.