### PR TITLE
initiate the first key update after sending / receiving 100 packets

### DIFF
--- a/internal/handshake/updatable_aead.go
+++ b/internal/handshake/updatable_aead.go
@@ -27,7 +27,6 @@ type updatableAEAD struct {
 	firstPacketNumber  protocol.PacketNumber
 	handshakeConfirmed bool
 
-	keyUpdateInterval  uint64
 	invalidPacketLimit uint64
 	invalidPacketCount uint64
 
@@ -74,7 +73,6 @@ func newUpdatableAEAD(rttStats *utils.RTTStats, tracer logging.ConnectionTracer,
 		largestAcked:            protocol.InvalidPacketNumber,
 		firstRcvdWithCurrentKey: protocol.InvalidPacketNumber,
 		firstSentWithCurrentKey: protocol.InvalidPacketNumber,
-		keyUpdateInterval:       KeyUpdateInterval,
 		rttStats:                rttStats,
 		tracer:                  tracer,
 		logger:                  logger,
@@ -116,6 +114,7 @@ func (a *updatableAEAD) getNextTrafficSecret(hash crypto.Hash, ts []byte) []byte
 	return hkdfExpandLabel(hash, ts, []byte{}, "quic ku", hash.Size())
 }
 
+// SetReadKey sets the read key.
 // For the client, this function is called before SetWriteKey.
 // For the server, this function is called after SetWriteKey.
 func (a *updatableAEAD) SetReadKey(suite *qtls.CipherSuiteTLS13, trafficSecret []byte) {
@@ -129,6 +128,7 @@ func (a *updatableAEAD) SetReadKey(suite *qtls.CipherSuiteTLS13, trafficSecret [
 	a.nextRcvAEAD = createAEAD(suite, a.nextRcvTrafficSecret, a.version)
 }
 
+// SetWriteKey sets the write key.
 // For the client, this function is called after SetReadKey.
 // For the server, this function is called before SetWriteKey.
 func (a *updatableAEAD) SetWriteKey(suite *qtls.CipherSuiteTLS13, trafficSecret []byte) {
@@ -284,11 +284,11 @@ func (a *updatableAEAD) shouldInitiateKeyUpdate() bool {
 	if !a.updateAllowed() {
 		return false
 	}
-	if a.numRcvdWithCurrentKey >= a.keyUpdateInterval {
+	if a.numRcvdWithCurrentKey >= KeyUpdateInterval {
 		a.logger.Debugf("Received %d packets with current key phase. Initiating key update to the next key phase: %d", a.numRcvdWithCurrentKey, a.keyPhase+1)
 		return true
 	}
-	if a.numSentWithCurrentKey >= a.keyUpdateInterval {
+	if a.numSentWithCurrentKey >= KeyUpdateInterval {
 		a.logger.Debugf("Sent %d packets with current key phase. Initiating key update to the next key phase: %d", a.numSentWithCurrentKey, a.keyPhase+1)
 		return true
 	}

--- a/internal/handshake/updatable_aead_test.go
+++ b/internal/handshake/updatable_aead_test.go
@@ -282,21 +282,25 @@ var _ = Describe("Updatable AEAD", func() {
 							})
 
 							Context("initiating key updates", func() {
+								const firstKeyUpdateInterval = 5
 								const keyUpdateInterval = 20
-								var origKeyUpdateInterval uint64
+								var origKeyUpdateInterval, origFirstKeyUpdateInterval uint64
 
 								BeforeEach(func() {
 									origKeyUpdateInterval = KeyUpdateInterval
+									origFirstKeyUpdateInterval = FirstKeyUpdateInterval
 									KeyUpdateInterval = keyUpdateInterval
+									FirstKeyUpdateInterval = firstKeyUpdateInterval
 									server.SetHandshakeConfirmed()
 								})
 
 								AfterEach(func() {
 									KeyUpdateInterval = origKeyUpdateInterval
+									FirstKeyUpdateInterval = origFirstKeyUpdateInterval
 								})
 
 								It("initiates a key update after sealing the maximum number of packets, for the first update", func() {
-									for i := 0; i < keyUpdateInterval; i++ {
+									for i := 0; i < firstKeyUpdateInterval; i++ {
 										pn := protocol.PacketNumber(i)
 										Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
 										server.Seal(nil, msg, pn, ad)
@@ -328,7 +332,7 @@ var _ = Describe("Updatable AEAD", func() {
 
 								It("errors if the peer acknowledges a packet sent in the next key phase using the old key phase", func() {
 									// First make sure that we update our keys.
-									for i := 0; i < keyUpdateInterval; i++ {
+									for i := 0; i < firstKeyUpdateInterval; i++ {
 										pn := protocol.PacketNumber(i)
 										Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
 										server.Seal(nil, msg, pn, ad)
@@ -336,7 +340,7 @@ var _ = Describe("Updatable AEAD", func() {
 									serverTracer.EXPECT().UpdatedKey(protocol.KeyPhase(1), false)
 									Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseOne))
 									// Now that our keys are updated, send a packet using the new keys.
-									const nextPN = keyUpdateInterval + 1
+									const nextPN = firstKeyUpdateInterval + 1
 									server.Seal(nil, msg, nextPN, ad)
 									// We haven't decrypted any packet in the new key phase yet.
 									// This means that the ACK must have been sent in the old key phase.
@@ -348,7 +352,7 @@ var _ = Describe("Updatable AEAD", func() {
 
 								It("doesn't error before actually sending a packet in the new key phase", func() {
 									// First make sure that we update our keys.
-									for i := 0; i < keyUpdateInterval; i++ {
+									for i := 0; i < firstKeyUpdateInterval; i++ {
 										pn := protocol.PacketNumber(i)
 										Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
 										server.Seal(nil, msg, pn, ad)
@@ -366,7 +370,7 @@ var _ = Describe("Updatable AEAD", func() {
 								})
 
 								It("initiates a key update after opening the maximum number of packets, for the first update", func() {
-									for i := 0; i < keyUpdateInterval; i++ {
+									for i := 0; i < firstKeyUpdateInterval; i++ {
 										pn := protocol.PacketNumber(i)
 										Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
 										encrypted := client.Seal(nil, msg, pn, ad)
@@ -399,7 +403,7 @@ var _ = Describe("Updatable AEAD", func() {
 
 								It("drops keys 3 PTOs after a key update", func() {
 									now := time.Now()
-									for i := 0; i < keyUpdateInterval; i++ {
+									for i := 0; i < firstKeyUpdateInterval; i++ {
 										pn := protocol.PacketNumber(i)
 										Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
 										server.Seal(nil, msg, pn, ad)
@@ -435,7 +439,7 @@ var _ = Describe("Updatable AEAD", func() {
 									data1 := client.Seal(nil, msg, 1, ad)
 									_, err := server.Open(nil, data1, now, 1, protocol.KeyPhaseZero, ad)
 									Expect(err).ToNot(HaveOccurred())
-									for i := 0; i < keyUpdateInterval; i++ {
+									for i := 0; i < firstKeyUpdateInterval; i++ {
 										pn := protocol.PacketNumber(i)
 										Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
 										server.Seal(nil, msg, pn, ad)
@@ -451,7 +455,7 @@ var _ = Describe("Updatable AEAD", func() {
 								})
 
 								It("drops keys early when the peer forces initiates a key update within the 3 PTO period", func() {
-									for i := 0; i < keyUpdateInterval; i++ {
+									for i := 0; i < firstKeyUpdateInterval; i++ {
 										pn := protocol.PacketNumber(i)
 										Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
 										server.Seal(nil, msg, pn, ad)
@@ -488,7 +492,7 @@ var _ = Describe("Updatable AEAD", func() {
 								It("drops keys early when we initiate another key update within the 3 PTO period", func() {
 									server.SetHandshakeConfirmed()
 									// send so many packets that we initiate the first key update
-									for i := 0; i < keyUpdateInterval; i++ {
+									for i := 0; i < firstKeyUpdateInterval; i++ {
 										pn := protocol.PacketNumber(i)
 										Expect(server.KeyPhase()).To(Equal(protocol.KeyPhaseZero))
 										server.Seal(nil, msg, pn, ad)

--- a/internal/handshake/updatable_aead_test.go
+++ b/internal/handshake/updatable_aead_test.go
@@ -283,11 +283,16 @@ var _ = Describe("Updatable AEAD", func() {
 
 							Context("initiating key updates", func() {
 								const keyUpdateInterval = 20
+								var origKeyUpdateInterval uint64
 
 								BeforeEach(func() {
-									Expect(server.keyUpdateInterval).To(BeEquivalentTo(protocol.KeyUpdateInterval))
-									server.keyUpdateInterval = keyUpdateInterval
+									origKeyUpdateInterval = KeyUpdateInterval
+									KeyUpdateInterval = keyUpdateInterval
 									server.SetHandshakeConfirmed()
+								})
+
+								AfterEach(func() {
+									KeyUpdateInterval = origKeyUpdateInterval
 								})
 
 								It("initiates a key update after sealing the maximum number of packets, for the first update", func() {

--- a/interop/client/main.go
+++ b/interop/client/main.go
@@ -88,7 +88,7 @@ func runTestcase(testcase string) error {
 	switch testcase {
 	case "handshake", "transfer", "retry":
 	case "keyupdate":
-		handshake.KeyUpdateInterval = 100
+		handshake.FirstKeyUpdateInterval = 100
 	case "chacha20":
 		tlsConf.CipherSuites = []uint16{tls.TLS_CHACHA20_POLY1305_SHA256}
 	case "multiconnect":


### PR DESCRIPTION
Fixes #3738.

This PR also adds some benchmarks:
```
BenchmarkPacketEncryption-10             4722142               236.5 ns/op        0 B/op           0 allocs/op
BenchmarkPacketDecryption-10             5013650               243.8 ns/op        0 B/op           0 allocs/op
BenchmarkRollKeys-10                      294410              4244 ns/op            7032 B/op         87 allocs/op
```

CPU-wise, a key update costs about as much as encrypting / decrypting 15 to 20 packets. Memory-wise, things don't look good. This is mostly because creating a new AES cipher and doing HKDF operations allocates like crazy (this is also the reason why the handshake is so expensive, see https://github.com/quic-go/quic-go/issues/3663).