### PR TITLE
ci: allow changing runners through config vars

### DIFF
--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -1,8 +1,8 @@
 name: Build interop Docker image
-on: 
+on:
   push:
     branches: [ interop ]
-  
+
 jobs:
   interop:
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:  [master]
+  pull_request:
+
 jobs:
   crosscompile:
     strategy:

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -5,7 +5,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ "1.19.x", "1.20.x" ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars[format('CROSS_COMPILE_RUNNER_{0}', matrix.os)] || '"ubuntu-latest"') }}
     name: "Cross Compilation (Go ${{matrix.go}})"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -4,6 +4,10 @@ on:
     tags: [v*]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
+  cancel-in-progress: true
+
 jobs:
   crosscompile:
     strategy:

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,6 +1,7 @@
 on:
   push:
     branches:  [master]
+    tags: [v*]
   pull_request:
 
 jobs:

--- a/.github/workflows/go-generate.yml
+++ b/.github/workflows/go-generate.yml
@@ -4,6 +4,10 @@ on:
     tags: [v*]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
+  cancel-in-progress: true
+
 jobs:
   gogenerate:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-generate.yml
+++ b/.github/workflows/go-generate.yml
@@ -1,6 +1,7 @@
 on:
   push:
     branches:  [master]
+    tags: [v*]
   pull_request:
 
 jobs:

--- a/.github/workflows/go-generate.yml
+++ b/.github/workflows/go-generate.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:  [master]
+  pull_request:
+
 jobs:
   gogenerate:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,10 @@ on:
     tags: [v*]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     strategy:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          stable: '!contains(${{ matrix.go }}, "beta") && !contains(${{ matrix.go }}, "rc")'
           go-version: ${{ matrix.go }}
       - run: go version
       - name: set qlogger

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:  [master]
+  pull_request:
 
 jobs:
   integration:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,7 @@
 on:
   push:
     branches:  [master]
+    tags: [v*]
   pull_request:
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ "1.19.x", "1.20.x" ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars[format('INTEGRATION_RUNNER_{0}', matrix.os)] || '"ubuntu-latest"') }}
     env:
       DEBUG: false # set this to true to export qlogs and save them as artifacts
       TIMESCALE_FACTOR: 3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:  [master]
+  pull_request:
 
 jobs:
   check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@ on:
     tags: [v*]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 on:
   push:
     branches:  [master]
+    tags: [v*]
   pull_request:
 
 jobs:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -4,6 +4,10 @@ on:
     tags: [v*]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     strategy:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,6 +1,7 @@
 on:
   push:
     branches:  [master]
+    tags: [v*]
   pull_request:
 
 jobs:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,5 +1,7 @@
-on: [push, pull_request]
-
+on:
+  push:
+    branches:  [master]
+  pull_request:
 
 jobs:
   unit:


### PR DESCRIPTION
###### Description

This PR:
- allows changing runners for jobs in integration and cross-compile workflows via configuration variables
- changes workflow triggers to: pull requests, pushes to the default branches, pushes to version tags
- configures concurrency groups for workflows: cancel in-progress runs in pull requests if the HEAD moves

###### Testing
- [x] ran integration workflow on `['self-hosted', 'linux', 'x64', 'xlarge']` https://github.com/pl-strflt/tf-aws-gh-runner/actions/runs/4687529039
- [x] ran cross-compile workflow on `['self-hosted', 'linux', 'x64', '2xlarge']` https://github.com/pl-strflt/tf-aws-gh-runner/actions/runs/4687351779