### PR TITLE
fix: return typed errors when after cancelling actions

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -41,11 +41,20 @@ const (
 	NoViablePathError         = qerr.NoViablePathError
 )
 
+type StreamErrorAction uint8
+
+const (
+	StreamErrorActionUnknown = iota
+	StreamErrorActionRead
+	StreamErrorActionWrite
+)
+
 // A StreamError is used for Stream.CancelRead and Stream.CancelWrite.
 // It is also returned from Stream.Read and Stream.Write if the peer canceled reading or writing.
 type StreamError struct {
 	StreamID  StreamID
 	ErrorCode StreamErrorCode
+	Action    StreamErrorAction
 }
 
 func (e *StreamError) Is(target error) bool {
@@ -54,5 +63,14 @@ func (e *StreamError) Is(target error) bool {
 }
 
 func (e *StreamError) Error() string {
-	return fmt.Sprintf("stream %d canceled with error code %d", e.StreamID, e.ErrorCode)
+	var format string
+	switch e.Action {
+	case StreamErrorActionRead:
+		format = "Read on stream %d canceled with error code %d"
+	case StreamErrorActionWrite:
+		format = "Write on stream %d canceled with error code %d"
+	default:
+		format = "stream %d canceled with error code %d"
+	}
+	return fmt.Sprintf(format, e.StreamID, e.ErrorCode)
 }

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -218,7 +218,7 @@ func (s *receiveStream) cancelReadImpl(errorCode qerr.StreamErrorCode) bool /* c
 		return false
 	}
 	s.canceledRead = true
-	s.cancelReadErr = fmt.Errorf("Read on stream %d canceled with error code %d", s.streamID, errorCode)
+	s.cancelReadErr = &StreamError{s.streamID, errorCode, StreamErrorActionRead}
 	s.signalRead()
 	s.sender.queueControlFrame(&wire.StopSendingFrame{
 		StreamID:  s.streamID,

--- a/send_stream.go
+++ b/send_stream.go
@@ -416,7 +416,7 @@ func (s *sendStream) Close() error {
 }
 
 func (s *sendStream) CancelWrite(errorCode StreamErrorCode) {
-	s.cancelWriteImpl(errorCode, fmt.Errorf("Write on stream %d canceled with error code %d", s.streamID, errorCode))
+	s.cancelWriteImpl(errorCode, &StreamError{s.streamID, errorCode, StreamErrorActionWrite})
 }
 
 // must be called after locking the mutex


### PR DESCRIPTION
This is errors.Is'ed by libp2p and the fmt.Errorf messages didn't passed that test: https://github.com/libp2p/go-libp2p/blob/82315917f76ca1e9e1c3aca3ad957080f0ac870c/p2p/transport/quic/stream.go#L23