### PR TITLE
qlog: use version_mismatch trigger on transport:connection_closed event

### DIFF
--- a/qlog/event.go
+++ b/qlog/event.go
@@ -148,8 +148,7 @@ func (e eventConnectionClosed) MarshalJSONObject(enc *gojay.Encoder) {
 		enc.StringKey("connection_code", transportError(transportErr.ErrorCode).String())
 		enc.StringKey("reason", transportErr.ErrorMessage)
 	case errors.As(e.e, &versionNegotiationErr):
-		enc.StringKey("owner", ownerRemote.String())
-		enc.StringKey("trigger", "version_negotiation")
+		enc.StringKey("trigger", "version_mismatch")
 	}
 }
 

--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -245,9 +245,8 @@ var _ = Describe("Tracing", func() {
 				Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
 				Expect(entry.Name).To(Equal("transport:connection_closed"))
 				ev := entry.Event
-				Expect(ev).To(HaveLen(2))
-				Expect(ev).To(HaveKeyWithValue("owner", "remote"))
-				Expect(ev).To(HaveKeyWithValue("trigger", "version_negotiation"))
+				Expect(ev).To(HaveLen(1))
+				Expect(ev).To(HaveKeyWithValue("trigger", "version_mismatch"))
 			})
 
 			It("records application errors", func() {


### PR DESCRIPTION
Fixes #3723.

It also doesn't really make sense to define an "owner" of this event. Both sides close the connection when they can't agree on a version.