### PR TITLE
attach the QUIC version to context returned by ClientHelloInfo.Context

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go"
-	"github.com/quic-go/quic-go/internal/handshake"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/quicvarint"
@@ -66,8 +65,9 @@ func ConfigureTLSConfig(tlsConf *tls.Config) *tls.Config {
 		GetConfigForClient: func(ch *tls.ClientHelloInfo) (*tls.Config, error) {
 			// determine the ALPN from the QUIC version used
 			proto := NextProtoH3
-			if qconn, ok := ch.Conn.(handshake.ConnWithVersion); ok {
-				proto = versionToALPN(qconn.GetQUICVersion())
+			val := ch.Context().Value(quic.QUICVersionContextKey)
+			if v, ok := val.(quic.VersionNumber); ok {
+				proto = versionToALPN(v)
 			}
 			config := tlsConf
 			if tlsConf.GetConfigForClient != nil {

--- a/interface.go
+++ b/interface.go
@@ -57,6 +57,10 @@ var ConnectionTracingKey = connTracingCtxKey{}
 
 type connTracingCtxKey struct{}
 
+// QUICVersionContextKey can be used to find out the QUIC version of a TLS handshake from the
+// context returned by tls.Config.ClientHelloInfo.Context.
+var QUICVersionContextKey = handshake.QUICVersionContextKey
+
 // Stream is the interface implemented by QUIC streams
 // In addition to the errors listed on the Connection,
 // calls to stream functions can return a StreamError if the stream is canceled.

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -2,6 +2,7 @@ package handshake
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -19,6 +20,10 @@ import (
 	"github.com/quic-go/quic-go/logging"
 	"github.com/quic-go/quic-go/quicvarint"
 )
+
+type quicVersionContextKey struct{}
+
+var QUICVersionContextKey = &quicVersionContextKey{}
 
 // TLS unexpected_message alert
 const alertUnexpectedMessage uint8 = 10
@@ -64,30 +69,25 @@ const clientSessionStateRevision = 3
 
 type conn struct {
 	localAddr, remoteAddr net.Addr
-	version               protocol.VersionNumber
-}
-
-var _ ConnWithVersion = &conn{}
-
-func newConn(local, remote net.Addr, version protocol.VersionNumber) ConnWithVersion {
-	return &conn{
-		localAddr:  local,
-		remoteAddr: remote,
-		version:    version,
-	}
 }
 
 var _ net.Conn = &conn{}
 
-func (c *conn) Read([]byte) (int, error)               { return 0, nil }
-func (c *conn) Write([]byte) (int, error)              { return 0, nil }
-func (c *conn) Close() error                           { return nil }
-func (c *conn) RemoteAddr() net.Addr                   { return c.remoteAddr }
-func (c *conn) LocalAddr() net.Addr                    { return c.localAddr }
-func (c *conn) SetReadDeadline(time.Time) error        { return nil }
-func (c *conn) SetWriteDeadline(time.Time) error       { return nil }
-func (c *conn) SetDeadline(time.Time) error            { return nil }
-func (c *conn) GetQUICVersion() protocol.VersionNumber { return c.version }
+func newConn(local, remote net.Addr) net.Conn {
+	return &conn{
+		localAddr:  local,
+		remoteAddr: remote,
+	}
+}
+
+func (c *conn) Read([]byte) (int, error)         { return 0, nil }
+func (c *conn) Write([]byte) (int, error)        { return 0, nil }
+func (c *conn) Close() error                     { return nil }
+func (c *conn) RemoteAddr() net.Addr             { return c.remoteAddr }
+func (c *conn) LocalAddr() net.Addr              { return c.localAddr }
+func (c *conn) SetReadDeadline(time.Time) error  { return nil }
+func (c *conn) SetWriteDeadline(time.Time) error { return nil }
+func (c *conn) SetDeadline(time.Time) error      { return nil }
 
 type cryptoSetup struct {
 	tlsConf   *tls.Config
@@ -183,7 +183,7 @@ func NewCryptoSetupClient(
 		protocol.PerspectiveClient,
 		version,
 	)
-	cs.conn = qtls.Client(newConn(localAddr, remoteAddr, version), cs.tlsConf, cs.extraConf)
+	cs.conn = qtls.Client(newConn(localAddr, remoteAddr), cs.tlsConf, cs.extraConf)
 	return cs, clientHelloWritten
 }
 
@@ -218,7 +218,7 @@ func NewCryptoSetupServer(
 		version,
 	)
 	cs.allow0RTT = allow0RTT
-	cs.conn = qtls.Server(newConn(localAddr, remoteAddr, version), cs.tlsConf, cs.extraConf)
+	cs.conn = qtls.Server(newConn(localAddr, remoteAddr), cs.tlsConf, cs.extraConf)
 	return cs
 }
 
@@ -307,7 +307,7 @@ func (h *cryptoSetup) RunHandshake() {
 	handshakeErrChan := make(chan error, 1)
 	go func() {
 		defer close(h.handshakeDone)
-		if err := h.conn.Handshake(); err != nil {
+		if err := h.conn.HandshakeContext(context.WithValue(context.Background(), QUICVersionContextKey, h.version)); err != nil {
 			handshakeErrChan <- err
 			return
 		}

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -3,7 +3,6 @@ package handshake
 import (
 	"errors"
 	"io"
-	"net"
 	"time"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -92,11 +91,4 @@ type CryptoSetup interface {
 	GetHandshakeSealer() (LongHeaderSealer, error)
 	Get0RTTSealer() (LongHeaderSealer, error)
 	Get1RTTSealer() (ShortHeaderSealer, error)
-}
-
-// ConnWithVersion is the connection used in the ClientHelloInfo.
-// It can be used to determine the QUIC version in use.
-type ConnWithVersion interface {
-	net.Conn
-	GetQUICVersion() protocol.VersionNumber
 }


### PR DESCRIPTION
I suggested this in https://github.com/golang/go/issues/44886#issuecomment-1454915595 (see 3.).