### PR TITLE
protocol: remove VersionTLS, used during the gQUIC -> TLS 1.3 transition

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Client", func() {
 		tracer = mocklogging.NewMockConnectionTracer(mockCtrl)
 		tr := mocklogging.NewMockTracer(mockCtrl)
 		tr.EXPECT().TracerForConnection(gomock.Any(), protocol.PerspectiveClient, gomock.Any()).Return(tracer).MaxTimes(1)
-		config = &Config{Tracer: tr, Versions: []protocol.VersionNumber{protocol.VersionTLS}}
+		config = &Config{Tracer: tr, Versions: []protocol.VersionNumber{protocol.Version1}}
 		Eventually(areConnsRunning).Should(BeFalse())
 		addr = &net.UDPAddr{IP: net.IPv4(192, 168, 100, 200), Port: 1337}
 		packetConn = NewMockPacketConn(mockCtrl)
@@ -62,7 +62,7 @@ var _ = Describe("Client", func() {
 		cl = &client{
 			srcConnID:  connID,
 			destConnID: connID,
-			version:    protocol.VersionTLS,
+			version:    protocol.Version1,
 			sconn:      newSendPconn(packetConn, addr),
 			tracer:     tracer,
 			logger:     utils.DefaultLogger,
@@ -510,7 +510,7 @@ var _ = Describe("Client", func() {
 			manager.EXPECT().Add(connID, gomock.Any())
 			mockMultiplexer.EXPECT().AddConn(packetConn, gomock.Any(), gomock.Any(), gomock.Any()).Return(manager, nil)
 
-			config := &Config{Versions: []protocol.VersionNumber{protocol.VersionTLS}, ConnectionIDGenerator: &mockConnIDGenerator{ConnID: connID}}
+			config := &Config{Versions: []protocol.VersionNumber{protocol.Version1}, ConnectionIDGenerator: &mockConnIDGenerator{ConnID: connID}}
 			c := make(chan struct{})
 			var cconn sendConn
 			var version protocol.VersionNumber
@@ -588,7 +588,7 @@ var _ = Describe("Client", func() {
 				return conn
 			}
 
-			config := &Config{Tracer: config.Tracer, Versions: []protocol.VersionNumber{protocol.VersionTLS}, ConnectionIDGenerator: &mockConnIDGenerator{ConnID: connID}}
+			config := &Config{Tracer: config.Tracer, Versions: []protocol.VersionNumber{protocol.Version1}, ConnectionIDGenerator: &mockConnIDGenerator{ConnID: connID}}
 			tracer.EXPECT().StartedConnection(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			_, err := DialAddr("localhost:7890", tlsConf, config)
 			Expect(err).ToNot(HaveOccurred())

--- a/connection_test.go
+++ b/connection_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Connection", func() {
 			tracer,
 			1234,
 			utils.DefaultLogger,
-			protocol.VersionTLS,
+			protocol.Version1,
 		).(*connection)
 		streamManager = NewMockStreamManager(mockCtrl)
 		conn.streamsMap = streamManager
@@ -1053,7 +1053,7 @@ var _ = Describe("Connection", func() {
 						Type:             protocol.PacketTypeHandshake,
 						DestConnectionID: connID,
 						SrcConnectionID:  destConnID,
-						Version:          protocol.VersionTLS,
+						Version:          protocol.Version1,
 						Length:           length,
 					},
 					PacketNumberLen: protocol.PacketNumberLen3,
@@ -2410,7 +2410,7 @@ var _ = Describe("Client Connection", func() {
 			tracer,
 			1234,
 			utils.DefaultLogger,
-			protocol.VersionTLS,
+			protocol.Version1,
 		).(*connection)
 		packer = NewMockPacker(mockCtrl)
 		conn.packer = packer

--- a/fuzzing/frames/cmd/corpus.go
+++ b/fuzzing/frames/cmd/corpus.go
@@ -11,7 +11,7 @@ import (
 	"github.com/quic-go/quic-go/internal/wire"
 )
 
-const version = protocol.VersionTLS
+const version = protocol.Version1
 
 func getRandomData(l int) []byte {
 	b := make([]byte, l)

--- a/fuzzing/frames/fuzz.go
+++ b/fuzzing/frames/fuzz.go
@@ -7,7 +7,7 @@ import (
 	"github.com/quic-go/quic-go/internal/wire"
 )
 
-const version = protocol.VersionTLS
+const version = protocol.Version1
 
 // PrefixLen is the number of bytes used for configuration
 const PrefixLen = 1

--- a/fuzzing/handshake/cmd/corpus.go
+++ b/fuzzing/handshake/cmd/corpus.go
@@ -90,7 +90,7 @@ func main() {
 		utils.NewRTTStats(),
 		nil,
 		utils.DefaultLogger.WithPrefix("client"),
-		protocol.VersionTLS,
+		protocol.Version1,
 	)
 
 	sChunkChan, sInitialStream, sHandshakeStream := initStreams()
@@ -109,7 +109,7 @@ func main() {
 		utils.NewRTTStats(),
 		nil,
 		utils.DefaultLogger.WithPrefix("server"),
-		protocol.VersionTLS,
+		protocol.Version1,
 	)
 
 	serverHandshakeCompleted := make(chan struct{})

--- a/fuzzing/handshake/fuzz.go
+++ b/fuzzing/handshake/fuzz.go
@@ -387,7 +387,7 @@ func runHandshake(runConfig [confLen]byte, messageConfig uint8, clientConf *tls.
 		utils.NewRTTStats(),
 		nil,
 		utils.DefaultLogger.WithPrefix("client"),
-		protocol.VersionTLS,
+		protocol.Version1,
 	)
 
 	var allow0RTT func() bool
@@ -408,7 +408,7 @@ func runHandshake(runConfig [confLen]byte, messageConfig uint8, clientConf *tls.
 		utils.NewRTTStats(),
 		nil,
 		utils.DefaultLogger.WithPrefix("server"),
-		protocol.VersionTLS,
+		protocol.Version1,
 	)
 
 	if len(data) == 0 {

--- a/fuzzing/header/fuzz.go
+++ b/fuzzing/header/fuzz.go
@@ -8,7 +8,7 @@ import (
 	"github.com/quic-go/quic-go/internal/wire"
 )
 
-const version = protocol.VersionTLS
+const version = protocol.Version1
 
 // PrefixLen is the number of bytes used for configuration
 const PrefixLen = 1

--- a/http3/client.go
+++ b/http3/client.go
@@ -33,7 +33,7 @@ const (
 var defaultQuicConfig = &quic.Config{
 	MaxIncomingStreams: -1, // don't allow the server to create bidirectional streams
 	KeepAlivePeriod:    10 * time.Second,
-	Versions:           []protocol.VersionNumber{protocol.VersionTLS},
+	Versions:           []protocol.VersionNumber{protocol.Version1},
 }
 
 type dialFunc func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error)

--- a/http3/server.go
+++ b/http3/server.go
@@ -45,13 +45,15 @@ const (
 )
 
 func versionToALPN(v protocol.VersionNumber) string {
-	if v == protocol.Version1 || v == protocol.Version2 {
+	//nolint:exhaustive // These are all the versions we care about.
+	switch v {
+	case protocol.Version1, protocol.Version2:
 		return NextProtoH3
-	}
-	if v == protocol.VersionTLS || v == protocol.VersionDraft29 {
+	case protocol.VersionDraft29:
 		return NextProtoH3Draft29
+	default:
+		return ""
 	}
-	return ""
 }
 
 // ConfigureTLSConfig creates a new tls.Config which can be used

--- a/integrationtests/self/conn_id_test.go
+++ b/integrationtests/self/conn_id_test.go
@@ -79,10 +79,10 @@ var _ = Describe("Connection ID lengths tests", func() {
 	It("downloads a file using a 0-byte connection ID for the client", func() {
 		serverConf := getQuicConfig(&quic.Config{
 			ConnectionIDLength: randomConnIDLen(),
-			Versions:           []protocol.VersionNumber{protocol.VersionTLS},
+			Versions:           []protocol.VersionNumber{protocol.Version1},
 		})
 		clientConf := getQuicConfig(&quic.Config{
-			Versions: []protocol.VersionNumber{protocol.VersionTLS},
+			Versions: []protocol.VersionNumber{protocol.Version1},
 		})
 
 		ln := runServer(serverConf)
@@ -93,11 +93,11 @@ var _ = Describe("Connection ID lengths tests", func() {
 	It("downloads a file when both client and server use a random connection ID length", func() {
 		serverConf := getQuicConfig(&quic.Config{
 			ConnectionIDLength: randomConnIDLen(),
-			Versions:           []protocol.VersionNumber{protocol.VersionTLS},
+			Versions:           []protocol.VersionNumber{protocol.Version1},
 		})
 		clientConf := getQuicConfig(&quic.Config{
 			ConnectionIDLength: randomConnIDLen(),
-			Versions:           []protocol.VersionNumber{protocol.VersionTLS},
+			Versions:           []protocol.VersionNumber{protocol.Version1},
 		})
 
 		ln := runServer(serverConf)
@@ -107,11 +107,11 @@ var _ = Describe("Connection ID lengths tests", func() {
 
 	It("downloads a file when both client and server use a custom connection ID generator", func() {
 		serverConf := getQuicConfig(&quic.Config{
-			Versions:              []protocol.VersionNumber{protocol.VersionTLS},
+			Versions:              []protocol.VersionNumber{protocol.Version1},
 			ConnectionIDGenerator: &connIDGenerator{length: randomConnIDLen()},
 		})
 		clientConf := getQuicConfig(&quic.Config{
-			Versions:              []protocol.VersionNumber{protocol.VersionTLS},
+			Versions:              []protocol.VersionNumber{protocol.Version1},
 			ConnectionIDGenerator: &connIDGenerator{length: randomConnIDLen()},
 		})
 

--- a/integrationtests/self/handshake_rtt_test.go
+++ b/integrationtests/self/handshake_rtt_test.go
@@ -76,8 +76,8 @@ var _ = Describe("Handshake RTT tests", func() {
 	var clientConfig *quic.Config
 
 	BeforeEach(func() {
-		serverConfig.Versions = []protocol.VersionNumber{protocol.VersionTLS}
-		clientConfig = getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{protocol.VersionTLS}})
+		serverConfig.Versions = []protocol.VersionNumber{protocol.Version1}
+		clientConfig = getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{protocol.Version1}})
 		clientConfig := getTLSClientConfig()
 		clientConfig.InsecureSkipVerify = true
 	})

--- a/integrationtests/self/stream_test.go
+++ b/integrationtests/self/stream_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Bidirectional streams", func() {
 		qconf      *quic.Config
 	)
 
-	for _, v := range []protocol.VersionNumber{protocol.VersionTLS} {
+	for _, v := range []protocol.VersionNumber{protocol.Version1} {
 		version := v
 
 		Context(fmt.Sprintf("with QUIC %s", version), func() {

--- a/integrationtests/self/uni_stream_test.go
+++ b/integrationtests/self/uni_stream_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Unidirectional Streams", func() {
 
 	BeforeEach(func() {
 		var err error
-		qconf = &quic.Config{Versions: []protocol.VersionNumber{protocol.VersionTLS}}
+		qconf = &quic.Config{Versions: []protocol.VersionNumber{protocol.Version1}}
 		server, err = quic.ListenAddr("localhost:0", getTLSConfig(), getQuicConfig(qconf))
 		Expect(err).ToNot(HaveOccurred())
 		serverAddr = fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port)

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -31,7 +31,7 @@ var _ = Describe("QUIC Proxy", func() {
 		hdr := wire.ExtendedHeader{
 			Header: wire.Header{
 				Type:             protocol.PacketTypeInitial,
-				Version:          protocol.VersionTLS,
+				Version:          protocol.Version1,
 				Length:           4 + protocol.ByteCount(len(payload)),
 				DestConnectionID: protocol.ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef, 0, 0, 0x13, 0x37}),
 				SrcConnectionID:  protocol.ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef, 0, 0, 0x13, 0x37}),
@@ -49,7 +49,7 @@ var _ = Describe("QUIC Proxy", func() {
 		hdr, data, _, err := wire.ParsePacket(b)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		Expect(hdr.Type).To(Equal(protocol.PacketTypeInitial))
-		extHdr, err := hdr.ParseExtended(bytes.NewReader(data), protocol.VersionTLS)
+		extHdr, err := hdr.ParseExtended(bytes.NewReader(data), protocol.Version1)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return extHdr.PacketNumber
 	}

--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&utils.RTTStats{},
 			nil,
 			utils.DefaultLogger.WithPrefix("server"),
-			protocol.VersionTLS,
+			protocol.Version1,
 		)
 
 		done := make(chan struct{})
@@ -145,7 +145,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&utils.RTTStats{},
 			nil,
 			utils.DefaultLogger.WithPrefix("client"),
-			protocol.VersionTLS,
+			protocol.Version1,
 		)
 
 		done := make(chan struct{})
@@ -181,7 +181,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&utils.RTTStats{},
 			nil,
 			utils.DefaultLogger.WithPrefix("server"),
-			protocol.VersionTLS,
+			protocol.Version1,
 		)
 
 		done := make(chan struct{})
@@ -222,7 +222,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&utils.RTTStats{},
 			nil,
 			utils.DefaultLogger.WithPrefix("server"),
-			protocol.VersionTLS,
+			protocol.Version1,
 		)
 
 		done := make(chan struct{})
@@ -257,7 +257,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 			&utils.RTTStats{},
 			nil,
 			utils.DefaultLogger.WithPrefix("server"),
-			protocol.VersionTLS,
+			protocol.Version1,
 		)
 
 		done := make(chan struct{})
@@ -375,7 +375,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				clientRTTStats,
 				nil,
 				utils.DefaultLogger.WithPrefix("client"),
-				protocol.VersionTLS,
+				protocol.Version1,
 			)
 
 			var allow0RTT func() bool
@@ -406,7 +406,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				serverRTTStats,
 				nil,
 				utils.DefaultLogger.WithPrefix("server"),
-				protocol.VersionTLS,
+				protocol.Version1,
 			)
 
 			handshake(client, cChunkChan, server, sChunkChan)
@@ -476,7 +476,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&utils.RTTStats{},
 				nil,
 				utils.DefaultLogger.WithPrefix("client"),
-				protocol.VersionTLS,
+				protocol.Version1,
 			)
 
 			done := make(chan struct{})
@@ -519,7 +519,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&utils.RTTStats{},
 				nil,
 				utils.DefaultLogger.WithPrefix("client"),
-				protocol.VersionTLS,
+				protocol.Version1,
 			)
 
 			sChunkChan, sInitialStream, sHandshakeStream := initStreams()
@@ -545,7 +545,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 				&utils.RTTStats{},
 				nil,
 				utils.DefaultLogger.WithPrefix("server"),
-				protocol.VersionTLS,
+				protocol.Version1,
 			)
 
 			done := make(chan struct{})
@@ -579,7 +579,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					&utils.RTTStats{},
 					nil,
 					utils.DefaultLogger.WithPrefix("client"),
-					protocol.VersionTLS,
+					protocol.Version1,
 				)
 
 				sChunkChan, sInitialStream, sHandshakeStream := initStreams()
@@ -600,7 +600,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					&utils.RTTStats{},
 					nil,
 					utils.DefaultLogger.WithPrefix("server"),
-					protocol.VersionTLS,
+					protocol.Version1,
 				)
 
 				done := make(chan struct{})
@@ -638,7 +638,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					&utils.RTTStats{},
 					nil,
 					utils.DefaultLogger.WithPrefix("client"),
-					protocol.VersionTLS,
+					protocol.Version1,
 				)
 
 				sChunkChan, sInitialStream, sHandshakeStream := initStreams()
@@ -659,7 +659,7 @@ var _ = Describe("Crypto Setup TLS", func() {
 					&utils.RTTStats{},
 					nil,
 					utils.DefaultLogger.WithPrefix("server"),
-					protocol.VersionTLS,
+					protocol.Version1,
 				)
 
 				done := make(chan struct{})

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -18,7 +18,6 @@ const (
 
 // The version numbers, making grepping easier
 const (
-	VersionTLS     VersionNumber = 0x1
 	VersionUnknown VersionNumber = math.MaxUint32
 	VersionDraft29 VersionNumber = 0xff00001d
 	Version1       VersionNumber = 0x1
@@ -31,15 +30,10 @@ var SupportedVersions = []VersionNumber{Version1, Version2, VersionDraft29}
 
 // IsValidVersion says if the version is known to quic-go
 func IsValidVersion(v VersionNumber) bool {
-	return v == VersionTLS || IsSupportedVersion(SupportedVersions, v)
+	return v == Version1 || IsSupportedVersion(SupportedVersions, v)
 }
 
 func (vn VersionNumber) String() string {
-	// For releases, VersionTLS will be set to a draft version.
-	// A switch statement can't contain duplicate cases.
-	if vn == VersionTLS && VersionTLS != VersionDraft29 && VersionTLS != Version1 {
-		return "TLS dev version (WIP)"
-	}
 	//nolint:exhaustive
 	switch vn {
 	case VersionUnknown:

--- a/internal/protocol/version_test.go
+++ b/internal/protocol/version_test.go
@@ -11,16 +11,11 @@ var _ = Describe("Version", func() {
 	}
 
 	It("says if a version is valid", func() {
-		Expect(IsValidVersion(VersionTLS)).To(BeTrue())
 		Expect(IsValidVersion(VersionUnknown)).To(BeFalse())
 		Expect(IsValidVersion(VersionDraft29)).To(BeTrue())
 		Expect(IsValidVersion(Version1)).To(BeTrue())
 		Expect(IsValidVersion(Version2)).To(BeTrue())
 		Expect(IsValidVersion(1234)).To(BeFalse())
-	})
-
-	It("versions don't have reserved version numbers", func() {
-		Expect(isReservedVersion(VersionTLS)).To(BeFalse())
 	})
 
 	It("has the right string representation", func() {

--- a/logging/packet_header_test.go
+++ b/logging/packet_header_test.go
@@ -13,28 +13,28 @@ var _ = Describe("Packet Header", func() {
 		It("recognizes Initial packets", func() {
 			Expect(PacketTypeFromHeader(&wire.Header{
 				Type:    protocol.PacketTypeInitial,
-				Version: protocol.VersionTLS,
+				Version: protocol.Version1,
 			})).To(Equal(PacketTypeInitial))
 		})
 
 		It("recognizes Handshake packets", func() {
 			Expect(PacketTypeFromHeader(&wire.Header{
 				Type:    protocol.PacketTypeHandshake,
-				Version: protocol.VersionTLS,
+				Version: protocol.Version1,
 			})).To(Equal(PacketTypeHandshake))
 		})
 
 		It("recognizes Retry packets", func() {
 			Expect(PacketTypeFromHeader(&wire.Header{
 				Type:    protocol.PacketTypeRetry,
-				Version: protocol.VersionTLS,
+				Version: protocol.Version1,
 			})).To(Equal(PacketTypeRetry))
 		})
 
 		It("recognizes 0-RTT packets", func() {
 			Expect(PacketTypeFromHeader(&wire.Header{
 				Type:    protocol.PacketType0RTT,
-				Version: protocol.VersionTLS,
+				Version: protocol.Version1,
 			})).To(Equal(PacketType0RTT))
 		})
 
@@ -43,7 +43,7 @@ var _ = Describe("Packet Header", func() {
 		})
 
 		It("handles unrecognized packet types", func() {
-			Expect(PacketTypeFromHeader(&wire.Header{Version: protocol.VersionTLS})).To(Equal(PacketTypeNotDetermined))
+			Expect(PacketTypeFromHeader(&wire.Header{Version: protocol.Version1})).To(Equal(PacketTypeNotDetermined))
 		})
 	})
 })

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Packet Handler Map", func() {
 				Type:             t,
 				DestConnectionID: connID,
 				Length:           length,
-				Version:          protocol.VersionTLS,
+				Version:          protocol.Version1,
 			},
 			PacketNumberLen: protocol.PacketNumberLen2,
 		}).Append(nil, protocol.Version1)

--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -427,7 +427,7 @@ var _ = Describe("Tracing", func() {
 							DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
 							SrcConnectionID:  protocol.ParseConnectionID([]byte{4, 3, 2, 1}),
 							Length:           1337,
-							Version:          protocol.VersionTLS,
+							Version:          protocol.Version1,
 						},
 						PacketNumber: 1337,
 					},
@@ -493,7 +493,7 @@ var _ = Describe("Tracing", func() {
 							SrcConnectionID:  protocol.ParseConnectionID([]byte{4, 3, 2, 1}),
 							Token:            []byte{0xde, 0xad, 0xbe, 0xef},
 							Length:           1234,
-							Version:          protocol.VersionTLS,
+							Version:          protocol.Version1,
 						},
 						PacketNumber: 1337,
 					},
@@ -562,7 +562,7 @@ var _ = Describe("Tracing", func() {
 						DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
 						SrcConnectionID:  protocol.ParseConnectionID([]byte{4, 3, 2, 1}),
 						Token:            []byte{0xde, 0xad, 0xbe, 0xef},
-						Version:          protocol.VersionTLS,
+						Version:          protocol.Version1,
 					},
 				)
 				entry := exportAndParseSingle()

--- a/server_test.go
+++ b/server_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Server", func() {
 			Header:          *hdr,
 			PacketNumber:    0x42,
 			PacketNumberLen: protocol.PacketNumberLen4,
-		}).Append(buf.Data, protocol.VersionTLS)
+		}).Append(buf.Data, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		n := len(buf.Data)
 		buf.Data = append(buf.Data, p...)
@@ -71,7 +71,7 @@ var _ = Describe("Server", func() {
 			Type:             protocol.PacketTypeInitial,
 			SrcConnectionID:  protocol.ParseConnectionID([]byte{5, 4, 3, 2, 1}),
 			DestConnectionID: destConnID,
-			Version:          protocol.VersionTLS,
+			Version:          protocol.Version1,
 		}
 		p := getPacket(hdr, make([]byte, protocol.MinInitialPacketSize))
 		p.buffer = getPacketBuffer()
@@ -131,7 +131,7 @@ var _ = Describe("Server", func() {
 	})
 
 	It("setups with the right values", func() {
-		supportedVersions := []protocol.VersionNumber{protocol.VersionTLS}
+		supportedVersions := []protocol.VersionNumber{protocol.Version1}
 		requireAddrVal := func(net.Addr) bool { return true }
 		config := Config{
 			Versions:                 supportedVersions,
@@ -247,7 +247,7 @@ var _ = Describe("Server", func() {
 					Type:             protocol.PacketTypeInitial,
 					SrcConnectionID:  protocol.ParseConnectionID([]byte{5, 4, 3, 2, 1}),
 					DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
-					Version:          protocol.VersionTLS,
+					Version:          protocol.Version1,
 					Token:            retryToken,
 				}
 				p := getPacket(hdr, make([]byte, protocol.MinInitialPacketSize))
@@ -413,7 +413,7 @@ var _ = Describe("Server", func() {
 					Type:             protocol.PacketTypeInitial,
 					SrcConnectionID:  protocol.ParseConnectionID([]byte{5, 4, 3, 2, 1}),
 					DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
-					Version:          protocol.VersionTLS,
+					Version:          protocol.Version1,
 				}
 				packet := getPacket(hdr, make([]byte, protocol.MinInitialPacketSize))
 				raddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1337}
@@ -444,7 +444,7 @@ var _ = Describe("Server", func() {
 					Type:             protocol.PacketTypeInitial,
 					SrcConnectionID:  protocol.ParseConnectionID([]byte{5, 4, 3, 2, 1}),
 					DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
-					Version:          protocol.VersionTLS,
+					Version:          protocol.Version1,
 				}
 				p := getPacket(hdr, make([]byte, protocol.MinInitialPacketSize))
 				run := make(chan struct{})
@@ -779,7 +779,7 @@ var _ = Describe("Server", func() {
 					SrcConnectionID:  protocol.ParseConnectionID([]byte{5, 4, 3, 2, 1}),
 					DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
 					Token:            token,
-					Version:          protocol.VersionTLS,
+					Version:          protocol.Version1,
 				}
 				packet := getPacket(hdr, make([]byte, protocol.MinInitialPacketSize))
 				packet.data = append(packet.data, []byte("coalesced packet")...) // add some garbage to simulate a coalesced packet
@@ -817,7 +817,7 @@ var _ = Describe("Server", func() {
 					SrcConnectionID:  protocol.ParseConnectionID([]byte{5, 4, 3, 2, 1}),
 					DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
 					Token:            token,
-					Version:          protocol.VersionTLS,
+					Version:          protocol.Version1,
 				}
 				packet := getPacket(hdr, make([]byte, protocol.MinInitialPacketSize))
 				packet.remoteAddr = raddr
@@ -850,7 +850,7 @@ var _ = Describe("Server", func() {
 					SrcConnectionID:  protocol.ParseConnectionID([]byte{5, 4, 3, 2, 1}),
 					DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
 					Token:            token,
-					Version:          protocol.VersionTLS,
+					Version:          protocol.Version1,
 				}
 				packet := getPacket(hdr, make([]byte, protocol.MinInitialPacketSize))
 				packet.data[len(packet.data)-10] ^= 0xff // corrupt the packet
@@ -881,7 +881,7 @@ var _ = Describe("Server", func() {
 					SrcConnectionID:  protocol.ParseConnectionID([]byte{5, 4, 3, 2, 1}),
 					DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
 					Token:            token,
-					Version:          protocol.VersionTLS,
+					Version:          protocol.Version1,
 				}
 				packet := getPacket(hdr, make([]byte, protocol.MinInitialPacketSize))
 				packet.remoteAddr = raddr
@@ -906,7 +906,7 @@ var _ = Describe("Server", func() {
 					SrcConnectionID:  protocol.ParseConnectionID([]byte{5, 4, 3, 2, 1}),
 					DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
 					Token:            token,
-					Version:          protocol.VersionTLS,
+					Version:          protocol.Version1,
 				}
 				packet := getPacket(hdr, make([]byte, protocol.MinInitialPacketSize))
 				packet.data[len(packet.data)-10] ^= 0xff // corrupt the packet


### PR DESCRIPTION
Depends on #3763.