### PR TITLE
embed packetInfo in receivedPacket struct, use netip.Addr

### DIFF
--- a/closed_conn.go
+++ b/closed_conn.go
@@ -30,7 +30,7 @@ func newClosedLocalConn(sendPacket func(net.Addr, *packetInfo), pers protocol.Pe
 	}
 }
 
-func (c *closedLocalConn) handlePacket(p *receivedPacket) {
+func (c *closedLocalConn) handlePacket(p receivedPacket) {
 	c.counter++
 	// exponential backoff
 	// only send a CONNECTION_CLOSE for the 1st, 2nd, 4th, 8th, 16th, ... packet arriving
@@ -58,7 +58,7 @@ func newClosedRemoteConn(pers protocol.Perspective) packetHandler {
 	return &closedRemoteConn{perspective: pers}
 }
 
-func (s *closedRemoteConn) handlePacket(*receivedPacket)         {}
+func (s *closedRemoteConn) handlePacket(receivedPacket)          {}
 func (s *closedRemoteConn) shutdown()                            {}
 func (s *closedRemoteConn) destroy(error)                        {}
 func (s *closedRemoteConn) getPerspective() protocol.Perspective { return s.perspective }

--- a/closed_conn.go
+++ b/closed_conn.go
@@ -16,13 +16,13 @@ type closedLocalConn struct {
 	perspective protocol.Perspective
 	logger      utils.Logger
 
-	sendPacket func(net.Addr, *packetInfo)
+	sendPacket func(net.Addr, packetInfo)
 }
 
 var _ packetHandler = &closedLocalConn{}
 
 // newClosedLocalConn creates a new closedLocalConn and runs it.
-func newClosedLocalConn(sendPacket func(net.Addr, *packetInfo), pers protocol.Perspective, logger utils.Logger) packetHandler {
+func newClosedLocalConn(sendPacket func(net.Addr, packetInfo), pers protocol.Perspective, logger utils.Logger) packetHandler {
 	return &closedLocalConn{
 		sendPacket:  sendPacket,
 		perspective: pers,

--- a/closed_conn_test.go
+++ b/closed_conn_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Closed local connection", func() {
 	It("repeats the packet containing the CONNECTION_CLOSE frame", func() {
 		written := make(chan net.Addr, 1)
 		conn := newClosedLocalConn(
-			func(addr net.Addr, _ *packetInfo) { written <- addr },
+			func(addr net.Addr, _ packetInfo) { written <- addr },
 			protocol.PerspectiveClient,
 			utils.DefaultLogger,
 		)

--- a/closed_conn_test.go
+++ b/closed_conn_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Closed local connection", func() {
 		)
 		addr := &net.UDPAddr{IP: net.IPv4(127, 1, 2, 3), Port: 1337}
 		for i := 1; i <= 20; i++ {
-			conn.handlePacket(&receivedPacket{remoteAddr: addr})
+			conn.handlePacket(receivedPacket{remoteAddr: addr})
 			if i == 1 || i == 2 || i == 4 || i == 8 || i == 16 {
 				Expect(written).To(Receive(Equal(addr))) // receive the CONNECTION_CLOSE
 			} else {

--- a/connection.go
+++ b/connection.go
@@ -70,7 +70,7 @@ type receivedPacket struct {
 
 	ecn protocol.ECN
 
-	info *packetInfo
+	info packetInfo // only valid if the contained IP address is valid
 }
 
 func (p *receivedPacket) Size() protocol.ByteCount { return protocol.ByteCount(len(p.data)) }

--- a/connection.go
+++ b/connection.go
@@ -1730,12 +1730,13 @@ func (s *connection) applyTransportParameters() {
 
 func (s *connection) triggerSending() error {
 	s.pacingDeadline = time.Time{}
+	now := time.Now()
 
-	sendMode := s.sentPacketHandler.SendMode()
+	sendMode := s.sentPacketHandler.SendMode(now)
 	//nolint:exhaustive // No need to handle pacing limited here.
 	switch sendMode {
 	case ackhandler.SendAny:
-		return s.sendPackets()
+		return s.sendPackets(now)
 	case ackhandler.SendNone:
 		return nil
 	case ackhandler.SendPacingLimited:
@@ -1752,9 +1753,9 @@ func (s *connection) triggerSending() error {
 		// We can at most send a single ACK only packet.
 		// There will only be a new ACK after receiving new packets.
 		// SendAck is only returned when we're congestion limited, so we don't need to set the pacinggs timer.
-		return s.maybeSendAckOnlyPacket()
+		return s.maybeSendAckOnlyPacket(now)
 	case ackhandler.SendPTOInitial:
-		if err := s.sendProbePacket(protocol.EncryptionInitial); err != nil {
+		if err := s.sendProbePacket(protocol.EncryptionInitial, now); err != nil {
 			return err
 		}
 		if s.sendQueue.WouldBlock() {
@@ -1763,7 +1764,7 @@ func (s *connection) triggerSending() error {
 		}
 		return s.triggerSending()
 	case ackhandler.SendPTOHandshake:
-		if err := s.sendProbePacket(protocol.EncryptionHandshake); err != nil {
+		if err := s.sendProbePacket(protocol.EncryptionHandshake, now); err != nil {
 			return err
 		}
 		if s.sendQueue.WouldBlock() {
@@ -1772,7 +1773,7 @@ func (s *connection) triggerSending() error {
 		}
 		return s.triggerSending()
 	case ackhandler.SendPTOAppData:
-		if err := s.sendProbePacket(protocol.Encryption1RTT); err != nil {
+		if err := s.sendProbePacket(protocol.Encryption1RTT, now); err != nil {
 			return err
 		}
 		if s.sendQueue.WouldBlock() {
@@ -1785,8 +1786,7 @@ func (s *connection) triggerSending() error {
 	}
 }
 
-func (s *connection) sendPackets() error {
-	now := time.Now()
+func (s *connection) sendPackets(now time.Time) error {
 	// Path MTU Discovery
 	// Can't use GSO, since we need to send a single packet that's larger than our current maximum size.
 	// Performance-wise, this doesn't matter, since we only send a very small (<10) number of
@@ -1817,7 +1817,7 @@ func (s *connection) sendPackets() error {
 		}
 		s.sentFirstPacket = true
 		s.sendPackedCoalescedPacket(packet, now)
-		sendMode := s.sentPacketHandler.SendMode()
+		sendMode := s.sentPacketHandler.SendMode(now)
 		if sendMode == ackhandler.SendPacingLimited {
 			s.resetPacingDeadline()
 		} else if sendMode == ackhandler.SendAny {
@@ -1848,7 +1848,7 @@ func (s *connection) sendPacketsWithoutGSO(now time.Time) error {
 		if s.sendQueue.WouldBlock() {
 			return nil
 		}
-		sendMode := s.sentPacketHandler.SendMode()
+		sendMode := s.sentPacketHandler.SendMode(now)
 		if sendMode == ackhandler.SendPacingLimited {
 			s.resetPacingDeadline()
 			return nil
@@ -1883,7 +1883,7 @@ func (s *connection) sendPacketsWithGSO(now time.Time) error {
 		}
 
 		if !dontSendMore {
-			sendMode := s.sentPacketHandler.SendMode()
+			sendMode := s.sentPacketHandler.SendMode(now)
 			if sendMode == ackhandler.SendPacingLimited {
 				s.resetPacingDeadline()
 			}
@@ -1927,8 +1927,7 @@ func (s *connection) resetPacingDeadline() {
 	s.pacingDeadline = deadline
 }
 
-func (s *connection) maybeSendAckOnlyPacket() error {
-	now := time.Now()
+func (s *connection) maybeSendAckOnlyPacket(now time.Time) error {
 	if !s.handshakeConfirmed {
 		packet, err := s.packer.PackCoalescedPacket(true, s.mtuDiscoverer.CurrentSize(), now, s.version)
 		if err != nil {
@@ -1954,8 +1953,7 @@ func (s *connection) maybeSendAckOnlyPacket() error {
 	return nil
 }
 
-func (s *connection) sendProbePacket(encLevel protocol.EncryptionLevel) error {
-	now := time.Now()
+func (s *connection) sendProbePacket(encLevel protocol.EncryptionLevel, now time.Time) error {
 	// Queue probe packets until we actually send out a packet,
 	// or until there are no more packets to queue.
 	var packet *coalescedPacket

--- a/connection_test.go
+++ b/connection_test.go
@@ -610,7 +610,7 @@ var _ = Describe("Connection", func() {
 			conn.sendQueue = newSendQueue(sconn)
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().Return(time.Now().Add(time.Hour)).AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			// only expect a single SentPacket() call
 			sph.EXPECT().SentPacket(gomock.Any())
 			tracer.EXPECT().SentShortHeaderPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
@@ -1210,7 +1210,7 @@ var _ = Describe("Connection", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			sph.EXPECT().SentPacket(gomock.Any())
 			conn.sentPacketHandler = sph
 			runConn()
@@ -1248,7 +1248,7 @@ var _ = Describe("Connection", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAck)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAck)
 			done := make(chan struct{})
 			packer.EXPECT().PackCoalescedPacket(true, gomock.Any(), gomock.Any(), conn.version).Do(func(bool, protocol.ByteCount, time.Time, protocol.VersionNumber) { close(done) })
 			conn.sentPacketHandler = sph
@@ -1262,7 +1262,7 @@ var _ = Describe("Connection", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			sph.EXPECT().SentPacket(gomock.Any())
 			conn.sentPacketHandler = sph
 			fc := mocks.NewMockConnectionFlowController(mockCtrl)
@@ -1283,7 +1283,7 @@ var _ = Describe("Connection", func() {
 		It("doesn't send when the SentPacketHandler doesn't allow it", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendNone).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone).AnyTimes()
 			sph.EXPECT().TimeUntilSend().AnyTimes()
 			conn.sentPacketHandler = sph
 			runConn()
@@ -1317,8 +1317,8 @@ var _ = Describe("Connection", func() {
 					sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 					sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 					sph.EXPECT().TimeUntilSend().AnyTimes()
-					sph.EXPECT().SendMode().Return(sendMode)
-					sph.EXPECT().SendMode().Return(ackhandler.SendNone)
+					sph.EXPECT().SendMode(gomock.Any()).Return(sendMode)
+					sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone)
 					sph.EXPECT().QueueProbePacket(encLevel)
 					p := getCoalescedPacket(123, enc != protocol.Encryption1RTT)
 					packer.EXPECT().MaybePackProbePacket(encLevel, gomock.Any(), gomock.Any(), conn.version).Return(p, nil)
@@ -1342,8 +1342,8 @@ var _ = Describe("Connection", func() {
 					sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 					sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 					sph.EXPECT().TimeUntilSend().AnyTimes()
-					sph.EXPECT().SendMode().Return(sendMode)
-					sph.EXPECT().SendMode().Return(ackhandler.SendNone)
+					sph.EXPECT().SendMode(gomock.Any()).Return(sendMode)
+					sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone)
 					sph.EXPECT().QueueProbePacket(encLevel).Return(false)
 					p := getCoalescedPacket(123, enc != protocol.Encryption1RTT)
 					packer.EXPECT().MaybePackProbePacket(encLevel, gomock.Any(), gomock.Any(), conn.version).Return(p, nil)
@@ -1403,8 +1403,8 @@ var _ = Describe("Connection", func() {
 
 		It("sends multiple packets one by one immediately", func() {
 			sph.EXPECT().SentPacket(gomock.Any()).Times(2)
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(2)
-			sph.EXPECT().SendMode().Return(ackhandler.SendPacingLimited)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(2)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendPacingLimited)
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 10}}, []byte("packet10"))
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 11}}, []byte("packet11"))
@@ -1427,7 +1427,7 @@ var _ = Describe("Connection", func() {
 		It("sends multiple packets one by one immediately, with GSO", func() {
 			enableGSO()
 			sph.EXPECT().SentPacket(gomock.Any()).Times(2)
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(3)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(3)
 			payload1 := make([]byte, conn.mtuDiscoverer.CurrentSize())
 			rand.Read(payload1)
 			payload2 := make([]byte, conn.mtuDiscoverer.CurrentSize())
@@ -1451,8 +1451,8 @@ var _ = Describe("Connection", func() {
 		It("stops appending packets when a smaller packet is packed, with GSO", func() {
 			enableGSO()
 			sph.EXPECT().SentPacket(gomock.Any()).Times(2)
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(2)
-			sph.EXPECT().SendMode().Return(ackhandler.SendNone)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(2)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone)
 			payload1 := make([]byte, conn.mtuDiscoverer.CurrentSize())
 			rand.Read(payload1)
 			payload2 := make([]byte, conn.mtuDiscoverer.CurrentSize()-1)
@@ -1474,7 +1474,7 @@ var _ = Describe("Connection", func() {
 
 		It("sends multiple packets, when the pacer allows immediate sending", func() {
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(2)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(2)
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 10}}, []byte("packet10"))
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
 			sender.EXPECT().WouldBlock().AnyTimes()
@@ -1491,7 +1491,7 @@ var _ = Describe("Connection", func() {
 		It("allows an ACK to be sent when pacing limited", func() {
 			sph.EXPECT().SentPacket(gomock.Any())
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
-			sph.EXPECT().SendMode().Return(ackhandler.SendPacingLimited)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendPacingLimited)
 			packer.EXPECT().PackAckOnlyPacket(gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 123}}, getPacketBuffer(), nil)
 
 			sender.EXPECT().WouldBlock().AnyTimes()
@@ -1509,8 +1509,8 @@ var _ = Describe("Connection", func() {
 		// we shouldn't send the ACK in the same run
 		It("doesn't send an ACK right after becoming congestion limited", func() {
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny)
-			sph.EXPECT().SendMode().Return(ackhandler.SendAck)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAck)
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 100}}, []byte("packet100"))
 			sender.EXPECT().WouldBlock().AnyTimes()
 			sender.EXPECT().Send(gomock.Any(), gomock.Any())
@@ -1526,15 +1526,15 @@ var _ = Describe("Connection", func() {
 		It("paces packets", func() {
 			pacingDelay := scaleDuration(100 * time.Millisecond)
 			gomock.InOrder(
-				sph.EXPECT().SendMode().Return(ackhandler.SendAny),
+				sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny),
 				expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 100}}, []byte("packet100")),
 				sph.EXPECT().SentPacket(gomock.Any()),
-				sph.EXPECT().SendMode().Return(ackhandler.SendPacingLimited),
+				sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendPacingLimited),
 				sph.EXPECT().TimeUntilSend().Return(time.Now().Add(pacingDelay)),
-				sph.EXPECT().SendMode().Return(ackhandler.SendAny),
+				sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny),
 				expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 101}}, []byte("packet101")),
 				sph.EXPECT().SentPacket(gomock.Any()),
-				sph.EXPECT().SendMode().Return(ackhandler.SendPacingLimited),
+				sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendPacingLimited),
 				sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour)),
 			)
 			written := make(chan struct{}, 2)
@@ -1553,8 +1553,8 @@ var _ = Describe("Connection", func() {
 
 		It("sends multiple packets at once", func() {
 			sph.EXPECT().SentPacket(gomock.Any()).Times(3)
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).Times(3)
-			sph.EXPECT().SendMode().Return(ackhandler.SendPacingLimited)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(3)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendPacingLimited)
 			sph.EXPECT().TimeUntilSend().Return(time.Now().Add(time.Hour))
 			for pn := protocol.PacketNumber(1000); pn < 1003; pn++ {
 				expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: pn}}, []byte("packet"))
@@ -1591,7 +1591,7 @@ var _ = Describe("Connection", func() {
 				written := make(chan struct{})
 				sender.EXPECT().WouldBlock().AnyTimes()
 				sph.EXPECT().SentPacket(gomock.Any())
-				sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+				sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 				expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 1000}}, []byte("packet1000"))
 				packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
 				sender.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(*packetBuffer, protocol.ByteCount) { close(written) })
@@ -1614,7 +1614,7 @@ var _ = Describe("Connection", func() {
 				sph.EXPECT().ReceivedBytes(gomock.Any())
 				conn.handlePacket(receivedPacket{buffer: getPacketBuffer()})
 			})
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 10}}, []byte("packet10"))
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
 			sender.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(*packetBuffer, protocol.ByteCount) { close(written) })
@@ -1627,7 +1627,7 @@ var _ = Describe("Connection", func() {
 
 		It("stops sending when the send queue is full", func() {
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny)
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 1000}}, []byte("packet1000"))
 			written := make(chan struct{}, 1)
 			sender.EXPECT().WouldBlock()
@@ -1646,7 +1646,7 @@ var _ = Describe("Connection", func() {
 
 			// now make room in the send queue
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			sender.EXPECT().WouldBlock().AnyTimes()
 			expectAppendPacket(packer, shortHeaderPacket{Packet: &ackhandler.Packet{PacketNumber: 1001}}, []byte("packet1001"))
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
@@ -1660,7 +1660,7 @@ var _ = Describe("Connection", func() {
 		})
 
 		It("doesn't set a pacing timer when there is no data to send", func() {
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			sender.EXPECT().WouldBlock().AnyTimes()
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
 			// don't EXPECT any calls to mconn.Write()
@@ -1678,8 +1678,8 @@ var _ = Describe("Connection", func() {
 			conn.mtuDiscoverer = mtuDiscoverer
 			conn.config.DisablePathMTUDiscovery = false
 			sph.EXPECT().SentPacket(gomock.Any())
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny)
-			sph.EXPECT().SendMode().Return(ackhandler.SendNone)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny)
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone)
 			written := make(chan struct{}, 1)
 			sender.EXPECT().WouldBlock().AnyTimes()
 			sender.EXPECT().Send(gomock.Any(), gomock.Any()).DoAndReturn(func(*packetBuffer, protocol.ByteCount) { written <- struct{}{} })
@@ -1727,7 +1727,7 @@ var _ = Describe("Connection", func() {
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 			sph.EXPECT().TimeUntilSend().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 
 			sph.EXPECT().SentPacket(gomock.Any())
 			conn.sentPacketHandler = sph
@@ -1754,7 +1754,7 @@ var _ = Describe("Connection", func() {
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), conn.version).Return(shortHeaderPacket{}, errNothingToPack)
 			sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
 			sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-			sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 			sph.EXPECT().SentPacket(gomock.Any()).Do(func(p *ackhandler.Packet) {
 				Expect(p.PacketNumber).To(Equal(protocol.PacketNumber(1234)))
 			})
@@ -1806,7 +1806,7 @@ var _ = Describe("Connection", func() {
 		packer.EXPECT().PackCoalescedPacket(false, gomock.Any(), gomock.Any(), conn.version).AnyTimes()
 
 		sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
-		sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+		sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 		sph.EXPECT().TimeUntilSend().Return(time.Now()).AnyTimes()
 		gomock.InOrder(
 			sph.EXPECT().SentPacket(gomock.Any()).Do(func(p *ackhandler.Packet) {
@@ -1860,7 +1860,7 @@ var _ = Describe("Connection", func() {
 		conn.sentPacketHandler = sph
 		sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 		sph.EXPECT().TimeUntilSend().AnyTimes()
-		sph.EXPECT().SendMode().AnyTimes()
+		sph.EXPECT().SendMode(gomock.Any()).AnyTimes()
 		sph.EXPECT().SetHandshakeConfirmed()
 		connRunner.EXPECT().Retire(clientDestConnID)
 		go func() {
@@ -1956,7 +1956,7 @@ var _ = Describe("Connection", func() {
 
 	It("sends a HANDSHAKE_DONE frame when the handshake completes", func() {
 		sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
-		sph.EXPECT().SendMode().Return(ackhandler.SendAny).AnyTimes()
+		sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).AnyTimes()
 		sph.EXPECT().GetLossDetectionTimeout().AnyTimes()
 		sph.EXPECT().TimeUntilSend().AnyTimes()
 		sph.EXPECT().SetHandshakeConfirmed()

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -20,7 +20,7 @@ type SentPacketHandler interface {
 	SetHandshakeConfirmed()
 
 	// The SendMode determines if and what kind of packets can be sent.
-	SendMode() SendMode
+	SendMode(now time.Time) SendMode
 	// TimeUntilSend is the time when the next packet should be sent.
 	// It is used for pacing packets.
 	TimeUntilSend() time.Time

--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -717,7 +717,7 @@ func (h *sentPacketHandler) PopPacketNumber(encLevel protocol.EncryptionLevel) p
 	return h.getPacketNumberSpace(encLevel).pns.Pop()
 }
 
-func (h *sentPacketHandler) SendMode() SendMode {
+func (h *sentPacketHandler) SendMode(now time.Time) SendMode {
 	numTrackedPackets := h.appDataPackets.history.Len()
 	if h.initialPackets != nil {
 		numTrackedPackets += h.initialPackets.history.Len()
@@ -756,7 +756,7 @@ func (h *sentPacketHandler) SendMode() SendMode {
 		}
 		return SendAck
 	}
-	if !h.congestion.HasPacingBudget() {
+	if !h.congestion.HasPacingBudget(now) {
 		return SendPacingLimited
 	}
 	return SendAny
@@ -764,10 +764,6 @@ func (h *sentPacketHandler) SendMode() SendMode {
 
 func (h *sentPacketHandler) TimeUntilSend() time.Time {
 	return h.congestion.TimeUntilSend(h.bytesInFlight)
-}
-
-func (h *sentPacketHandler) HasPacingBudget() bool {
-	return h.congestion.HasPacingBudget()
 }
 
 func (h *sentPacketHandler) SetMaxDatagramSize(s protocol.ByteCount) {

--- a/internal/congestion/cubic_sender.go
+++ b/internal/congestion/cubic_sender.go
@@ -120,8 +120,8 @@ func (c *cubicSender) TimeUntilSend(_ protocol.ByteCount) time.Time {
 	return c.pacer.TimeUntilSend()
 }
 
-func (c *cubicSender) HasPacingBudget() bool {
-	return c.pacer.Budget(c.clock.Now()) >= c.maxDatagramSize
+func (c *cubicSender) HasPacingBudget(now time.Time) bool {
+	return c.pacer.Budget(now) >= c.maxDatagramSize
 }
 
 func (c *cubicSender) maxCongestionWindow() protocol.ByteCount {

--- a/internal/congestion/interface.go
+++ b/internal/congestion/interface.go
@@ -9,7 +9,7 @@ import (
 // A SendAlgorithm performs congestion control
 type SendAlgorithm interface {
 	TimeUntilSend(bytesInFlight protocol.ByteCount) time.Time
-	HasPacingBudget() bool
+	HasPacingBudget(now time.Time) bool
 	OnPacketSent(sentTime time.Time, bytesInFlight protocol.ByteCount, packetNumber protocol.PacketNumber, bytes protocol.ByteCount, isRetransmittable bool)
 	CanSend(bytesInFlight protocol.ByteCount) bool
 	MaybeExitSlowStart()

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -162,17 +162,17 @@ func (mr *MockSentPacketHandlerMockRecorder) ResetForRetry() *gomock.Call {
 }
 
 // SendMode mocks base method.
-func (m *MockSentPacketHandler) SendMode() ackhandler.SendMode {
+func (m *MockSentPacketHandler) SendMode(arg0 time.Time) ackhandler.SendMode {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendMode")
+	ret := m.ctrl.Call(m, "SendMode", arg0)
 	ret0, _ := ret[0].(ackhandler.SendMode)
 	return ret0
 }
 
 // SendMode indicates an expected call of SendMode.
-func (mr *MockSentPacketHandlerMockRecorder) SendMode() *gomock.Call {
+func (mr *MockSentPacketHandlerMockRecorder) SendMode(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMode", reflect.TypeOf((*MockSentPacketHandler)(nil).SendMode))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMode", reflect.TypeOf((*MockSentPacketHandler)(nil).SendMode), arg0)
 }
 
 // SentPacket mocks base method.

--- a/internal/mocks/congestion.go
+++ b/internal/mocks/congestion.go
@@ -64,17 +64,17 @@ func (mr *MockSendAlgorithmWithDebugInfosMockRecorder) GetCongestionWindow() *go
 }
 
 // HasPacingBudget mocks base method.
-func (m *MockSendAlgorithmWithDebugInfos) HasPacingBudget() bool {
+func (m *MockSendAlgorithmWithDebugInfos) HasPacingBudget(arg0 time.Time) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPacingBudget")
+	ret := m.ctrl.Call(m, "HasPacingBudget", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // HasPacingBudget indicates an expected call of HasPacingBudget.
-func (mr *MockSendAlgorithmWithDebugInfosMockRecorder) HasPacingBudget() *gomock.Call {
+func (mr *MockSendAlgorithmWithDebugInfosMockRecorder) HasPacingBudget(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPacingBudget", reflect.TypeOf((*MockSendAlgorithmWithDebugInfos)(nil).HasPacingBudget))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPacingBudget", reflect.TypeOf((*MockSendAlgorithmWithDebugInfos)(nil).HasPacingBudget), arg0)
 }
 
 // InRecovery mocks base method.

--- a/mock_packer_test.go
+++ b/mock_packer_test.go
@@ -38,39 +38,39 @@ func (m *MockPacker) EXPECT() *MockPackerMockRecorder {
 }
 
 // AppendPacket mocks base method.
-func (m *MockPacker) AppendPacket(arg0 *packetBuffer, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (shortHeaderPacket, error) {
+func (m *MockPacker) AppendPacket(arg0 *packetBuffer, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (shortHeaderPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendPacket", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AppendPacket", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(shortHeaderPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AppendPacket indicates an expected call of AppendPacket.
-func (mr *MockPackerMockRecorder) AppendPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) AppendPacket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendPacket", reflect.TypeOf((*MockPacker)(nil).AppendPacket), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendPacket", reflect.TypeOf((*MockPacker)(nil).AppendPacket), arg0, arg1, arg2, arg3)
 }
 
 // MaybePackProbePacket mocks base method.
-func (m *MockPacker) MaybePackProbePacket(arg0 protocol.EncryptionLevel, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (*coalescedPacket, error) {
+func (m *MockPacker) MaybePackProbePacket(arg0 protocol.EncryptionLevel, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MaybePackProbePacket", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "MaybePackProbePacket", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MaybePackProbePacket indicates an expected call of MaybePackProbePacket.
-func (mr *MockPackerMockRecorder) MaybePackProbePacket(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) MaybePackProbePacket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybePackProbePacket", reflect.TypeOf((*MockPacker)(nil).MaybePackProbePacket), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybePackProbePacket", reflect.TypeOf((*MockPacker)(nil).MaybePackProbePacket), arg0, arg1, arg2, arg3)
 }
 
 // PackAckOnlyPacket mocks base method.
-func (m *MockPacker) PackAckOnlyPacket(arg0 protocol.ByteCount, arg1 protocol.VersionNumber) (shortHeaderPacket, *packetBuffer, error) {
+func (m *MockPacker) PackAckOnlyPacket(arg0 protocol.ByteCount, arg1 time.Time, arg2 protocol.VersionNumber) (shortHeaderPacket, *packetBuffer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackAckOnlyPacket", arg0, arg1)
+	ret := m.ctrl.Call(m, "PackAckOnlyPacket", arg0, arg1, arg2)
 	ret0, _ := ret[0].(shortHeaderPacket)
 	ret1, _ := ret[1].(*packetBuffer)
 	ret2, _ := ret[2].(error)
@@ -78,54 +78,54 @@ func (m *MockPacker) PackAckOnlyPacket(arg0 protocol.ByteCount, arg1 protocol.Ve
 }
 
 // PackAckOnlyPacket indicates an expected call of PackAckOnlyPacket.
-func (mr *MockPackerMockRecorder) PackAckOnlyPacket(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackAckOnlyPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackAckOnlyPacket", reflect.TypeOf((*MockPacker)(nil).PackAckOnlyPacket), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackAckOnlyPacket", reflect.TypeOf((*MockPacker)(nil).PackAckOnlyPacket), arg0, arg1, arg2)
 }
 
 // PackApplicationClose mocks base method.
-func (m *MockPacker) PackApplicationClose(arg0 *qerr.ApplicationError, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (*coalescedPacket, error) {
+func (m *MockPacker) PackApplicationClose(arg0 *qerr.ApplicationError, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackApplicationClose", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PackApplicationClose", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PackApplicationClose indicates an expected call of PackApplicationClose.
-func (mr *MockPackerMockRecorder) PackApplicationClose(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackApplicationClose(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackApplicationClose", reflect.TypeOf((*MockPacker)(nil).PackApplicationClose), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackApplicationClose", reflect.TypeOf((*MockPacker)(nil).PackApplicationClose), arg0, arg1, arg2, arg3)
 }
 
 // PackCoalescedPacket mocks base method.
-func (m *MockPacker) PackCoalescedPacket(arg0 bool, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (*coalescedPacket, error) {
+func (m *MockPacker) PackCoalescedPacket(arg0 bool, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackCoalescedPacket", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PackCoalescedPacket", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PackCoalescedPacket indicates an expected call of PackCoalescedPacket.
-func (mr *MockPackerMockRecorder) PackCoalescedPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackCoalescedPacket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackCoalescedPacket", reflect.TypeOf((*MockPacker)(nil).PackCoalescedPacket), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackCoalescedPacket", reflect.TypeOf((*MockPacker)(nil).PackCoalescedPacket), arg0, arg1, arg2, arg3)
 }
 
 // PackConnectionClose mocks base method.
-func (m *MockPacker) PackConnectionClose(arg0 *qerr.TransportError, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (*coalescedPacket, error) {
+func (m *MockPacker) PackConnectionClose(arg0 *qerr.TransportError, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackConnectionClose", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PackConnectionClose", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PackConnectionClose indicates an expected call of PackConnectionClose.
-func (mr *MockPackerMockRecorder) PackConnectionClose(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackConnectionClose(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackConnectionClose", reflect.TypeOf((*MockPacker)(nil).PackConnectionClose), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackConnectionClose", reflect.TypeOf((*MockPacker)(nil).PackConnectionClose), arg0, arg1, arg2, arg3)
 }
 
 // PackMTUProbePacket mocks base method.

--- a/mock_packet_handler_test.go
+++ b/mock_packet_handler_test.go
@@ -61,7 +61,7 @@ func (mr *MockPacketHandlerMockRecorder) getPerspective() *gomock.Call {
 }
 
 // handlePacket mocks base method.
-func (m *MockPacketHandler) handlePacket(arg0 *receivedPacket) {
+func (m *MockPacketHandler) handlePacket(arg0 receivedPacket) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "handlePacket", arg0)
 }

--- a/mock_quic_conn_test.go
+++ b/mock_quic_conn_test.go
@@ -309,7 +309,7 @@ func (mr *MockQUICConnMockRecorder) getPerspective() *gomock.Call {
 }
 
 // handlePacket mocks base method.
-func (m *MockQUICConn) handlePacket(arg0 *receivedPacket) {
+func (m *MockQUICConn) handlePacket(arg0 receivedPacket) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "handlePacket", arg0)
 }

--- a/mock_unknown_packet_handler_test.go
+++ b/mock_unknown_packet_handler_test.go
@@ -34,7 +34,7 @@ func (m *MockUnknownPacketHandler) EXPECT() *MockUnknownPacketHandlerMockRecorde
 }
 
 // handlePacket mocks base method.
-func (m *MockUnknownPacketHandler) handlePacket(arg0 *receivedPacket) {
+func (m *MockUnknownPacketHandler) handlePacket(arg0 receivedPacket) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "handlePacket", arg0)
 }

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -39,7 +39,7 @@ type rawConn interface {
 type closePacket struct {
 	payload []byte
 	addr    net.Addr
-	info    *packetInfo
+	info    packetInfo
 }
 
 type unknownPacketHandler interface {
@@ -177,7 +177,7 @@ func (h *packetHandlerMap) ReplaceWithClosed(ids []protocol.ConnectionID, pers p
 	var handler packetHandler
 	if connClosePacket != nil {
 		handler = newClosedLocalConn(
-			func(addr net.Addr, info *packetInfo) {
+			func(addr net.Addr, info packetInfo) {
 				h.enqueueClosePacket(closePacket{payload: connClosePacket, addr: addr, info: info})
 			},
 			pers,

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -25,7 +25,7 @@ type connCapabilities struct {
 
 // rawConn is a connection that allow reading of a receivedPackeh.
 type rawConn interface {
-	ReadPacket() (*receivedPacket, error)
+	ReadPacket() (receivedPacket, error)
 	// The size parameter is used for GSO.
 	// If GSO is not support, len(b) must be equal to size.
 	WritePacket(b []byte, size uint16, addr net.Addr, oob []byte) (int, error)
@@ -43,7 +43,7 @@ type closePacket struct {
 }
 
 type unknownPacketHandler interface {
-	handlePacket(*receivedPacket)
+	handlePacket(receivedPacket)
 	setCloseError(error)
 }
 

--- a/packet_handler_map_test.go
+++ b/packet_handler_map_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Packet Handler Map", func() {
 		Expect(ok).To(BeTrue())
 		Expect(h).ToNot(Equal(handler))
 		addr := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234}
-		h.handlePacket(&receivedPacket{remoteAddr: addr})
+		h.handlePacket(receivedPacket{remoteAddr: addr})
 		Expect(closePackets).To(HaveLen(1))
 		Expect(closePackets[0].addr).To(Equal(addr))
 		Expect(closePackets[0].payload).To(Equal([]byte("foobar")))
@@ -152,7 +152,7 @@ var _ = Describe("Packet Handler Map", func() {
 		Expect(ok).To(BeTrue())
 		Expect(h).ToNot(Equal(handler))
 		addr := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234}
-		h.handlePacket(&receivedPacket{remoteAddr: addr})
+		h.handlePacket(receivedPacket{remoteAddr: addr})
 		Expect(closePackets).To(BeEmpty())
 
 		time.Sleep(dur)

--- a/send_conn.go
+++ b/send_conn.go
@@ -60,7 +60,7 @@ func (c *sconn) LocalAddr() net.Addr {
 	if c.info != nil {
 		if udpAddr, ok := addr.(*net.UDPAddr); ok {
 			addrCopy := *udpAddr
-			addrCopy.IP = c.info.addr
+			addrCopy.IP = c.info.addr.AsSlice()
 			addr = &addrCopy
 		}
 	}

--- a/send_conn.go
+++ b/send_conn.go
@@ -21,13 +21,25 @@ type sconn struct {
 	rawConn
 
 	remoteAddr net.Addr
-	info       *packetInfo
+	info       packetInfo
 	oob        []byte
 }
 
 var _ sendConn = &sconn{}
 
-func newSendConn(c rawConn, remote net.Addr, info *packetInfo) *sconn {
+func newSendConn(c rawConn, remote net.Addr) *sconn {
+	sc := &sconn{
+		rawConn:    c,
+		remoteAddr: remote,
+	}
+	if c.capabilities().GSO {
+		// add 32 bytes, so we can add the UDP_SEGMENT msg
+		sc.oob = make([]byte, 0, 32)
+	}
+	return sc
+}
+
+func newSendConnWithPacketInfo(c rawConn, remote net.Addr, info packetInfo) *sconn {
 	oob := info.OOB()
 	if c.capabilities().GSO {
 		// add 32 bytes, so we can add the UDP_SEGMENT msg
@@ -57,7 +69,7 @@ func (c *sconn) RemoteAddr() net.Addr {
 
 func (c *sconn) LocalAddr() net.Addr {
 	addr := c.rawConn.LocalAddr()
-	if c.info != nil {
+	if c.info.addr.IsValid() {
 		if udpAddr, ok := addr.(*net.UDPAddr); ok {
 			addrCopy := *udpAddr
 			addrCopy.IP = c.info.addr.AsSlice()

--- a/send_conn_test.go
+++ b/send_conn_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Connection (for sending packets)", func() {
 		packetConn = NewMockPacketConn(mockCtrl)
 		rawConn, err := wrapConn(packetConn)
 		Expect(err).ToNot(HaveOccurred())
-		c = newSendConn(rawConn, addr, nil)
+		c = newSendConnWithPacketInfo(rawConn, addr, packetInfo{})
 	})
 
 	It("writes", func() {

--- a/sys_conn.go
+++ b/sys_conn.go
@@ -79,16 +79,16 @@ type basicConn struct {
 
 var _ rawConn = &basicConn{}
 
-func (c *basicConn) ReadPacket() (*receivedPacket, error) {
+func (c *basicConn) ReadPacket() (receivedPacket, error) {
 	buffer := getPacketBuffer()
 	// The packet size should not exceed protocol.MaxPacketBufferSize bytes
 	// If it does, we only read a truncated packet, which will then end up undecryptable
 	buffer.Data = buffer.Data[:protocol.MaxPacketBufferSize]
 	n, addr, err := c.PacketConn.ReadFrom(buffer.Data)
 	if err != nil {
-		return nil, err
+		return receivedPacket{}, err
 	}
-	return &receivedPacket{
+	return receivedPacket{
 		remoteAddr: addr,
 		rcvTime:    time.Now(),
 		data:       buffer.Data[:n],

--- a/sys_conn_no_oob.go
+++ b/sys_conn_no_oob.go
@@ -2,7 +2,10 @@
 
 package quic
 
-import "net"
+import (
+	"net"
+	"net/netip"
+)
 
 func newConn(c net.PacketConn, supportsDF bool) (*basicConn, error) {
 	return &basicConn{PacketConn: c, supportsDF: supportsDF}, nil
@@ -12,7 +15,7 @@ func inspectReadBuffer(any) (int, error)  { return 0, nil }
 func inspectWriteBuffer(any) (int, error) { return 0, nil }
 
 type packetInfo struct {
-	addr net.IP
+	addr netip.Addr
 }
 
 func (i *packetInfo) OOB() []byte { return nil }

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -154,7 +154,7 @@ var _ = Describe("OOB Conn Test", func() {
 			Expect(p.rcvTime).To(BeTemporally("~", time.Now(), scaleDuration(20*time.Millisecond)))
 			Expect(p.data).To(Equal([]byte("foobar")))
 			Expect(p.remoteAddr).To(Equal(sentFrom))
-			Expect(p.info).To(Not(BeNil()))
+			Expect(p.info.addr.IsValid()).To(BeTrue())
 			Expect(net.IP(p.info.addr.AsSlice())).To(Equal(ip))
 		})
 

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var _ = Describe("OOB Conn Test", func() {
-	runServer := func(network, address string) (*net.UDPConn, <-chan *receivedPacket) {
+	runServer := func(network, address string) (*net.UDPConn, <-chan receivedPacket) {
 		addr, err := net.ResolveUDPAddr(network, address)
 		Expect(err).ToNot(HaveOccurred())
 		udpConn, err := net.ListenUDP(network, addr)
@@ -28,7 +28,7 @@ var _ = Describe("OOB Conn Test", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(oobConn.capabilities().DF).To(BeTrue())
 
-		packetChan := make(chan *receivedPacket)
+		packetChan := make(chan receivedPacket)
 		go func() {
 			defer GinkgoRecover()
 			for {
@@ -69,7 +69,7 @@ var _ = Describe("OOB Conn Test", func() {
 				},
 			)
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(p.rcvTime).To(BeTemporally("~", time.Now(), scaleDuration(20*time.Millisecond)))
 			Expect(p.data).To(Equal([]byte("foobar")))
@@ -89,7 +89,7 @@ var _ = Describe("OOB Conn Test", func() {
 				},
 			)
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(p.rcvTime).To(BeTemporally("~", time.Now(), scaleDuration(20*time.Millisecond)))
 			Expect(p.data).To(Equal([]byte("foobar")))
@@ -111,7 +111,7 @@ var _ = Describe("OOB Conn Test", func() {
 				},
 			)
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(utils.IsIPv4(p.remoteAddr.(*net.UDPAddr).IP)).To(BeTrue())
 			Expect(p.ecn).To(Equal(protocol.ECNCE))
@@ -149,7 +149,7 @@ var _ = Describe("OOB Conn Test", func() {
 			addr.IP = ip
 			sentFrom := sendPacket("udp4", addr)
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(p.rcvTime).To(BeTemporally("~", time.Now(), scaleDuration(20*time.Millisecond)))
 			Expect(p.data).To(Equal([]byte("foobar")))
@@ -167,7 +167,7 @@ var _ = Describe("OOB Conn Test", func() {
 			addr.IP = ip
 			sentFrom := sendPacket("udp6", addr)
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(p.rcvTime).To(BeTemporally("~", time.Now(), scaleDuration(20*time.Millisecond)))
 			Expect(p.data).To(Equal([]byte("foobar")))
@@ -185,7 +185,7 @@ var _ = Describe("OOB Conn Test", func() {
 			ip4 := net.ParseIP("127.0.0.1").To4()
 			sendPacket("udp4", &net.UDPAddr{IP: ip4, Port: port})
 
-			var p *receivedPacket
+			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(utils.IsIPv4(p.remoteAddr.(*net.UDPAddr).IP)).To(BeTrue())
 			Expect(p.info).To(Not(BeNil()))

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -155,7 +155,7 @@ var _ = Describe("OOB Conn Test", func() {
 			Expect(p.data).To(Equal([]byte("foobar")))
 			Expect(p.remoteAddr).To(Equal(sentFrom))
 			Expect(p.info).To(Not(BeNil()))
-			Expect(p.info.addr.To4()).To(Equal(ip))
+			Expect(net.IP(p.info.addr.AsSlice())).To(Equal(ip))
 		})
 
 		It("reads packet info on IPv6", func() {
@@ -173,7 +173,7 @@ var _ = Describe("OOB Conn Test", func() {
 			Expect(p.data).To(Equal([]byte("foobar")))
 			Expect(p.remoteAddr).To(Equal(sentFrom))
 			Expect(p.info).To(Not(BeNil()))
-			Expect(p.info.addr).To(Equal(ip))
+			Expect(net.IP(p.info.addr.AsSlice())).To(Equal(ip))
 		})
 
 		It("reads packet info on a connection that supports both IPv4 and IPv6", func() {
@@ -182,14 +182,14 @@ var _ = Describe("OOB Conn Test", func() {
 			port := conn.LocalAddr().(*net.UDPAddr).Port
 
 			// IPv4
-			ip4 := net.ParseIP("127.0.0.1").To4()
+			ip4 := net.ParseIP("127.0.0.1")
 			sendPacket("udp4", &net.UDPAddr{IP: ip4, Port: port})
 
 			var p receivedPacket
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(utils.IsIPv4(p.remoteAddr.(*net.UDPAddr).IP)).To(BeTrue())
 			Expect(p.info).To(Not(BeNil()))
-			Expect(p.info.addr.To4()).To(Equal(ip4))
+			Expect(net.IP(p.info.addr.AsSlice())).To(Equal(ip4.To4()))
 
 			// IPv6
 			ip6 := net.ParseIP("::1")
@@ -198,7 +198,7 @@ var _ = Describe("OOB Conn Test", func() {
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(utils.IsIPv4(p.remoteAddr.(*net.UDPAddr).IP)).To(BeFalse())
 			Expect(p.info).To(Not(BeNil()))
-			Expect(p.info.addr).To(Equal(ip6))
+			Expect(net.IP(p.info.addr.AsSlice())).To(Equal(ip6))
 		})
 	})
 

--- a/sys_conn_windows.go
+++ b/sys_conn_windows.go
@@ -3,7 +3,7 @@
 package quic
 
 import (
-	"net"
+	"net/netip"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -36,7 +36,7 @@ func inspectWriteBuffer(c syscall.RawConn) (int, error) {
 }
 
 type packetInfo struct {
-	addr net.IP
+	addr netip.Addr
 }
 
 func (i *packetInfo) OOB() []byte { return nil }

--- a/transport.go
+++ b/transport.go
@@ -74,7 +74,7 @@ type Transport struct {
 	conn rawConn
 
 	closeQueue          chan closePacket
-	statelessResetQueue chan *receivedPacket
+	statelessResetQueue chan receivedPacket
 
 	listening   chan struct{} // is closed when listen returns
 	closed      bool
@@ -197,7 +197,7 @@ func (t *Transport) init(isServer bool) error {
 		t.listening = make(chan struct{})
 
 		t.closeQueue = make(chan closePacket, 4)
-		t.statelessResetQueue = make(chan *receivedPacket, 4)
+		t.statelessResetQueue = make(chan receivedPacket, 4)
 
 		if t.ConnectionIDGenerator != nil {
 			t.connIDGenerator = t.ConnectionIDGenerator
@@ -339,7 +339,7 @@ func (t *Transport) listen(conn rawConn) {
 	}
 }
 
-func (t *Transport) handlePacket(p *receivedPacket) {
+func (t *Transport) handlePacket(p receivedPacket) {
 	connID, err := wire.ParseConnectionID(p.data, t.connIDLen)
 	if err != nil {
 		t.logger.Debugf("error parsing connection ID on packet from %s: %s", p.remoteAddr, err)
@@ -371,7 +371,7 @@ func (t *Transport) handlePacket(p *receivedPacket) {
 	t.server.handlePacket(p)
 }
 
-func (t *Transport) maybeSendStatelessReset(p *receivedPacket) {
+func (t *Transport) maybeSendStatelessReset(p receivedPacket) {
 	if t.StatelessResetKey == nil {
 		p.buffer.Release()
 		return
@@ -392,7 +392,7 @@ func (t *Transport) maybeSendStatelessReset(p *receivedPacket) {
 	}
 }
 
-func (t *Transport) sendStatelessReset(p *receivedPacket) {
+func (t *Transport) sendStatelessReset(p receivedPacket) {
 	defer p.buffer.Release()
 
 	connID, err := wire.ParseConnectionID(p.data, t.connIDLen)

--- a/transport.go
+++ b/transport.go
@@ -155,7 +155,7 @@ func (t *Transport) Dial(ctx context.Context, addr net.Addr, tlsConf *tls.Config
 	if t.isSingleUse {
 		onClose = func() { t.Close() }
 	}
-	return dial(ctx, newSendConn(t.conn, addr, nil), t.connIDGenerator, t.handlerMap, tlsConf, conf, onClose, false)
+	return dial(ctx, newSendConn(t.conn, addr), t.connIDGenerator, t.handlerMap, tlsConf, conf, onClose, false)
 }
 
 // DialEarly dials a new connection, attempting to use 0-RTT if possible.
@@ -171,7 +171,7 @@ func (t *Transport) DialEarly(ctx context.Context, addr net.Addr, tlsConf *tls.C
 	if t.isSingleUse {
 		onClose = func() { t.Close() }
 	}
-	return dial(ctx, newSendConn(t.conn, addr, nil), t.connIDGenerator, t.handlerMap, tlsConf, conf, onClose, true)
+	return dial(ctx, newSendConn(t.conn, addr), t.connIDGenerator, t.handlerMap, tlsConf, conf, onClose, true)
 }
 
 func (t *Transport) init(isServer bool) error {

--- a/transport_test.go
+++ b/transport_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Transport", func() {
 		handled := make(chan struct{}, 2)
 		phm.EXPECT().Get(connID1).DoAndReturn(func(protocol.ConnectionID) (packetHandler, bool) {
 			h := NewMockPacketHandler(mockCtrl)
-			h.EXPECT().handlePacket(gomock.Any()).Do(func(p *receivedPacket) {
+			h.EXPECT().handlePacket(gomock.Any()).Do(func(p receivedPacket) {
 				defer GinkgoRecover()
 				connID, err := wire.ParseConnectionID(p.data, 0)
 				Expect(err).ToNot(HaveOccurred())
@@ -81,7 +81,7 @@ var _ = Describe("Transport", func() {
 		})
 		phm.EXPECT().Get(connID2).DoAndReturn(func(protocol.ConnectionID) (packetHandler, bool) {
 			h := NewMockPacketHandler(mockCtrl)
-			h.EXPECT().handlePacket(gomock.Any()).Do(func(p *receivedPacket) {
+			h.EXPECT().handlePacket(gomock.Any()).Do(func(p receivedPacket) {
 				defer GinkgoRecover()
 				connID, err := wire.ParseConnectionID(p.data, 0)
 				Expect(err).ToNot(HaveOccurred())
@@ -205,7 +205,7 @@ var _ = Describe("Transport", func() {
 		gomock.InOrder(
 			phm.EXPECT().GetByResetToken(token),
 			phm.EXPECT().Get(connID).Return(conn, true),
-			conn.EXPECT().handlePacket(gomock.Any()).Do(func(p *receivedPacket) {
+			conn.EXPECT().handlePacket(gomock.Any()).Do(func(p receivedPacket) {
 				Expect(p.data).To(Equal(b))
 				Expect(p.rcvTime).To(BeTemporally("~", time.Now(), time.Second))
 			}),


### PR DESCRIPTION
This completely eliminates allocations when reading packets from the socket. Here's a profile of a 10 GB transfer (receive side):
![profile001](https://github.com/quic-go/quic-go/assets/1478487/106e9ddb-bf26-4292-9449-93f95cd99dba)

Out of the 2.66 GB of allocations, 2.40 GB (that's > 90%) are caused in the UDP send / receive path in the standard library. This once again highlights how absolutely crucial the implementation of the new UDP API (https://github.com/golang/go/issues/45886) would be.