### PR TITLE
don't apply invalid transport parameters

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1659,6 +1659,7 @@ func (s *connection) handleTransportParameters(params *wire.TransportParameters)
 			ErrorCode:    qerr.TransportParameterError,
 			ErrorMessage: err.Error(),
 		})
+		return
 	}
 	s.peerParams = params
 	// On the client side we have to wait for handshake completion.


### PR DESCRIPTION
I don't think this can be exploited, but it seems safer (and more correct) to return immediately here.