### PR TITLE
http3: check scheme before host to be consistent with net/http

### DIFF
--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -110,7 +110,6 @@ func (r *RoundTripper) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.
 		closeRequestBody(req)
 		return nil, errors.New("http3: nil Request.URL")
 	}
-	// check Scheme before Host so the error message is comprehensible
 	if req.URL.Scheme != "https" {
 		closeRequestBody(req)
 		return nil, fmt.Errorf("http3: unsupported protocol scheme: %s", req.URL.Scheme)

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -110,6 +110,11 @@ func (r *RoundTripper) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.
 		closeRequestBody(req)
 		return nil, errors.New("http3: nil Request.URL")
 	}
+	// check Scheme before Host so the error message is comprehensible
+	if req.URL.Scheme != "https" {
+		closeRequestBody(req)
+		return nil, fmt.Errorf("http3: unsupported protocol scheme: %s", req.URL.Scheme)
+	}
 	if req.URL.Host == "" {
 		closeRequestBody(req)
 		return nil, errors.New("http3: no Host in request URL")
@@ -117,10 +122,6 @@ func (r *RoundTripper) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.
 	if req.Header == nil {
 		closeRequestBody(req)
 		return nil, errors.New("http3: nil Request.Header")
-	}
-	if req.URL.Scheme != "https" {
-		closeRequestBody(req)
-		return nil, fmt.Errorf("http3: unsupported protocol scheme: %s", req.URL.Scheme)
 	}
 	for k, vv := range req.Header {
 		if !httpguts.ValidHeaderFieldName(k) {


### PR DESCRIPTION
In case of a missing scheme in an url passed to `http3.RoundTripper`, the error message is "_http3: no Host in request URL_" whereas with `net/http` it's "_unsupported protocol scheme ""_" which is more comprehensible.

see [h3dial](https://github.com/kgersen/h3dial) for an example:
```
go run main.go badurl
QUIC-GO:
  dialing badurl
2023/04/14 15:12:53 Get "badurl": http3: no Host in request URL
net/http:
  dialing badurl
2023/04/14 15:12:53 Get "badurl": unsupported protocol scheme ""

```

this simple PR fixes the order Scheme and Host are checked.
h3dial with this PR applied:
```
QUIC-GO:
  dialing badurl
2023/04/14 15:35:29 Get "badurl": http3: unsupported protocol scheme: 
net/http:
  dialing badurl
2023/04/14 15:35:29 Get "badurl": unsupported protocol scheme ""

```