### PR TITLE
ci: remove special casing for AppVeyor

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"net"
-	"os"
 	"time"
 
 	mocklogging "github.com/quic-go/quic-go/internal/mocks/logging"
@@ -102,10 +101,6 @@ var _ = Describe("Client", func() {
 		})
 
 		It("resolves the address", func() {
-			if os.Getenv("APPVEYOR") == "True" {
-				Skip("This test is flaky on AppVeyor.")
-			}
-
 			manager := NewMockPacketHandlerManager(mockCtrl)
 			manager.EXPECT().Add(gomock.Any(), gomock.Any())
 			manager.EXPECT().Destroy()
@@ -391,10 +386,6 @@ var _ = Describe("Client", func() {
 		})
 
 		It("closes the connection when it was created by DialAddr", func() {
-			if os.Getenv("APPVEYOR") == "True" {
-				Skip("This test is flaky on AppVeyor.")
-			}
-
 			manager := NewMockPacketHandlerManager(mockCtrl)
 			mockMultiplexer.EXPECT().AddConn(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(manager, nil)
 			manager.EXPECT().Add(gomock.Any(), gomock.Any())


### PR DESCRIPTION
We dropped AppVeyor a long time ago.