### PR TITLE
specify resource_class in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ executors:
 jobs:
   "test": &test
     executor: test-go119
+    resource_class: large
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Apparently we can use the `large` `resource_class` on CircleCI.