### PR TITLE
qtls: don't set the tls.Config.CipherSuites for cipher suite tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -47,7 +47,6 @@ var generateConnectionIDForInitial = protocol.GenerateConnectionIDForInitial
 // DialAddr establishes a new QUIC connection to a server.
 // It uses a new UDP connection and closes this connection when the QUIC connection is closed.
 // The hostname for SNI is taken from the given address.
-// The tls.Config.CipherSuites allows setting of TLS 1.3 cipher suites.
 func DialAddr(
 	addr string,
 	tlsConf *tls.Config,
@@ -59,7 +58,6 @@ func DialAddr(
 // DialAddrEarly establishes a new 0-RTT QUIC connection to a server.
 // It uses a new UDP connection and closes this connection when the QUIC connection is closed.
 // The hostname for SNI is taken from the given address.
-// The tls.Config.CipherSuites allows setting of TLS 1.3 cipher suites.
 func DialAddrEarly(
 	addr string,
 	tlsConf *tls.Config,

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.20.1
 	github.com/quic-go/qpack v0.4.0
-	github.com/quic-go/qtls-go1-19 v0.2.1
-	github.com/quic-go/qtls-go1-20 v0.1.1
+	github.com/quic-go/qtls-go1-19 v0.3.0
+	github.com/quic-go/qtls-go1-20 v0.2.0
 	golang.org/x/crypto v0.4.0
 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db
 	golang.org/x/net v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -88,10 +88,10 @@ github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7q
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
-github.com/quic-go/qtls-go1-19 v0.2.1 h1:aJcKNMkH5ASEJB9FXNeZCyTEIHU1J7MmHyz1Q1TSG1A=
-github.com/quic-go/qtls-go1-19 v0.2.1/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
-github.com/quic-go/qtls-go1-20 v0.1.1 h1:KbChDlg82d3IHqaj2bn6GfKRj84Per2VGf5XV3wSwQk=
-github.com/quic-go/qtls-go1-20 v0.1.1/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
+github.com/quic-go/qtls-go1-19 v0.3.0 h1:aUBoQdpHzUWtPw5tQZbsD2GnrWCNu7/RIX1PtqGeLYY=
+github.com/quic-go/qtls-go1-19 v0.3.0/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
+github.com/quic-go/qtls-go1-20 v0.2.0 h1:jUHn+obJ6WI5JudqBO0Iy1ra5Vh5vsitQ1gXQvkmN+E=
+github.com/quic-go/qtls-go1-20 v0.2.0/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=

--- a/integrationtests/gomodvendor/go.sum
+++ b/integrationtests/gomodvendor/go.sum
@@ -111,10 +111,10 @@ github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7q
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
-github.com/quic-go/qtls-go1-19 v0.2.1 h1:aJcKNMkH5ASEJB9FXNeZCyTEIHU1J7MmHyz1Q1TSG1A=
-github.com/quic-go/qtls-go1-19 v0.2.1/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
-github.com/quic-go/qtls-go1-20 v0.1.1 h1:KbChDlg82d3IHqaj2bn6GfKRj84Per2VGf5XV3wSwQk=
-github.com/quic-go/qtls-go1-20 v0.1.1/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
+github.com/quic-go/qtls-go1-19 v0.3.0 h1:aUBoQdpHzUWtPw5tQZbsD2GnrWCNu7/RIX1PtqGeLYY=
+github.com/quic-go/qtls-go1-19 v0.3.0/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
+github.com/quic-go/qtls-go1-20 v0.2.0 h1:jUHn+obJ6WI5JudqBO0Iy1ra5Vh5vsitQ1gXQvkmN+E=
+github.com/quic-go/qtls-go1-20 v0.2.0/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/quic-go/quic-go/integrationtests/tools/israce"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
+	"github.com/quic-go/quic-go/internal/qtls"
 	"github.com/quic-go/quic-go/logging"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -194,8 +195,10 @@ var _ = Describe("Handshake tests", func() {
 			suiteID := id
 
 			It(fmt.Sprintf("using %s", name), func() {
+				reset := qtls.SetCipherSuite(suiteID)
+				defer reset()
+
 				tlsConf := getTLSConfig()
-				tlsConf.CipherSuites = []uint16{suiteID}
 				ln, err := quic.ListenAddr("localhost:0", tlsConf, serverConfig)
 				Expect(err).ToNot(HaveOccurred())
 				defer ln.Close()

--- a/internal/qtls/go119.go
+++ b/internal/qtls/go119.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"crypto/cipher"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"unsafe"
 
@@ -96,4 +97,26 @@ func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
 		AEAD:   cs.AEAD,
 		Hash:   cs.Hash,
 	}
+}
+
+//go:linkname cipherSuitesTLS13 github.com/quic-go/qtls-go1-19.cipherSuitesTLS13
+var cipherSuitesTLS13 []unsafe.Pointer
+
+// SetCipherSuite modifies the cipherSuiteTLS13 slice of cipher suites inside qtls
+// such that it only contains the cipher suite with the chosen id.
+// The reset function returned resets them back to the original value.
+func SetCipherSuite(id uint16) (reset func()) {
+	orig := append([]unsafe.Pointer{}, cipherSuitesTLS13...)
+	// The order is given by the order of the slice elements in cipherSuitesTLS13 in qtls.
+	switch id {
+	case tls.TLS_AES_128_GCM_SHA256:
+		cipherSuitesTLS13 = cipherSuitesTLS13[:1]
+	case tls.TLS_CHACHA20_POLY1305_SHA256:
+		cipherSuitesTLS13 = cipherSuitesTLS13[1:2]
+	case tls.TLS_AES_256_GCM_SHA384:
+		cipherSuitesTLS13 = cipherSuitesTLS13[2:]
+	default:
+		panic(fmt.Sprintf("unexpected cipher suite: %d", id))
+	}
+	return func() { cipherSuitesTLS13 = orig }
 }

--- a/internal/qtls/go120.go
+++ b/internal/qtls/go120.go
@@ -6,6 +6,7 @@ import (
 	"crypto"
 	"crypto/cipher"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"unsafe"
 
@@ -96,4 +97,26 @@ func CipherSuiteTLS13ByID(id uint16) *CipherSuiteTLS13 {
 		AEAD:   cs.AEAD,
 		Hash:   cs.Hash,
 	}
+}
+
+//go:linkname cipherSuitesTLS13 github.com/quic-go/qtls-go1-20.cipherSuitesTLS13
+var cipherSuitesTLS13 []unsafe.Pointer
+
+// SetCipherSuite modifies the cipherSuiteTLS13 slice of cipher suites inside qtls
+// such that it only contains the cipher suite with the chosen id.
+// The reset function returned resets them back to the original value.
+func SetCipherSuite(id uint16) (reset func()) {
+	orig := append([]unsafe.Pointer{}, cipherSuitesTLS13...)
+	// The order is given by the order of the slice elements in cipherSuitesTLS13 in qtls.
+	switch id {
+	case tls.TLS_AES_128_GCM_SHA256:
+		cipherSuitesTLS13 = cipherSuitesTLS13[:1]
+	case tls.TLS_CHACHA20_POLY1305_SHA256:
+		cipherSuitesTLS13 = cipherSuitesTLS13[1:2]
+	case tls.TLS_AES_256_GCM_SHA384:
+		cipherSuitesTLS13 = cipherSuitesTLS13[2:]
+	default:
+		panic(fmt.Sprintf("unexpected cipher suite: %d", id))
+	}
+	return func() { cipherSuitesTLS13 = orig }
 }

--- a/server.go
+++ b/server.go
@@ -157,11 +157,10 @@ func listenAddr(addr string, tlsConf *tls.Config, config *Config, acceptEarly bo
 // and WriteMsgUDP will be used instead of ReadFrom and WriteTo to read/write
 // packets. A single net.PacketConn only be used for a single call to Listen.
 // The PacketConn can be used for simultaneous calls to Dial. QUIC connection
-// IDs are used for demultiplexing the different connections. The tls.Config
-// must not be nil and must contain a certificate configuration. The
-// tls.Config.CipherSuites allows setting of TLS 1.3 cipher suites. Furthermore,
-// it must define an application control (using NextProtos). The quic.Config may
-// be nil, in that case the default values will be used.
+// IDs are used for demultiplexing the different connections.
+// The tls.Config must not be nil and must contain a certificate configuration.
+// Furthermore, it must define an application control (using NextProtos).
+// The quic.Config may be nil, in that case the default values will be used.
 func Listen(conn net.PacketConn, tlsConf *tls.Config, config *Config) (Listener, error) {
 	return listen(conn, tlsConf, config, false)
 }


### PR DESCRIPTION
The standard library crypto/tls implementation doesn't allow setting of `tls.Config.CipherSuites`, and this won't change when QUIC support is added.

This PR introduces a workaround suggested by Filippo. It uses `go:linkname` to (temporarily) modify the slice of TLS 1.3 cipher suites in https://github.com/golang/go/blob/20e9b7f1b53d49fd66e0344b1d0d42d3cf5e47b6/src/crypto/tls/cipher_suites.go#L201-L205. This is exactly how we'll be able to test this once we switch to crypto/tls.