### PR TITLE
use a chan instead of a context in Connection.HandshakeComplete

### DIFF
--- a/client.go
+++ b/client.go
@@ -325,7 +325,7 @@ func (c *client) dial(ctx context.Context) error {
 	case <-earlyConnChan:
 		// ready to send 0-RTT data
 		return nil
-	case <-c.conn.HandshakeComplete().Done():
+	case <-c.conn.HandshakeComplete():
 		// handshake successfully completed
 		return nil
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Client", func() {
 				remoteAddrChan <- sconn.RemoteAddr().String()
 				conn := NewMockQuicConn(mockCtrl)
 				conn.EXPECT().run()
-				conn.EXPECT().HandshakeComplete().Return(context.Background())
+				conn.EXPECT().HandshakeComplete().Return(make(chan struct{}))
 				return conn
 			}
 			_, err := DialAddr("localhost:17890", tlsConf, &Config{HandshakeIdleTimeout: time.Millisecond})
@@ -163,7 +163,7 @@ var _ = Describe("Client", func() {
 				hostnameChan <- tlsConf.ServerName
 				conn := NewMockQuicConn(mockCtrl)
 				conn.EXPECT().run()
-				conn.EXPECT().HandshakeComplete().Return(context.Background())
+				conn.EXPECT().HandshakeComplete().Return(make(chan struct{}))
 				return conn
 			}
 			tlsConf.ServerName = "foobar"
@@ -195,7 +195,7 @@ var _ = Describe("Client", func() {
 			) quicConn {
 				hostnameChan <- tlsConf.ServerName
 				conn := NewMockQuicConn(mockCtrl)
-				conn.EXPECT().HandshakeComplete().Return(context.Background())
+				conn.EXPECT().HandshakeComplete().Return(make(chan struct{}))
 				conn.EXPECT().run()
 				return conn
 			}
@@ -235,9 +235,9 @@ var _ = Describe("Client", func() {
 				Expect(enable0RTT).To(BeFalse())
 				conn := NewMockQuicConn(mockCtrl)
 				conn.EXPECT().run().Do(func() { close(run) })
-				ctx, cancel := context.WithCancel(context.Background())
-				cancel()
-				conn.EXPECT().HandshakeComplete().Return(ctx)
+				c := make(chan struct{})
+				close(c)
+				conn.EXPECT().HandshakeComplete().Return(c)
 				return conn
 			}
 			tracer.EXPECT().StartedConnection(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -278,7 +278,7 @@ var _ = Describe("Client", func() {
 				Expect(enable0RTT).To(BeTrue())
 				conn := NewMockQuicConn(mockCtrl)
 				conn.EXPECT().run().Do(func() { <-done })
-				conn.EXPECT().HandshakeComplete().Return(context.Background())
+				conn.EXPECT().HandshakeComplete().Return(make(chan struct{}))
 				conn.EXPECT().earlyConnReady().Return(readyChan)
 				return conn
 			}
@@ -325,7 +325,7 @@ var _ = Describe("Client", func() {
 			) quicConn {
 				conn := NewMockQuicConn(mockCtrl)
 				conn.EXPECT().run().Return(testErr)
-				conn.EXPECT().HandshakeComplete().Return(context.Background())
+				conn.EXPECT().HandshakeComplete().Return(make(chan struct{}))
 				return conn
 			}
 			tracer.EXPECT().StartedConnection(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -350,7 +350,7 @@ var _ = Describe("Client", func() {
 			conn.EXPECT().run().Do(func() {
 				<-connRunning
 			})
-			conn.EXPECT().HandshakeComplete().Return(context.Background())
+			conn.EXPECT().HandshakeComplete().Return(make(chan struct{}))
 			newClientConnection = func(
 				_ sendConn,
 				_ connRunner,
@@ -425,7 +425,7 @@ var _ = Describe("Client", func() {
 			conn.EXPECT().run().Do(func() {
 				<-run
 			})
-			conn.EXPECT().HandshakeComplete().Return(context.Background())
+			conn.EXPECT().HandshakeComplete().Return(make(chan struct{}))
 
 			done := make(chan struct{})
 			go func() {
@@ -546,7 +546,7 @@ var _ = Describe("Client", func() {
 				// TODO: check connection IDs?
 				conn := NewMockQuicConn(mockCtrl)
 				conn.EXPECT().run()
-				conn.EXPECT().HandshakeComplete().Return(context.Background())
+				conn.EXPECT().HandshakeComplete().Return(make(chan struct{}))
 				return conn
 			}
 			_, err := Dial(packetConn, addr, "localhost:1337", tlsConf, config)
@@ -580,7 +580,7 @@ var _ = Describe("Client", func() {
 				versionP protocol.VersionNumber,
 			) quicConn {
 				conn := NewMockQuicConn(mockCtrl)
-				conn.EXPECT().HandshakeComplete().Return(context.Background())
+				conn.EXPECT().HandshakeComplete().Return(make(chan struct{}))
 				if counter == 0 {
 					Expect(pn).To(BeZero())
 					Expect(hasNegotiatedVersion).To(BeFalse())

--- a/connection.go
+++ b/connection.go
@@ -696,8 +696,8 @@ func (s *connection) earlyConnReady() <-chan struct{} {
 	return s.earlyConnReadyChan
 }
 
-func (s *connection) HandshakeComplete() context.Context {
-	return s.handshakeCtx
+func (s *connection) HandshakeComplete() <-chan struct{} {
+	return s.handshakeCtx.Done()
 }
 
 func (s *connection) Context() context.Context {
@@ -2195,7 +2195,7 @@ func (s *connection) GetVersion() protocol.VersionNumber {
 }
 
 func (s *connection) NextConnection() Connection {
-	<-s.HandshakeComplete().Done()
+	<-s.HandshakeComplete()
 	s.streamsMap.UseResetMaps()
 	return s
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -1834,9 +1834,9 @@ var _ = Describe("Connection", func() {
 			conn.run()
 		}()
 		handshakeCtx := conn.HandshakeComplete()
-		Consistently(handshakeCtx.Done()).ShouldNot(BeClosed())
+		Consistently(handshakeCtx).ShouldNot(BeClosed())
 		close(finishHandshake)
-		Eventually(handshakeCtx.Done()).Should(BeClosed())
+		Eventually(handshakeCtx).Should(BeClosed())
 		// make sure the go routine returns
 		streamManager.EXPECT().CloseWithError(gomock.Any())
 		expectReplaceWithClosed()
@@ -1865,7 +1865,7 @@ var _ = Describe("Connection", func() {
 		}()
 
 		handshakeCtx := conn.HandshakeComplete()
-		Consistently(handshakeCtx.Done()).ShouldNot(BeClosed())
+		Consistently(handshakeCtx).ShouldNot(BeClosed())
 		close(finishHandshake)
 		var frames []*ackhandler.Frame
 		Eventually(func() []*ackhandler.Frame {
@@ -1908,10 +1908,10 @@ var _ = Describe("Connection", func() {
 			conn.run()
 		}()
 		handshakeCtx := conn.HandshakeComplete()
-		Consistently(handshakeCtx.Done()).ShouldNot(BeClosed())
+		Consistently(handshakeCtx).ShouldNot(BeClosed())
 		mconn.EXPECT().Write(gomock.Any())
 		conn.closeLocal(errors.New("handshake error"))
-		Consistently(handshakeCtx.Done()).ShouldNot(BeClosed())
+		Consistently(handshakeCtx).ShouldNot(BeClosed())
 		Eventually(conn.Context().Done()).Should(BeClosed())
 	})
 

--- a/http3/client.go
+++ b/http3/client.go
@@ -266,7 +266,7 @@ func (c *client) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Respon
 	} else {
 		// wait for the handshake to complete
 		select {
-		case <-conn.HandshakeComplete().Done():
+		case <-conn.HandshakeComplete():
 		case <-req.Context().Done():
 			return nil, req.Context().Err()
 		}
@@ -449,7 +449,7 @@ func (c *client) HandshakeComplete() bool {
 		return false
 	}
 	select {
-	case <-(*conn).HandshakeComplete().Done():
+	case <-(*conn).HandshakeComplete():
 		return true
 	default:
 		return false

--- a/integrationtests/self/early_data_test.go
+++ b/integrationtests/self/early_data_test.go
@@ -40,7 +40,7 @@ var _ = Describe("early data", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(str.Close()).To(Succeed())
 					// make sure the Write finished before the handshake completed
-					Expect(conn.HandshakeComplete().Done()).ToNot(BeClosed())
+					Expect(conn.HandshakeComplete()).ToNot(BeClosed())
 					Eventually(conn.Context().Done()).Should(BeClosed())
 				}()
 				serverPort := ln.Addr().(*net.UDPAddr).Port

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -142,7 +142,7 @@ var _ = Describe("0-RTT", func() {
 				_, err = str.Write(testdata)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(str.Close()).To(Succeed())
-				<-conn.HandshakeComplete().Done()
+				<-conn.HandshakeComplete()
 				Expect(conn.ConnectionState().TLS.Used0RTT).To(BeTrue())
 				io.ReadAll(str) // wait for the EOF from the server to arrive before closing the conn
 				conn.CloseWithError(0, "")
@@ -302,7 +302,7 @@ var _ = Describe("0-RTT", func() {
 				Expect(firstStr.Close()).To(Succeed())
 
 				// wait for the handshake to complete
-				Eventually(conn.HandshakeComplete().Done()).Should(BeClosed())
+				Eventually(conn.HandshakeComplete()).Should(BeClosed())
 				str, err := conn.OpenUniStream()
 				Expect(err).ToNot(HaveOccurred())
 				_, err = str.Write(PRData)

--- a/interface.go
+++ b/interface.go
@@ -193,9 +193,10 @@ type EarlyConnection interface {
 	Connection
 
 	// HandshakeComplete blocks until the handshake completes (or fails).
-	// Data sent before completion of the handshake is encrypted with 1-RTT keys.
-	// Note that the client's identity hasn't been verified yet.
-	HandshakeComplete() context.Context
+	// For the client, data sent before completion of the handshake is encrypted with 0-RTT keys.
+	// For the serfer, data sent before completion of the handshake is encrypted with 1-RTT keys,
+	// however the client's identity is only verified once the handshake completes.
+	HandshakeComplete() <-chan struct{}
 
 	NextConnection() Connection
 }

--- a/internal/mocks/quic/early_conn.go
+++ b/internal/mocks/quic/early_conn.go
@@ -110,10 +110,10 @@ func (mr *MockEarlyConnectionMockRecorder) Context() *gomock.Call {
 }
 
 // HandshakeComplete mocks base method.
-func (m *MockEarlyConnection) HandshakeComplete() context.Context {
+func (m *MockEarlyConnection) HandshakeComplete() <-chan struct{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandshakeComplete")
-	ret0, _ := ret[0].(context.Context)
+	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 

--- a/interop/http09/client.go
+++ b/interop/http09/client.go
@@ -96,7 +96,7 @@ func (c *client) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, c.dialErr
 	}
 	if req.Method != MethodGet0RTT {
-		<-c.conn.HandshakeComplete().Done()
+		<-c.conn.HandshakeComplete()
 	}
 	return c.doRequest(req)
 }

--- a/mock_quic_conn_test.go
+++ b/mock_quic_conn_test.go
@@ -123,10 +123,10 @@ func (mr *MockQuicConnMockRecorder) GetVersion() *gomock.Call {
 }
 
 // HandshakeComplete mocks base method.
-func (m *MockQuicConn) HandshakeComplete() context.Context {
+func (m *MockQuicConn) HandshakeComplete() <-chan struct{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandshakeComplete")
-	ret0, _ := ret[0].(context.Context)
+	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 

--- a/server.go
+++ b/server.go
@@ -536,7 +536,7 @@ func (s *baseServer) handleNewConn(conn quicConn) {
 	} else {
 		// wait until the handshake is complete (or fails)
 		select {
-		case <-conn.HandshakeComplete().Done():
+		case <-conn.HandshakeComplete():
 		case <-connCtx.Done():
 			return
 		}


### PR DESCRIPTION
Fixes #3707.

As pointed out by @MarcoPolo, this should be a chan, not a context.