### PR TITLE
fix logging of coalesced packets that don't contain long header packets

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2026,6 +2026,21 @@ func (s *connection) logShortHeaderPacket(
 
 func (s *connection) logCoalescedPacket(packet *coalescedPacket) {
 	if s.logger.Debug() {
+		// There's a short period between dropping both Initial and Handshake keys and completion of the handshake,
+		// during which we might call PackCoalescedPacket but just pack a short header packet.
+		if len(packet.longHdrPackets) == 0 && packet.shortHdrPacket != nil {
+			s.logShortHeaderPacket(
+				packet.shortHdrPacket.DestConnID,
+				packet.shortHdrPacket.Ack,
+				packet.shortHdrPacket.Frames,
+				packet.shortHdrPacket.PacketNumber,
+				packet.shortHdrPacket.PacketNumberLen,
+				packet.shortHdrPacket.KeyPhase,
+				packet.shortHdrPacket.Length,
+				false,
+			)
+			return
+		}
 		if len(packet.longHdrPackets) > 1 {
 			s.logger.Debugf("-> Sending coalesced packet (%d parts, %d bytes) for connection %s", len(packet.longHdrPackets), packet.buffer.Len(), s.logID)
 		} else {


### PR DESCRIPTION
Fixes #3703.

There's a short period between dropping both Initial and Handshake keys and completion of the handshake, during which we might call PackCoalescedPacket but just pack a short header packet.