### PR TITLE
pass the current timestamp to the pacer instead of calling time.Now()

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1730,12 +1730,13 @@ func (s *connection) applyTransportParameters() {
 
 func (s *connection) triggerSending() error {
 	s.pacingDeadline = time.Time{}
+	now := time.Now()
 
-	sendMode := s.sentPacketHandler.SendMode()
+	sendMode := s.sentPacketHandler.SendMode(now)
 	//nolint:exhaustive // No need to handle pacing limited here.
 	switch sendMode {
 	case ackhandler.SendAny:
-		return s.sendPackets()
+		return s.sendPackets(now)
 	case ackhandler.SendNone:
 		return nil
 	case ackhandler.SendPacingLimited:
@@ -1752,9 +1753,9 @@ func (s *connection) triggerSending() error {
 		// We can at most send a single ACK only packet.
 		// There will only be a new ACK after receiving new packets.
 		// SendAck is only returned when we're congestion limited, so we don't need to set the pacinggs timer.
-		return s.maybeSendAckOnlyPacket()
+		return s.maybeSendAckOnlyPacket(now)
 	case ackhandler.SendPTOInitial:
-		if err := s.sendProbePacket(protocol.EncryptionInitial); err != nil {
+		if err := s.sendProbePacket(protocol.EncryptionInitial, now); err != nil {
 			return err
 		}
 		if s.sendQueue.WouldBlock() {
@@ -1763,7 +1764,7 @@ func (s *connection) triggerSending() error {
 		}
 		return s.triggerSending()
 	case ackhandler.SendPTOHandshake:
-		if err := s.sendProbePacket(protocol.EncryptionHandshake); err != nil {
+		if err := s.sendProbePacket(protocol.EncryptionHandshake, now); err != nil {
 			return err
 		}
 		if s.sendQueue.WouldBlock() {
@@ -1772,7 +1773,7 @@ func (s *connection) triggerSending() error {
 		}
 		return s.triggerSending()
 	case ackhandler.SendPTOAppData:
-		if err := s.sendProbePacket(protocol.Encryption1RTT); err != nil {
+		if err := s.sendProbePacket(protocol.Encryption1RTT, now); err != nil {
 			return err
 		}
 		if s.sendQueue.WouldBlock() {
@@ -1785,8 +1786,7 @@ func (s *connection) triggerSending() error {
 	}
 }
 
-func (s *connection) sendPackets() error {
-	now := time.Now()
+func (s *connection) sendPackets(now time.Time) error {
 	// Path MTU Discovery
 	// Can't use GSO, since we need to send a single packet that's larger than our current maximum size.
 	// Performance-wise, this doesn't matter, since we only send a very small (<10) number of
@@ -1817,7 +1817,7 @@ func (s *connection) sendPackets() error {
 		}
 		s.sentFirstPacket = true
 		s.sendPackedCoalescedPacket(packet, now)
-		sendMode := s.sentPacketHandler.SendMode()
+		sendMode := s.sentPacketHandler.SendMode(now)
 		if sendMode == ackhandler.SendPacingLimited {
 			s.resetPacingDeadline()
 		} else if sendMode == ackhandler.SendAny {
@@ -1848,7 +1848,7 @@ func (s *connection) sendPacketsWithoutGSO(now time.Time) error {
 		if s.sendQueue.WouldBlock() {
 			return nil
 		}
-		sendMode := s.sentPacketHandler.SendMode()
+		sendMode := s.sentPacketHandler.SendMode(now)
 		if sendMode == ackhandler.SendPacingLimited {
 			s.resetPacingDeadline()
 			return nil
@@ -1883,7 +1883,7 @@ func (s *connection) sendPacketsWithGSO(now time.Time) error {
 		}
 
 		if !dontSendMore {
-			sendMode := s.sentPacketHandler.SendMode()
+			sendMode := s.sentPacketHandler.SendMode(now)
 			if sendMode == ackhandler.SendPacingLimited {
 				s.resetPacingDeadline()
 			}
@@ -1927,8 +1927,7 @@ func (s *connection) resetPacingDeadline() {
 	s.pacingDeadline = deadline
 }
 
-func (s *connection) maybeSendAckOnlyPacket() error {
-	now := time.Now()
+func (s *connection) maybeSendAckOnlyPacket(now time.Time) error {
 	if !s.handshakeConfirmed {
 		packet, err := s.packer.PackCoalescedPacket(true, s.mtuDiscoverer.CurrentSize(), now, s.version)
 		if err != nil {
@@ -1954,8 +1953,7 @@ func (s *connection) maybeSendAckOnlyPacket() error {
 	return nil
 }
 
-func (s *connection) sendProbePacket(encLevel protocol.EncryptionLevel) error {
-	now := time.Now()
+func (s *connection) sendProbePacket(encLevel protocol.EncryptionLevel, now time.Time) error {
 	// Queue probe packets until we actually send out a packet,
 	// or until there are no more packets to queue.
 	var packet *coalescedPacket

--- a/connection_test.go
+++ b/connection_test.go
@@ -610,7 +610,7 @@ var _ = Describe("Connection", func() {
 			conn.sendQueue = newSendQueue(sconn)
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().Return(time.Now().Add(time.Hour)).AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			// only expect a single SentPacket() call
 			sph.EXPECT().SentPacket(gomock.Any())
 			tracer.EXPECT().SentShortHeaderPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -1210,7 +1210,7 @@ var _ = Describe("Connection", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			sph.EXPECT().SentPacket(gomock.Any())
 			conn.sentPacketHandler = sph
 			runConn()
@@ -1248,7 +1248,7 @@ var _ = Describe("Connection", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAck)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAck)
 			done := make(chan struct{})
 			packer.EXPECT().PackCoalescedPacket(true, gomock.Any(), gomock.Any(), conn.version).Do(func(bool, protocol.ByteCount, time.Time, protocol.VersionNumber) { close(done) })
 			conn.sentPacketHandler = sph
@@ -1262,7 +1262,7 @@ var _ = Describe("Connection", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			sph.EXPECT().SentPacket(gomock.Any())
 			conn.sentPacketHandler = sph
 			fc := mocks.NewMockConnectionFlowController(mockCtrl)
@@ -1283,7 +1283,7 @@ var _ = Describe("Connection", func() {
 		It("doesn't send when the SentPacketHandler doesn't allow it", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendNone).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone).AnyTimes()
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			conn.sentPacketHandler = sph
 			runConn()
@@ -1317,8 +1317,8 @@ var _ = Describe("Connection", func() {
 					sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 					sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 					sph.EXPECT().TimeUntilSend().AnyTimes()
-					sph.EXPECT().SendMode().Return(sendMode)
-					sph.EXPECT().SendMode().Return(ackhandler.SendNone)
+					sph.EXPECT().SendMode(gomock.Any()).Return(sendMode)
+					sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone)
 					sph.EXPECT().QueueProbePacket(encLevel)
 					p := getCoalescedPacket(123, enc != protocol.Encryption1RTT)
 					packer.EXPECT().MaybePackProbePacket(encLevel, gomock.Any(), gomock.Any(), conn.version).Return(p, nil)
@@ -1342,8 +1342,8 @@ var _ = Describe("Connection", func() {
 					sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 					sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 					sph.EXPECT().TimeUntilSend().AnyTimes()
-					sph.EXPECT().SendMode().Return(sendMode)
-					sph.EXPECT().SendMode().Return(ackhandler.SendNone)
+					sph.EXPECT().SendMode(gomock.Any()).Return(sendMode)
+					sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone)
 					sph.EXPECT().QueueProbePacket(encLevel).Return(false)
 					p := getCoalescedPacket(123, enc != protocol.Encryption1RTT)
 					packer.EXPECT().MaybePackProbePacket(encLevel, gomock.Any(), gomock.Any(), conn.version).Return(p, nil)
@@ -1403,8 +1403,8 @@ var _ = Describe("Connection", func() {
 
 		It("sends multiple packets one by one immediately", func() {
 			sph.EXPECT().SentPacket(gomock.Any()).Times(2)
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(2)
-			sph.EXPECT().SendMode().Return(ackhandler.SendPacingLimited)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(2)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendPacingLimited)
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 10}}, []byte("packet10"))
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 11}}, []byte("packet11"))
@@ -1427,7 +1427,7 @@ var _ = Describe("Connection", func() {
 		It("sends multiple packets one by one immediately, with GSO", func() {
 			enableGSO()
 			sph.EXPECT().SentPacket(gomock.Any()).Times(2)
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(3)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(3)
 			payload1 := make([]byte, conn.mtuDiscoverer.CurrentSize())
 			rand.Read(payload1)
 			payload2 := make([]byte, conn.mtuDiscoverer.CurrentSize())
@@ -1451,8 +1451,8 @@ var _ = Describe("Connection", func() {
 		It("stops appending packets when a smaller packet is packed, with GSO", func() {
 			enableGSO()
 			sph.EXPECT().SentPacket(gomock.Any()).Times(2)
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(2)
-			sph.EXPECT().SendMode().Return(ackhandler.SendNone)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(2)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone)
 			payload1 := make([]byte, conn.mtuDiscoverer.CurrentSize())
 			rand.Read(payload1)
 			payload2 := make([]byte, conn.mtuDiscoverer.CurrentSize()-1)
@@ -1474,7 +1474,7 @@ var _ = Describe("Connection", func() {
 
 		It("sends multiple packets, when the pacer allows immediate sending", func() {
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(2)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(2)
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 10}}, []byte("packet10"))
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
 			sender.EXPECT().WouldBlock().AnyTimes()
@@ -1491,7 +1491,7 @@ var _ = Describe("Connection", func() {
 		It("allows an ACK to be sent when pacing limited", func() {
 			sph.EXPECT().SentPacket(gomock.Any())
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
-			sph.EXPECT().SendMode().Return(ackhandler.SendPacingLimited)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendPacingLimited)
 			packer.EXPECT().PackAckOnlyPacket(gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 123}}, getPacketBuffer(), nil)
 
 			sender.EXPECT().WouldBlock().AnyTimes()
@@ -1509,8 +1509,8 @@ var _ = Describe("Connection", func() {
 		// we shouldn't send the ACK in the same run
 		It("doesn't send an ACK right after becoming congestion limited", func() {
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny)
-			sph.EXPECT().SendMode().Return(ackhandler.SendAck)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAck)
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 100}}, []byte("packet100"))
 			sender.EXPECT().WouldBlock().AnyTimes()
 			sender.EXPECT().Send(gomock.Any(), gomock.Any())
@@ -1526,15 +1526,15 @@ var _ = Describe("Connection", func() {
 		It("paces packets", func() {
 			pacingDelay := scaleDuration(100 * time.Millisecond)
 			gomock.InOrder(
-				sph.EXPECT().SendMode().Return(ackhandler.SendAny),
+				sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny),
 				expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 100}}, []byte("packet100")),
 				sph.EXPECT().SentPacket(gomock.Any()),
-				sph.EXPECT().SendMode().Return(ackhandler.SendPacingLimited),
+				sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendPacingLimited),
 				sph.EXPECT().TimeUntilSend().Return(time.Now().Add(pacingDelay)),
-				sph.EXPECT().SendMode().Return(ackhandler.SendAny),
+				sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny),
 				expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 101}}, []byte("packet101")),
 				sph.EXPECT().SentPacket(gomock.Any()),
-				sph.EXPECT().SendMode().Return(ackhandler.SendPacingLimited),
+				sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendPacingLimited),
 				sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour)),
 			)
 			written := make(chan struct{}, 2)
@@ -1553,8 +1553,8 @@ var _ = Describe("Connection", func() {
 
 		It("sends multiple packets at once", func() {
 			sph.EXPECT().SentPacket(gomock.Any()).Times(3)
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(3)
-			sph.EXPECT().SendMode().Return(ackhandler.SendPacingLimited)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(3)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendPacingLimited)
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
 			for pn := protocol.PacketNumber(1000); pn < 1003; pn++ {
 				expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: pn}}, []byte("packet"))
@@ -1591,7 +1591,7 @@ var _ = Describe("Connection", func() {
 				written := make(chan struct{})
 				sender.EXPECT().WouldBlock().AnyTimes()
 				sph.EXPECT().SentPacket(gomock.Any())
-				sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+				sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 				expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 1000}}, []byte("packet1000"))
 				packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
 				sender.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(*packetBuffer, protocol.ByteCount) { close(written) })
@@ -1614,7 +1614,7 @@ var _ = Describe("Connection", func() {
 				sph.EXPECT().ReceivedBytes(gomock.Any())
 				conn.handlePacket(receivedPacket{buffer: getPacketBuffer()})
 			})
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 10}}, []byte("packet10"))
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
 			sender.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(*packetBuffer, protocol.ByteCount) { close(written) })
@@ -1627,7 +1627,7 @@ var _ = Describe("Connection", func() {
 
 		It("stops sending when the send queue is full", func() {
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny)
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 1000}}, []byte("packet1000"))
 			written := make(chan struct{}, 1)
 			sender.EXPECT().WouldBlock()
@@ -1646,7 +1646,7 @@ var _ = Describe("Connection", func() {
 
 			// now make room in the send queue
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			sender.EXPECT().WouldBlock().AnyTimes()
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 1001}}, []byte("packet1001"))
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
@@ -1660,7 +1660,7 @@ var _ = Describe("Connection", func() {
 		})
 
 		It("doesn't set a pacing timer when there is no data to send", func() {
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			sender.EXPECT().WouldBlock().AnyTimes()
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
 			// don't EXPECT any calls to mconn.Write()
@@ -1678,8 +1678,8 @@ var _ = Describe("Connection", func() {
 			conn.mtuDiscoverer = mtuDiscoverer
 			conn.config.DisablePathMTUDiscovery = false
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny)
-			sph.EXPECT().SendMode().Return(ackhandler.SendNone)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone)
 			written := make(chan struct{}, 1)
 			sender.EXPECT().WouldBlock().AnyTimes()
 			sender.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(*packetBuffer, protocol.ByteCount) { written <- struct{}{} })
@@ -1727,7 +1727,7 @@ var _ = Describe("Connection", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 			sph.EXPECT().TimeUntilSend().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 
 			sph.EXPECT().SentPacket(gomock.Any())
 			conn.sentPacketHandler = sph
@@ -1754,7 +1754,7 @@ var _ = Describe("Connection", func() {
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			sph.EXPECT().SentPacket(gomock.Any()).Do(func(p *ackhandler.Packet) {
 				Expect(p.PacketNumber).To(Equal(protocol.PacketNumber(1234)))
 			})
@@ -1806,7 +1806,7 @@ var _ = Describe("Connection", func() {
 		packer.EXPECT().PackCoalescedPacket(false, gomock.Any(), gomock.Any(), conn.version).AnyTimes()
 
 		sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-		sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+		sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 		sph.EXPECT().TimeUntilSend().Return(time.Now()).AnyTimes()
 		gomock.InOrder(
 			sph.EXPECT().SentPacket(gomock.Any()).Do(func(p *ackhandler.Packet) {
@@ -1860,7 +1860,7 @@ var _ = Describe("Connection", func() {
 		conn.sentPacketHandler = sph
 		sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 		sph.EXPECT().TimeUntilSend().AnyTimes()
-		sph.EXPECT().SendMode().AnyTimes()
+		sph.EXPECT().SendMode(gomock.Any()).AnyTimes()
 		sph.EXPECT().SetHandshakeConfirmed()
 		connRunner.EXPECT().Retire(clientDestConnID)
 		go func() {
@@ -1956,7 +1956,7 @@ var _ = Describe("Connection", func() {
 
 	It("sends a HANDSHAKE_DONE frame when the handshake completes", func() {
 		sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
-		sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+		sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 		sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 		sph.EXPECT().TimeUntilSend().AnyTimes()
 		sph.EXPECT().SetHandshakeConfirmed()

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -20,7 +20,7 @@ type SentPacketHandler interface {
 	SetHandshakeConfirmed()
 
 	// The SendMode determines if and what kind of packets can be sent.
-	SendMode() SendMode
+	SendMode(now time.Time) SendMode
 	// TimeUntilSend is the time when the next packet should be sent.
 	// It is used for pacing packets.
 	TimeUntilSend() time.Time

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -717,7 +717,7 @@ func (h *sentPacketHandler) PopPacketNumber(encLevel protocol.EncryptionLevel) p
 	return h.getPacketNumberSpace(encLevel).pns.Pop()
 }
 
-func (h *sentPacketHandler) SendMode() SendMode {
+func (h *sentPacketHandler) SendMode(now time.Time) SendMode {
 	numTrackedPackets := h.appDataPackets.history.Len()
 	if h.initialPackets != nil {
 		numTrackedPackets += h.initialPackets.history.Len()
@@ -756,7 +756,7 @@ func (h *sentPacketHandler) SendMode() SendMode {
 		}
 		return SendAck
 	}
-	if !h.congestion.HasPacingBudget() {
+	if !h.congestion.HasPacingBudget(now) {
 		return SendPacingLimited
 	}
 	return SendAny
@@ -764,10 +764,6 @@ func (h *sentPacketHandler) SendMode() SendMode {
 
 func (h *sentPacketHandler) TimeUntilSend() time.Time {
 	return h.congestion.TimeUntilSend(h.bytesInFlight)
-}
-
-func (h *sentPacketHandler) HasPacingBudget() bool {
-	return h.congestion.HasPacingBudget()
 }
 
 func (h *sentPacketHandler) SetMaxDatagramSize(s protocol.ByteCount) {

--- a/internal/congestion/cubic_sender.go
+++ b/internal/congestion/cubic_sender.go
@@ -120,8 +120,8 @@ func (c *cubicSender) TimeUntilSend(_ protocol.ByteCount) time.Time {
 	return c.pacer.TimeUntilSend()
 }
 
-func (c *cubicSender) HasPacingBudget() bool {
-	return c.pacer.Budget(c.clock.Now()) >= c.maxDatagramSize
+func (c *cubicSender) HasPacingBudget(now time.Time) bool {
+	return c.pacer.Budget(now) >= c.maxDatagramSize
 }
 
 func (c *cubicSender) maxCongestionWindow() protocol.ByteCount {

--- a/internal/congestion/interface.go
+++ b/internal/congestion/interface.go
@@ -9,7 +9,7 @@ import (
 // A SendAlgorithm performs congestion control
 type SendAlgorithm interface {
 	TimeUntilSend(bytesInFlight protocol.ByteCount) time.Time
-	HasPacingBudget() bool
+	HasPacingBudget(now time.Time) bool
 	OnPacketSent(sentTime time.Time, bytesInFlight protocol.ByteCount, packetNumber protocol.PacketNumber, bytes protocol.ByteCount, isRetransmittable bool)
 	CanSend(bytesInFlight protocol.ByteCount) bool
 	MaybeExitSlowStart()

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -162,17 +162,17 @@ func (mr *MockSentPacketHandlerMockRecorder) ResetForRetry() *gomock.Call {
 }
 
 // SendMode mocks base method.
-func (m *MockSentPacketHandler) SendMode() ackhandler.SendMode {
+func (m *MockSentPacketHandler) SendMode(arg0 time.Time) ackhandler.SendMode {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendMode")
+	ret := m.ctrl.Call(m, "SendMode", arg0)
 	ret0, _ := ret[0].(ackhandler.SendMode)
 	return ret0
 }
 
 // SendMode indicates an expected call of SendMode.
-func (mr *MockSentPacketHandlerMockRecorder) SendMode() *gomock.Call {
+func (mr *MockSentPacketHandlerMockRecorder) SendMode(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMode", reflect.TypeOf((*MockSentPacketHandler)(nil).SendMode))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMode", reflect.TypeOf((*MockSentPacketHandler)(nil).SendMode), arg0)
 }
 
 // SentPacket mocks base method.

--- a/internal/mocks/congestion.go
+++ b/internal/mocks/congestion.go
@@ -64,17 +64,17 @@ func (mr *MockSendAlgorithmWithDebugInfosMockRecorder) GetCongestionWindow() *go
 }
 
 // HasPacingBudget mocks base method.
-func (m *MockSendAlgorithmWithDebugInfos) HasPacingBudget() bool {
+func (m *MockSendAlgorithmWithDebugInfos) HasPacingBudget(arg0 time.Time) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPacingBudget")
+	ret := m.ctrl.Call(m, "HasPacingBudget", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // HasPacingBudget indicates an expected call of HasPacingBudget.
-func (mr *MockSendAlgorithmWithDebugInfosMockRecorder) HasPacingBudget() *gomock.Call {
+func (mr *MockSendAlgorithmWithDebugInfosMockRecorder) HasPacingBudget(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPacingBudget", reflect.TypeOf((*MockSendAlgorithmWithDebugInfos)(nil).HasPacingBudget))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPacingBudget", reflect.TypeOf((*MockSendAlgorithmWithDebugInfos)(nil).HasPacingBudget), arg0)
 }
 
 // InRecovery mocks base method.


### PR DESCRIPTION
The pacer was responsible for ~75% of the calls to `time.Now()`. It makes sense to use the same timestamp that's also used for packing the packet.