### PR TITLE
ci: update golangci-lint config, increase timeout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,4 +31,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          args: --timeout=3m
           version: v1.52.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,15 @@
 run:
-  skip-files:
-    - internal/qtls/structs_equal_test.go
-
 linters-settings:
   depguard:
     type: blacklist
     packages:
       - github.com/marten-seemann/qtls
+      - github.com/quic-go/qtls-go1-19
+      - github.com/quic-go/qtls-go1-20
     packages-with-error-message:
       - github.com/marten-seemann/qtls: "importing qtls only allowed in internal/qtls"
+      - github.com/quic-go/qtls-go1-19: "importing qtls only allowed in internal/qtls"
+      - github.com/quic-go/qtls-go1-20: "importing qtls only allowed in internal/qtls"
   misspell:
     ignore-words:
       - ect
@@ -17,7 +18,6 @@ linters:
   disable-all: true
   enable:
     - asciicheck
-    - deadcode
     - depguard
     - exhaustive
     - exportloopref
@@ -30,11 +30,9 @@ linters:
     - prealloc
     - staticcheck
     - stylecheck
-    - structcheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - vet
 
 issues:


### PR DESCRIPTION
Some of the linters we've been using are deprecated now. We also hadn't update our qtls depguard config for a very long time.