### PR TITLE
avoid copying when detecting stateless resets

### DIFF
--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -456,8 +456,7 @@ func (h *packetHandlerMap) maybeHandleStatelessReset(data []byte) bool {
 		return false
 	}
 
-	var token protocol.StatelessResetToken
-	copy(token[:], data[len(data)-16:])
+	token := *(*protocol.StatelessResetToken)(data[len(data)-16:])
 	if sess, ok := h.resetTokens[token]; ok {
 		h.logger.Debugf("Received a stateless reset with token %#x. Closing connection.", token)
 		go sess.destroy(&StatelessResetError{Token: token})


### PR DESCRIPTION
Once we drop support for Go 1.19, this can be further simplified to:
```go
token := protocol.StatelessResetToken(data[len(data)-16:])
```

See https://tip.golang.org/doc/go1.20#language.