### PR TITLE
ci: speed up the cross compilation job by parallelizing

### DIFF
--- a/.github/workflows/cross-compile.sh
+++ b/.github/workflows/cross-compile.sh
@@ -2,17 +2,11 @@
 
 set -e
 
-GOVERSION=$(go version | cut -d " " -f 3 | cut -b 3-6)
-
 for dist in $(go tool dist list); do
 	goos=$(echo $dist | cut -d "/" -f1)
 	goarch=$(echo $dist | cut -d "/" -f2)
 	# cross-compiling for android is a pain...
 	if [[ "$goos" == "android" ]]; then continue; fi
-	# Go 1.14 lacks syscall.IPV6_RECVTCLASS
-	if [[ $GOVERSION == "1.14" && $goos == "darwin" && $goarch == "arm" ]]; then continue; fi
-	# darwin/arm64 requires Cgo for Go < 1.16
-	if [[ $GOVERSION != "1.16" && "$goos" == "darwin" && $goarch == "arm64" ]]; then continue; fi
   # iOS builds require Cgo, see https://github.com/golang/go/issues/43343
   # Cgo would then need a C cross compilation setup. Not worth the hassle.
 	if [[ "$goos" == "ios" ]]; then continue; fi

--- a/.github/workflows/cross-compile.sh
+++ b/.github/workflows/cross-compile.sh
@@ -2,16 +2,17 @@
 
 set -e
 
-for dist in $(go tool dist list); do
-	goos=$(echo $dist | cut -d "/" -f1)
-	goarch=$(echo $dist | cut -d "/" -f2)
-	# cross-compiling for android is a pain...
-	if [[ "$goos" == "android" ]]; then continue; fi
-  # iOS builds require Cgo, see https://github.com/golang/go/issues/43343
-  # Cgo would then need a C cross compilation setup. Not worth the hassle.
-	if [[ "$goos" == "ios" ]]; then continue; fi
+dist="$1"
+goos=$(echo "$dist" | cut -d "/" -f1)
+goarch=$(echo "$dist" | cut -d "/" -f2)
 
-	echo "$dist"
-	GOOS=$goos GOARCH=$goarch go build -o main example/main.go
-	rm main
-done
+# cross-compiling for android is a pain...
+if [[ "$goos" == "android" ]]; then exit; fi
+# iOS builds require Cgo, see https://github.com/golang/go/issues/43343
+# Cgo would then need a C cross compilation setup. Not worth the hassle.
+if [[ "$goos" == "ios" ]]; then exit; fi
+
+echo "$dist"
+out="main-$goos-$goarch"
+GOOS=$goos GOARCH=$goarch go build -o $out example/main.go
+rm $out

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -19,4 +19,5 @@ jobs:
       - name: Install dependencies
         run: go build example/main.go
       - name: Run cross compilation
-        run: .github/workflows/cross-compile.sh
+        # run in parallel on as many cores as are available on the machine
+        run: go tool dist list | xargs -I % -P "$(nproc)" .github/workflows/cross-compile.sh %


### PR DESCRIPTION
Current speedup is minimal, but will probably become significant once we switch to PL-provided runners (#3773 or #3783).