### PR TITLE
pass around receivedPacket as struct instead of as pointer

### DIFF
--- a/closed_conn.go
+++ b/closed_conn.go
@@ -30,7 +30,7 @@ func newClosedLocalConn(sendPacket func(net.Addr, *packetInfo), pers protocol.Pe
 	}
 }
 
-func (c *closedLocalConn) handlePacket(p *receivedPacket) {
+func (c *closedLocalConn) handlePacket(p receivedPacket) {
 	c.counter++
 	// exponential backoff
 	// only send a CONNECTION_CLOSE for the 1st, 2nd, 4th, 8th, 16th, ... packet arriving
@@ -58,7 +58,7 @@ func newClosedRemoteConn(pers protocol.Perspective) packetHandler {
 	return &closedRemoteConn{perspective: pers}
 }
 
-func (s *closedRemoteConn) handlePacket(*receivedPacket)         {}
+func (s *closedRemoteConn) handlePacket(receivedPacket)          {}
 func (s *closedRemoteConn) shutdown()                            {}
 func (s *closedRemoteConn) destroy(error)                        {}
 func (s *closedRemoteConn) getPerspective() protocol.Perspective { return s.perspective }

--- a/closed_conn_test.go
+++ b/closed_conn_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Closed local connection", func() {
 		)
 		addr := &net.UDPAddr{IP: net.IPv4(127, 1, 2, 3), Port: 1337}
 		for i := 1; i <= 20; i++ {
-			conn.handlePacket(&receivedPacket{remoteAddr: addr})
+			conn.handlePacket(receivedPacket{remoteAddr: addr})
 			if i == 1 || i == 2 || i == 4 || i == 8 || i == 16 {
 				Expect(written).To(Receive(Equal(addr))) // receive the CONNECTION_CLOSE
 			} else {

--- a/connection.go
+++ b/connection.go
@@ -168,7 +168,7 @@ type connection struct {
 	oneRTTStream        cryptoStream // only set for the server
 	cryptoStreamHandler cryptoStreamHandler
 
-	receivedPackets  chan *receivedPacket
+	receivedPackets  chan receivedPacket
 	sendingScheduled chan struct{}
 
 	closeOnce sync.Once
@@ -180,8 +180,8 @@ type connection struct {
 	handshakeCtx       context.Context
 	handshakeCtxCancel context.CancelFunc
 
-	undecryptablePackets          []*receivedPacket // undecryptable packets, waiting for a change in encryption level
-	undecryptablePacketsToProcess []*receivedPacket
+	undecryptablePackets          []receivedPacket // undecryptable packets, waiting for a change in encryption level
+	undecryptablePacketsToProcess []receivedPacket
 
 	clientHelloWritten    <-chan *wire.TransportParameters
 	earlyConnReadyChan    chan struct{}
@@ -509,7 +509,7 @@ func (s *connection) preSetup() {
 		s.perspective,
 	)
 	s.framer = newFramer(s.streamsMap)
-	s.receivedPackets = make(chan *receivedPacket, protocol.MaxConnUnprocessedPackets)
+	s.receivedPackets = make(chan receivedPacket, protocol.MaxConnUnprocessedPackets)
 	s.closeChan = make(chan closeError, 1)
 	s.sendingScheduled = make(chan struct{}, 1)
 	s.handshakeCtx, s.handshakeCtxCancel = context.WithCancel(context.Background())
@@ -806,7 +806,7 @@ func (s *connection) handleHandshakeConfirmed() {
 	}
 }
 
-func (s *connection) handlePacketImpl(rp *receivedPacket) bool {
+func (s *connection) handlePacketImpl(rp receivedPacket) bool {
 	s.sentPacketHandler.ReceivedBytes(rp.Size())
 
 	if wire.IsVersionNegotiationPacket(rp.data) {
@@ -822,7 +822,7 @@ func (s *connection) handlePacketImpl(rp *receivedPacket) bool {
 	for len(data) > 0 {
 		var destConnID protocol.ConnectionID
 		if counter > 0 {
-			p = p.Clone()
+			p = *(p.Clone())
 			p.data = data
 
 			var err error
@@ -895,7 +895,7 @@ func (s *connection) handlePacketImpl(rp *receivedPacket) bool {
 	return processed
 }
 
-func (s *connection) handleShortHeaderPacket(p *receivedPacket, destConnID protocol.ConnectionID) bool {
+func (s *connection) handleShortHeaderPacket(p receivedPacket, destConnID protocol.ConnectionID) bool {
 	var wasQueued bool
 
 	defer func() {
@@ -946,7 +946,7 @@ func (s *connection) handleShortHeaderPacket(p *receivedPacket, destConnID proto
 	return true
 }
 
-func (s *connection) handleLongHeaderPacket(p *receivedPacket, hdr *wire.Header) bool /* was the packet successfully processed */ {
+func (s *connection) handleLongHeaderPacket(p receivedPacket, hdr *wire.Header) bool /* was the packet successfully processed */ {
 	var wasQueued bool
 
 	defer func() {
@@ -1003,7 +1003,7 @@ func (s *connection) handleLongHeaderPacket(p *receivedPacket, hdr *wire.Header)
 	return true
 }
 
-func (s *connection) handleUnpackError(err error, p *receivedPacket, pt logging.PacketType) (wasQueued bool) {
+func (s *connection) handleUnpackError(err error, p receivedPacket, pt logging.PacketType) (wasQueued bool) {
 	switch err {
 	case handshake.ErrKeysDropped:
 		if s.tracer != nil {
@@ -1105,7 +1105,7 @@ func (s *connection) handleRetryPacket(hdr *wire.Header, data []byte) bool /* wa
 	return true
 }
 
-func (s *connection) handleVersionNegotiationPacket(p *receivedPacket) {
+func (s *connection) handleVersionNegotiationPacket(p receivedPacket) {
 	if s.perspective == protocol.PerspectiveServer || // servers never receive version negotiation packets
 		s.receivedFirstPacket || s.versionNegotiated { // ignore delayed / duplicated version negotiation packets
 		if s.tracer != nil {
@@ -1340,7 +1340,7 @@ func (s *connection) handleFrame(f wire.Frame, encLevel protocol.EncryptionLevel
 }
 
 // handlePacket is called by the server with a new packet
-func (s *connection) handlePacket(p *receivedPacket) {
+func (s *connection) handlePacket(p receivedPacket) {
 	// Discard packets once the amount of queued packets is larger than
 	// the channel size, protocol.MaxConnUnprocessedPackets
 	select {
@@ -2229,7 +2229,7 @@ func (s *connection) scheduleSending() {
 
 // tryQueueingUndecryptablePacket queues a packet for which we're missing the decryption keys.
 // The logging.PacketType is only used for logging purposes.
-func (s *connection) tryQueueingUndecryptablePacket(p *receivedPacket, pt logging.PacketType) {
+func (s *connection) tryQueueingUndecryptablePacket(p receivedPacket, pt logging.PacketType) {
 	if s.handshakeComplete {
 		panic("shouldn't queue undecryptable packets after handshake completion")
 	}

--- a/mock_packet_handler_test.go
+++ b/mock_packet_handler_test.go
@@ -61,7 +61,7 @@ func (mr *MockPacketHandlerMockRecorder) getPerspective() *gomock.Call {
 }
 
 // handlePacket mocks base method.
-func (m *MockPacketHandler) handlePacket(arg0 *receivedPacket) {
+func (m *MockPacketHandler) handlePacket(arg0 receivedPacket) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "handlePacket", arg0)
 }

--- a/mock_quic_conn_test.go
+++ b/mock_quic_conn_test.go
@@ -309,7 +309,7 @@ func (mr *MockQUICConnMockRecorder) getPerspective() *gomock.Call {
 }
 
 // handlePacket mocks base method.
-func (m *MockQUICConn) handlePacket(arg0 *receivedPacket) {
+func (m *MockQUICConn) handlePacket(arg0 receivedPacket) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "handlePacket", arg0)
 }

--- a/mock_unknown_packet_handler_test.go
+++ b/mock_unknown_packet_handler_test.go
@@ -34,7 +34,7 @@ func (m *MockUnknownPacketHandler) EXPECT() *MockUnknownPacketHandlerMockRecorde
 }
 
 // handlePacket mocks base method.
-func (m *MockUnknownPacketHandler) handlePacket(arg0 *receivedPacket) {
+func (m *MockUnknownPacketHandler) handlePacket(arg0 receivedPacket) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "handlePacket", arg0)
 }

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -25,7 +25,7 @@ type connCapabilities struct {
 
 // rawConn is a connection that allow reading of a receivedPackeh.
 type rawConn interface {
-	ReadPacket() (*receivedPacket, error)
+	ReadPacket() (receivedPacket, error)
 	// The size parameter is used for GSO.
 	// If GSO is not support, len(b) must be equal to size.
 	WritePacket(b []byte, size uint16, addr net.Addr, oob []byte) (int, error)
@@ -43,7 +43,7 @@ type closePacket struct {
 }
 
 type unknownPacketHandler interface {
-	handlePacket(*receivedPacket)
+	handlePacket(receivedPacket)
 	setCloseError(error)
 }
 

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Packet Handler Map", func() {
 		Expect(ok).To(BeTrue())
 		Expect(h).ToNot(Equal(handler))
 		addr := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234}
-		h.handlePacket(&receivedPacket{remoteAddr: addr})
+		h.handlePacket(receivedPacket{remoteAddr: addr})
 		Expect(closePackets).To(HaveLen(1))
 		Expect(closePackets[0].addr).To(Equal(addr))
 		Expect(closePackets[0].payload).To(Equal([]byte("foobar")))
@@ -152,7 +152,7 @@ var _ = Describe("Packet Handler Map", func() {
 		Expect(ok).To(BeTrue())
 		Expect(h).ToNot(Equal(handler))
 		addr := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234}
-		h.handlePacket(&receivedPacket{remoteAddr: addr})
+		h.handlePacket(receivedPacket{remoteAddr: addr})
 		Expect(closePackets).To(BeEmpty())
 
 		time.Sleep(dur)

--- a/sys_conn.go
+++ b/sys_conn.go
@@ -79,16 +79,16 @@ type basicConn struct {
 
 var _ rawConn = &basicConn{}
 
-func (c *basicConn) ReadPacket() (*receivedPacket, error) {
+func (c *basicConn) ReadPacket() (receivedPacket, error) {
 	buffer := getPacketBuffer()
 	// The packet size should not exceed protocol.MaxPacketBufferSize bytes
 	// If it does, we only read a truncated packet, which will then end up undecryptable
 	buffer.Data = buffer.Data[:protocol.MaxPacketBufferSize]
 	n, addr, err := c.PacketConn.ReadFrom(buffer.Data)
 	if err != nil {
-		return nil, err
+		return receivedPacket{}, err
 	}
-	return &receivedPacket{
+	return receivedPacket{
 		remoteAddr: addr,
 		rcvTime:    time.Now(),
 		data:       buffer.Data[:n],

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var _ = Describe("OOB Conn Test", func() {
-	runServer := func(network, address string) (*net.UDPConn, <-chan *receivedPacket) {
+	runServer := func(network, address string) (*net.UDPConn, <-chan receivedPacket) {
 		addr, err := net.ResolveUDPAddr(network, address)
 		Expect(err).ToNot(HaveOccurred())
 		udpConn, err := net.ListenUDP(network, addr)
@@ -28,7 +28,7 @@ var _ = Describe("OOB Conn Test", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(oobConn.capabilities().DF).To(BeTrue())
 
-		packetChan := make(chan *receivedPacket)
+		packetChan := make(chan receivedPacket)
 		go func() {
 			defer GinkgoRecover()
 			for {
@@ -69,7 +69,7 @@ var _ = Describe("OOB Conn Test", func() {
 				},
 			)
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(p.rcvTime).To(BeTemporally("~", time.Now(), scaleDuration(20*time.Millisecond)))
 			Expect(p.data).To(Equal([]byte("foobar")))
@@ -89,7 +89,7 @@ var _ = Describe("OOB Conn Test", func() {
 				},
 			)
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(p.rcvTime).To(BeTemporally("~", time.Now(), scaleDuration(20*time.Millisecond)))
 			Expect(p.data).To(Equal([]byte("foobar")))
@@ -111,7 +111,7 @@ var _ = Describe("OOB Conn Test", func() {
 				},
 			)
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(utils.IsIPv4(p.remoteAddr.(*net.UDPAddr).IP)).To(BeTrue())
 			Expect(p.ecn).To(Equal(protocol.ECNCE))
@@ -149,7 +149,7 @@ var _ = Describe("OOB Conn Test", func() {
 			addr.IP = ip
 			sentFrom := sendPacket("udp4", addr)
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(p.rcvTime).To(BeTemporally("~", time.Now(), scaleDuration(20*time.Millisecond)))
 			Expect(p.data).To(Equal([]byte("foobar")))
@@ -167,7 +167,7 @@ var _ = Describe("OOB Conn Test", func() {
 			addr.IP = ip
 			sentFrom := sendPacket("udp6", addr)
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(p.rcvTime).To(BeTemporally("~", time.Now(), scaleDuration(20*time.Millisecond)))
 			Expect(p.data).To(Equal([]byte("foobar")))
@@ -185,7 +185,7 @@ var _ = Describe("OOB Conn Test", func() {
 			ip4 := net.ParseIP("127.0.0.1").To4()
 			sendPacket("udp4", &net.UDPAddr{IP: ip4, Port: port})
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(utils.IsIPv4(p.remoteAddr.(*net.UDPAddr).IP)).To(BeTrue())
 			Expect(p.info).To(Not(BeNil()))

--- a/transport.go
+++ b/transport.go
@@ -74,7 +74,7 @@ type Transport struct {
 	conn rawConn
 
 	closeQueue          chan closePacket
-	statelessResetQueue chan *receivedPacket
+	statelessResetQueue chan receivedPacket
 
 	listening   chan struct{} // is closed when listen returns
 	closed      bool
@@ -197,7 +197,7 @@ func (t *Transport) init(isServer bool) error {
 		t.listening = make(chan struct{})
 
 		t.closeQueue = make(chan closePacket, 4)
-		t.statelessResetQueue = make(chan *receivedPacket, 4)
+		t.statelessResetQueue = make(chan receivedPacket, 4)
 
 		if t.ConnectionIDGenerator != nil {
 			t.connIDGenerator = t.ConnectionIDGenerator
@@ -339,7 +339,7 @@ func (t *Transport) listen(conn rawConn) {
 	}
 }
 
-func (t *Transport) handlePacket(p *receivedPacket) {
+func (t *Transport) handlePacket(p receivedPacket) {
 	connID, err := wire.ParseConnectionID(p.data, t.connIDLen)
 	if err != nil {
 		t.logger.Debugf("error parsing connection ID on packet from %s: %s", p.remoteAddr, err)
@@ -371,7 +371,7 @@ func (t *Transport) handlePacket(p *receivedPacket) {
 	t.server.handlePacket(p)
 }
 
-func (t *Transport) maybeSendStatelessReset(p *receivedPacket) {
+func (t *Transport) maybeSendStatelessReset(p receivedPacket) {
 	if t.StatelessResetKey == nil {
 		p.buffer.Release()
 		return
@@ -392,7 +392,7 @@ func (t *Transport) maybeSendStatelessReset(p *receivedPacket) {
 	}
 }
 
-func (t *Transport) sendStatelessReset(p *receivedPacket) {
+func (t *Transport) sendStatelessReset(p receivedPacket) {
 	defer p.buffer.Release()
 
 	connID, err := wire.ParseConnectionID(p.data, t.connIDLen)

--- a/transport_test.go
+++ b/transport_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Transport", func() {
 		handled := make(chan struct{}, 2)
 		phm.EXPECT().Get(connID1).DoAndReturn(func(protocol.ConnectionID) (packetHandler, bool) {
 			h := NewMockPacketHandler(mockCtrl)
-			h.EXPECT().handlePacket(gomock.Any()).Do(func(p *receivedPacket) {
+			h.EXPECT().handlePacket(gomock.Any()).Do(func(p receivedPacket) {
 				defer GinkgoRecover()
 				connID, err := wire.ParseConnectionID(p.data, 0)
 				Expect(err).ToNot(HaveOccurred())
@@ -81,7 +81,7 @@ var _ = Describe("Transport", func() {
 		})
 		phm.EXPECT().Get(connID2).DoAndReturn(func(protocol.ConnectionID) (packetHandler, bool) {
 			h := NewMockPacketHandler(mockCtrl)
-			h.EXPECT().handlePacket(gomock.Any()).Do(func(p *receivedPacket) {
+			h.EXPECT().handlePacket(gomock.Any()).Do(func(p receivedPacket) {
 				defer GinkgoRecover()
 				connID, err := wire.ParseConnectionID(p.data, 0)
 				Expect(err).ToNot(HaveOccurred())
@@ -205,7 +205,7 @@ var _ = Describe("Transport", func() {
 		gomock.InOrder(
 			phm.EXPECT().GetByResetToken(token),
 			phm.EXPECT().Get(connID).Return(conn, true),
-			conn.EXPECT().handlePacket(gomock.Any()).Do(func(p *receivedPacket) {
+			conn.EXPECT().handlePacket(gomock.Any()).Do(func(p receivedPacket) {
 				Expect(p.data).To(Equal(b))
 				Expect(p.rcvTime).To(BeTemporally("~", time.Now(), time.Second))
 			}),


### PR DESCRIPTION
Depends on #3815.

Part of #3526.
This massively reduces the amount of allocations in the receive path.

---

Benchmark transferring 1 GB of data.

Before:
![before](https://github.com/quic-go/quic-go/assets/1478487/8106657a-f587-46d4-b038-1c11a96b1737)


After:
![after](https://github.com/quic-go/quic-go/assets/1478487/0c2a3ae0-e141-4988-80a3-f77f1c3d18dc)

As you can see, this is saving 84 MB of allocs per 1 GB of data transferred in `oobConn.ReadPacket`. There worst offender here is the standard library now, and we can't do anything about that until the standard library gives us a better UDP (#3563).