### PR TITLE
change how the multiplex test is skipped on Linux

### DIFF
--- a/integrationtests/self/multiplex_test.go
+++ b/integrationtests/self/multiplex_test.go
@@ -156,58 +156,58 @@ var _ = Describe("Multiplexing", func() {
 			Eventually(done, timeout).Should(BeClosed())
 		})
 
-		It("runs a server and client on the same conn", func() {
-			if runtime.GOOS == "linux" {
-				Skip("This test would require setting of iptables rules, see https://stackoverflow.com/questions/23859164/linux-udp-socket-sendto-operation-not-permitted.")
-			}
-			addr1, err := net.ResolveUDPAddr("udp", "localhost:0")
-			Expect(err).ToNot(HaveOccurred())
-			conn1, err := net.ListenUDP("udp", addr1)
-			Expect(err).ToNot(HaveOccurred())
-			defer conn1.Close()
-			tr1 := &quic.Transport{Conn: conn1}
+		// This test would require setting of iptables rules, see https://stackoverflow.com/questions/23859164/linux-udp-socket-sendto-operation-not-permitted.
+		if runtime.GOOS != "linux" {
+			It("runs a server and client on the same conn", func() {
+				addr1, err := net.ResolveUDPAddr("udp", "localhost:0")
+				Expect(err).ToNot(HaveOccurred())
+				conn1, err := net.ListenUDP("udp", addr1)
+				Expect(err).ToNot(HaveOccurred())
+				defer conn1.Close()
+				tr1 := &quic.Transport{Conn: conn1}
 
-			addr2, err := net.ResolveUDPAddr("udp", "localhost:0")
-			Expect(err).ToNot(HaveOccurred())
-			conn2, err := net.ListenUDP("udp", addr2)
-			Expect(err).ToNot(HaveOccurred())
-			defer conn2.Close()
-			tr2 := &quic.Transport{Conn: conn2}
+				addr2, err := net.ResolveUDPAddr("udp", "localhost:0")
+				Expect(err).ToNot(HaveOccurred())
+				conn2, err := net.ListenUDP("udp", addr2)
+				Expect(err).ToNot(HaveOccurred())
+				defer conn2.Close()
+				tr2 := &quic.Transport{Conn: conn2}
 
-			server1, err := tr1.Listen(
-				getTLSConfig(),
-				getQuicConfig(nil),
-			)
-			Expect(err).ToNot(HaveOccurred())
-			runServer(server1)
-			defer server1.Close()
+				server1, err := tr1.Listen(
+					getTLSConfig(),
+					getQuicConfig(nil),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				runServer(server1)
+				defer server1.Close()
 
-			server2, err := tr2.Listen(
-				getTLSConfig(),
-				getQuicConfig(nil),
-			)
-			Expect(err).ToNot(HaveOccurred())
-			runServer(server2)
-			defer server2.Close()
+				server2, err := tr2.Listen(
+					getTLSConfig(),
+					getQuicConfig(nil),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				runServer(server2)
+				defer server2.Close()
 
-			done1 := make(chan struct{})
-			done2 := make(chan struct{})
-			go func() {
-				defer GinkgoRecover()
-				dial(tr2, server1.Addr())
-				close(done1)
-			}()
-			go func() {
-				defer GinkgoRecover()
-				dial(tr1, server2.Addr())
-				close(done2)
-			}()
-			timeout := 30 * time.Second
-			if debugLog() {
-				timeout = time.Minute
-			}
-			Eventually(done1, timeout).Should(BeClosed())
-			Eventually(done2, timeout).Should(BeClosed())
-		})
+				done1 := make(chan struct{})
+				done2 := make(chan struct{})
+				go func() {
+					defer GinkgoRecover()
+					dial(tr2, server1.Addr())
+					close(done1)
+				}()
+				go func() {
+					defer GinkgoRecover()
+					dial(tr1, server2.Addr())
+					close(done2)
+				}()
+				timeout := 30 * time.Second
+				if debugLog() {
+					timeout = time.Minute
+				}
+				Eventually(done1, timeout).Should(BeClosed())
+				Eventually(done2, timeout).Should(BeClosed())
+			})
+		}
 	})
 })


### PR DESCRIPTION
I have the impression that this somehow increases flakiness. Suspicion is that Ginkgo _sometimes_ executes the `BeforeEach`, but not the `AfterEach` on skipped tests. This shouldn't happen, but I'm not in the mood to debug Ginkgo tests. One more reason to move away from it.