### PR TITLE
add Connection.SetIdleTimeout

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2176,6 +2176,11 @@ func (s *connection) ReceiveMessage() ([]byte, error) {
 	return s.datagramQueue.Receive()
 }
 
+func (s *connection) SetIdleTimeout(timeout time.Duration) {
+	s.idleTimeout = timeout
+	s.maybeResetTimer()
+}
+
 func (s *connection) LocalAddr() net.Addr {
 	return s.conn.LocalAddr()
 }

--- a/interface.go
+++ b/interface.go
@@ -187,6 +187,9 @@ type Connection interface {
 	SendMessage([]byte) error
 	// ReceiveMessage gets a message received in a datagram, as specified in RFC 9221.
 	ReceiveMessage() ([]byte, error)
+
+	// SetIdleTimeout sets this connection's idle timeout.
+	SetIdleTimeout(time.Duration)
 }
 
 // An EarlyConnection is a connection that is handshaking.


### PR DESCRIPTION
Hi,

For the context, I'm testing QUIC non-HTTP use cases and I use NextProtos to select the application I want so I can mix multiple applicatons on one port (ie: `dns` and `h3`).

Applications may have different idle timeouts requirements (ie "heartbeat of 1s" vs "keep my HTTP/3 connection for 2 minutes just in case I want to send another request").

Since I use a single port, I have a single listener and thus a single `quic.Config`, so I can't set the idle timeout here. `Config.GetConfigForClient` is also the wrong place as I require the TLS negociation done before setting the timeout. I can also imagine protocols that would like to change the timeout dynamically.

Thus, I propose in this PR a interface change to allow this dynamic change.

Since there's already a `maybeResetTimer`, it's very simple to implement. One caveat could be some race condition; if it's a concern, I can convert `idleTimeout` to an `atomic.Uint64`.