### PR TITLE
ci: allow changing runners through config vars

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -5,7 +5,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ "1.19.x", "1.20.x" ]
-    runs-on: ${{ fromJSON(vars[format('CROSS_COMPILE_RUNNER_{0}', matrix.os)] || '"ubuntu-latest"') }}
+    runs-on: ${{ fromJSON(vars['CROSS_COMPILE_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}
     name: "Cross Compilation (Go ${{matrix.go}})"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -5,7 +5,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ "1.19.x", "1.20.x" ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars[format('CROSS_COMPILE_RUNNER_{0}', matrix.os)] || '"ubuntu-latest"') }}
     name: "Cross Compilation (Go ${{matrix.go}})"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ "1.19.x", "1.20.x" ]
-    runs-on: ${{ fromJSON(vars[format('INTEGRATION_RUNNER_{0}', matrix.os)] || '"ubuntu-latest"') }}
+    runs-on: ${{ fromJSON(vars['INTEGRATION_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}
     env:
       DEBUG: false # set this to true to export qlogs and save them as artifacts
       TIMESCALE_FACTOR: 3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ "1.19.x", "1.20.x" ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars[format('INTEGRATION_RUNNER_{0}', matrix.os)] || '"ubuntu-latest"') }}
     env:
       DEBUG: false # set this to true to export qlogs and save them as artifacts
       TIMESCALE_FACTOR: 3

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: [ "ubuntu", "windows", "macos" ]
         go: [ "1.19.x", "1.20.x" ]
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ fromJSON(vars[format('UNIT_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
     name: Unit tests (${{ matrix.os}}, Go ${{ matrix.go }})
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Minimal version of #3773, making **only** the changes required to run on custom machines.