### PR TITLE
http3: use HTTP/2 as the default protocol in ListenAndServe

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -717,19 +717,6 @@ func ListenAndServe(addr, certFile, keyFile string, handler http.Handler) error 
 	}
 	defer udpConn.Close()
 
-	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
-	if err != nil {
-		return err
-	}
-	tcpConn, err := net.ListenTCP("tcp", tcpAddr)
-	if err != nil {
-		return err
-	}
-	defer tcpConn.Close()
-
-	tlsConn := tls.NewListener(tcpConn, config)
-	defer tlsConn.Close()
-
 	if handler == nil {
 		handler = http.DefaultServeMux
 	}
@@ -738,17 +725,14 @@ func ListenAndServe(addr, certFile, keyFile string, handler http.Handler) error 
 		TLSConfig: config,
 		Handler:   handler,
 	}
-	httpServer := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			quicServer.SetQuicHeaders(w.Header())
-			handler.ServeHTTP(w, r)
-		}),
-	}
 
 	hErr := make(chan error)
 	qErr := make(chan error)
 	go func() {
-		hErr <- httpServer.Serve(tlsConn)
+		hErr <- http.ListenAndServeTLS(addr, certFile, keyFile, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			quicServer.SetQuicHeaders(w.Header())
+			handler.ServeHTTP(w, r)
+		}))
 	}()
 	go func() {
 		qErr <- quicServer.Serve(udpConn)


### PR DESCRIPTION
Running the [example](https://github.com/lucas-clemente/quic-go/blob/master/example/main.go) code with `-tcp` flag, and request the url `https://localhost:6121/demo/tiles`.

The current default protocol is `HTTP/1.1`.
![http/1.1](https://user-images.githubusercontent.com/5756338/211218353-4557fac8-b83b-459d-99d1-07b923980697.jpg)


Use `HTTP/2` as the default protocol in this PR.
![http2](https://user-images.githubusercontent.com/5756338/211218368-31a30f45-0a67-4f29-af43-ed71ce5ac55a.jpg)


