### PR TITLE
http3: ContentLength must be -1 for unknown body length

### DIFF
--- a/http3/request.go
+++ b/http3/request.go
@@ -83,10 +83,21 @@ func requestFromHeaders(headers []qpack.HeaderField) (*http.Request, error) {
 	}
 
 	var contentLength int64
-	if len(contentLengthStr) > 0 {
-		contentLength, err = strconv.ParseInt(contentLengthStr, 10, 64)
-		if err != nil {
-			return nil, err
+	if mayHaveBody(method) {
+		if len(contentLengthStr) > 0 {
+			// parse the Content-Length header as a uint, without the sign bit, so it can be
+			// safely packed back into an int64. The header itself is an uint64, but a Content-Length header
+			// cannot be negative.
+			if cl, err := strconv.ParseUint(contentLengthStr, 10, 63); err != nil {
+				return nil, err
+			} else {
+				contentLength = int64(cl)
+			}
+		} else {
+			// if there is allowed to be a body based on the http method,
+			// and there's no content-length header, we set explicitly to -1, which
+			// indicates "unknown length"
+			contentLength = -1
 		}
 	}
 
@@ -110,4 +121,16 @@ func hostnameFromRequest(req *http.Request) string {
 		return req.URL.Host
 	}
 	return ""
+}
+
+func mayHaveBody(method string) bool {
+	switch method {
+	// HACK: methods which permit sending a body
+	// this isn't entirely accurate, but is a tradeoff we're willing to make
+	// to attempt to be more correct. It's technically possible to send a GET
+	// request with a body, and this is within spec, it's just extremely frowned upon.
+	case http.MethodPost, http.MethodPatch, http.MethodDelete, http.MethodPut:
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
According to the http.Request docs, on a server request, a ContentLength of -1 indicates an unknown length.

So in the case of a request without an explicit Content-Length header, the ContentLength was being set to 0, which explicitly indicates there's no body to read. Whereas -1 would indicate to read until EOF.

From my understanding, requestFromHeaders() is only used within the server context, and if it were used for the client context, this would be wrong, since a 0 is correct as unknown length on a client Request.

Please correct me if I am misunderstanding, but this caused me a bug integrating an http3.Server into my project.

I worked around it on my end by doing something similar in my handler:

```go
if req.Body != nil && req.ContentLength == 0 && req.Header.Get("Content-Length") == "" {
    req.ContentLength = -1
}
```

This is less than ideal, but works in my case.