### PR TITLE
wire: speed up identification of 0-RTT packets

### DIFF
--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -108,13 +108,15 @@ func Is0RTTPacket(b []byte) bool {
 		return false
 	}
 	version := protocol.VersionNumber(binary.BigEndian.Uint32(b[1:5]))
-	if !protocol.IsSupportedVersion(protocol.SupportedVersions, version) {
+	//nolint:exhaustive // We only need to test QUIC versions that we support.
+	switch version {
+	case protocol.Version1, protocol.VersionDraft29:
+		return b[0]>>4&0b11 == 0b01
+	case protocol.Version2:
+		return b[0]>>4&0b11 == 0b10
+	default:
 		return false
 	}
-	if version == protocol.Version2 {
-		return b[0]>>4&0b11 == 0b10
-	}
-	return b[0]>>4&0b11 == 0b01
 }
 
 var ErrUnsupportedVersion = errors.New("unsupported version")

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/binary"
 	"io"
 	mrand "math/rand"
+	"testing"
+	"time"
 
 	"github.com/quic-go/quic-go/internal/protocol"
 
@@ -489,3 +491,17 @@ var _ = Describe("Header Parsing", func() {
 		Expect((&Header{Type: protocol.PacketTypeHandshake}).PacketType()).To(Equal("Handshake"))
 	})
 })
+
+func BenchmarkIs0RTTPacket(b *testing.B) {
+	random := mrand.New(mrand.NewSource(time.Now().UnixNano()))
+	packets := make([][]byte, 1024)
+	for i := 0; i < len(packets); i++ {
+		packets[i] = make([]byte, random.Intn(256))
+		random.Read(packets[i])
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Is0RTTPacket(packets[i%len(packets)])
+	}
+}


### PR DESCRIPTION
This is significantly faster:
```
Is0RTTPacket-10        1.95ns ± 4%    1.05ns ± 2%  -46.30%  (p=0.000 n=12+12)
```