### PR TITLE
http3: add compatibility with net/http.ResponseController

### DIFF
--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/internal/utils"
@@ -15,6 +16,7 @@ import (
 
 type responseWriter struct {
 	conn        quic.Connection
+	str         quic.Stream
 	bufferedStr *bufio.Writer
 	buf         []byte
 
@@ -36,6 +38,7 @@ func newResponseWriter(str quic.Stream, conn quic.Connection, logger utils.Logge
 		header:      http.Header{},
 		buf:         make([]byte, 16),
 		conn:        conn,
+		str:         str,
 		bufferedStr: bufio.NewWriter(str),
 		logger:      logger,
 	}
@@ -119,6 +122,14 @@ func (w *responseWriter) Flush() {
 
 func (w *responseWriter) StreamCreator() StreamCreator {
 	return w.conn
+}
+
+func (w *responseWriter) SetReadDeadline(deadline time.Time) error {
+	return w.str.SetReadDeadline(deadline)
+}
+
+func (w *responseWriter) SetWriteDeadline(deadline time.Time) error {
+	return w.str.SetWriteDeadline(deadline)
 }
 
 // copied from http2/http2.go

--- a/integrationtests/self/go119_test.go
+++ b/integrationtests/self/go119_test.go
@@ -1,0 +1,22 @@
+//go:build go1.19 && !go1.20
+
+package self_test
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+var (
+	go120           = false
+	errNotSupported = errors.New("not supported")
+)
+
+func setReadDeadline(w http.ResponseWriter, deadline time.Time) error {
+	return errNotSupported
+}
+
+func setWriteDeadline(w http.ResponseWriter, deadline time.Time) error {
+	return errNotSupported
+}

--- a/integrationtests/self/go120_test.go
+++ b/integrationtests/self/go120_test.go
@@ -1,0 +1,22 @@
+//go:build go1.20
+
+package self_test
+
+import (
+	"net/http"
+	"time"
+)
+
+var go120 = true
+
+func setReadDeadline(w http.ResponseWriter, deadline time.Time) error {
+	rc := http.NewResponseController(w)
+
+	return rc.SetReadDeadline(deadline)
+}
+
+func setWriteDeadline(w http.ResponseWriter, deadline time.Time) error {
+	rc := http.NewResponseController(w)
+
+	return rc.SetWriteDeadline(deadline)
+}

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -386,14 +386,14 @@ var _ = Describe("HTTP tests", func() {
 				Expect(repl).To(Equal(data))
 			})
 
-			It("supports read deadlines", Focus, func() {
+			It("supports read deadlines", func() {
 				if !go120 {
 					Skip("This test requires Go 1.20+")
 				}
 
 				mux.HandleFunc("/read-deadline", func(w http.ResponseWriter, r *http.Request) {
 					defer GinkgoRecover()
-					err := SetReadDeadline(w, time.Now().Add(deadlineDelay))
+					err := setReadDeadline(w, time.Now().Add(deadlineDelay))
 					Expect(err).ToNot(HaveOccurred())
 
 					body, err := io.ReadAll(r.Body)
@@ -414,14 +414,14 @@ var _ = Describe("HTTP tests", func() {
 				Expect(string(body)).To(Equal("ok"))
 			})
 
-			It("supports write deadlines", Focus, func() {
+			It("supports write deadlines", func() {
 				if !go120 {
 					Skip("This test requires Go 1.20+")
 				}
 
 				mux.HandleFunc("/write-deadline", func(w http.ResponseWriter, r *http.Request) {
 					defer GinkgoRecover()
-					err := SetWriteDeadline(w, time.Now().Add(deadlineDelay))
+					err := setWriteDeadline(w, time.Now().Add(deadlineDelay))
 					Expect(err).ToNot(HaveOccurred())
 
 					_, err = io.Copy(w, neverEnding('a'))

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -35,6 +35,8 @@ func (b neverEnding) Read(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
+const deadlineDelay = 250 * time.Millisecond
+
 var _ = Describe("HTTP tests", func() {
 	var (
 		mux            *http.ServeMux
@@ -385,10 +387,13 @@ var _ = Describe("HTTP tests", func() {
 			})
 
 			It("supports read deadlines", Focus, func() {
+				if !go120 {
+					Skip("This test requires Go 1.20+")
+				}
+
 				mux.HandleFunc("/read-deadline", func(w http.ResponseWriter, r *http.Request) {
 					defer GinkgoRecover()
-					rc := http.NewResponseController(w)
-					err := rc.SetReadDeadline(time.Now().Add(time.Second))
+					err := SetReadDeadline(w, time.Now().Add(deadlineDelay))
 					Expect(err).ToNot(HaveOccurred())
 
 					body, err := io.ReadAll(r.Body)
@@ -398,35 +403,38 @@ var _ = Describe("HTTP tests", func() {
 					w.Write([]byte("ok"))
 				})
 
-				expectedEnd := time.Now().Add(time.Second)
+				expectedEnd := time.Now().Add(deadlineDelay)
 				resp, err := client.Post("https://localhost:"+port+"/read-deadline", "text/plain", neverEnding('a'))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(200))
 
-				body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 2*time.Second))
+				body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 2*deadlineDelay))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(time.Now().After(expectedEnd)).To(BeTrue())
 				Expect(string(body)).To(Equal("ok"))
 			})
 
 			It("supports write deadlines", Focus, func() {
+				if !go120 {
+					Skip("This test requires Go 1.20+")
+				}
+
 				mux.HandleFunc("/write-deadline", func(w http.ResponseWriter, r *http.Request) {
 					defer GinkgoRecover()
-					rc := http.NewResponseController(w)
-					err := rc.SetWriteDeadline(time.Now().Add(time.Second))
+					err := SetWriteDeadline(w, time.Now().Add(deadlineDelay))
 					Expect(err).ToNot(HaveOccurred())
 
 					_, err = io.Copy(w, neverEnding('a'))
 					Expect(err).To(MatchError(os.ErrDeadlineExceeded))
 				})
 
-				expectedEnd := time.Now().Add(time.Second)
+				expectedEnd := time.Now().Add(deadlineDelay)
 
 				resp, err := client.Get("https://localhost:" + port + "/write-deadline")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(200))
 
-				body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 2*time.Second))
+				body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 2*deadlineDelay))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(time.Now().After(expectedEnd)).To(BeTrue())
 				Expect(string(body)).To(ContainSubstring("aa"))


### PR DESCRIPTION
[Go 1.20 added a new `"net/http".ResponseController` type](https://tip.golang.org/doc/go1.20#http_responsecontroller) that allows, among other things, to set per-request timeouts.

This patch adds support for this new type. It is necessary for caddyserver/caddy#5509 and dunglas/mercure#764.