### PR TITLE
Correct the description of MaxIncomingStreams and MaxIncomingUniStreams

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -299,12 +299,12 @@ type Config struct {
 	// To avoid deadlocks, it is not valid to call other functions on the connection or on streams
 	// in this callback.
 	AllowConnectionWindowIncrease func(conn Connection, delta uint64) bool
-	// MaxIncomingStreams is the maximum number of concurrent bidirectional streams that a peer is allowed to open.
+	// MaxIncomingStreams is the maximum number of bidirectional streams that a peer is allowed to open.
 	// Values above 2^60 are invalid.
 	// If not set, it will default to 100.
 	// If set to a negative value, it doesn't allow any bidirectional streams.
 	MaxIncomingStreams int64
-	// MaxIncomingUniStreams is the maximum number of concurrent unidirectional streams that a peer is allowed to open.
+	// MaxIncomingUniStreams is the maximum number of unidirectional streams that a peer is allowed to open.
 	// Values above 2^60 are invalid.
 	// If not set, it will default to 100.
 	// If set to a negative value, it doesn't allow any unidirectional streams.


### PR DESCRIPTION
Based on the current implementation, it appears that the configuration parameters `MaxIncomingStreams` and `MaxIncomingUniStreams` define `the maximum number of streams that a peer is allowed to open`, rather than `the maximum number of concurrent streams that can be opened`.