### PR TITLE
reuse the same ACK frame struct over and over again when receiving

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1251,7 +1251,11 @@ func (s *connection) handleFrames(
 ) (isAckEliciting bool, _ error) {
 	// Only used for tracing.
 	// If we're not tracing, this slice will always remain empty.
-	var frames []wire.Frame
+	var frames []logging.Frame
+	if log != nil {
+		frames = make([]logging.Frame, 0, 4)
+	}
+	var handleErr error
 	for len(data) > 0 {
 		l, frame, err := s.frameParser.ParseNext(data, encLevel, s.version)
 		if err != nil {
@@ -1264,27 +1268,27 @@ func (s *connection) handleFrames(
 		if ackhandler.IsFrameAckEliciting(frame) {
 			isAckEliciting = true
 		}
-		// Only process frames now if we're not logging.
-		// If we're logging, we need to make sure that the packet_received event is logged first.
-		if log == nil {
-			if err := s.handleFrame(frame, encLevel, destConnID); err != nil {
+		if log != nil {
+			frames = append(frames, logutils.ConvertFrame(frame))
+			// An error occurred handling a previous frame.
+			// Don't handle the current frame.
+			if handleErr != nil {
+				continue
+			}
+		}
+		if err := s.handleFrame(frame, encLevel, destConnID); err != nil {
+			if log == nil {
 				return false, err
 			}
-		} else {
-			frames = append(frames, frame)
+			// If we're logging, we need to keep parsing (but not handling) all frames.
+			handleErr = err
 		}
 	}
 
 	if log != nil {
-		fs := make([]logging.Frame, len(frames))
-		for i, frame := range frames {
-			fs[i] = logutils.ConvertFrame(frame)
-		}
-		log(fs)
-		for _, frame := range frames {
-			if err := s.handleFrame(frame, encLevel, destConnID); err != nil {
-				return false, err
-			}
+		log(frames)
+		if handleErr != nil {
+			return false, handleErr
 		}
 	}
 	return

--- a/connection.go
+++ b/connection.go
@@ -1304,7 +1304,6 @@ func (s *connection) handleFrame(f wire.Frame, encLevel protocol.EncryptionLevel
 		err = s.handleStreamFrame(frame)
 	case *wire.AckFrame:
 		err = s.handleAckFrame(frame, encLevel)
-		wire.PutAckFrame(frame)
 	case *wire.ConnectionCloseFrame:
 		s.handleConnectionCloseFrame(frame)
 	case *wire.ResetStreamFrame:

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -11,7 +11,9 @@ import (
 type SentPacketHandler interface {
 	// SentPacket may modify the packet
 	SentPacket(packet *Packet)
-	ReceivedAck(ackFrame *wire.AckFrame, encLevel protocol.EncryptionLevel, recvTime time.Time) (bool /* 1-RTT packet acked */, error)
+	// ReceivedAck processes an ACK frame.
+	// It does not store a copy of the frame.
+	ReceivedAck(f *wire.AckFrame, encLevel protocol.EncryptionLevel, recvTime time.Time) (bool /* 1-RTT packet acked */, error)
 	ReceivedBytes(protocol.ByteCount)
 	DropPackets(protocol.EncryptionLevel)
 	ResetForRetry() error

--- a/internal/wire/ack_frame.go
+++ b/internal/wire/ack_frame.go
@@ -22,19 +22,17 @@ type AckFrame struct {
 }
 
 // parseAckFrame reads an ACK frame
-func parseAckFrame(r *bytes.Reader, typ uint64, ackDelayExponent uint8, _ protocol.VersionNumber) (*AckFrame, error) {
+func parseAckFrame(frame *AckFrame, r *bytes.Reader, typ uint64, ackDelayExponent uint8, _ protocol.VersionNumber) error {
 	ecn := typ == ackECNFrameType
-
-	frame := GetAckFrame()
 
 	la, err := quicvarint.Read(r)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	largestAcked := protocol.PacketNumber(la)
 	delay, err := quicvarint.Read(r)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	delayTime := time.Duration(delay*1<<ackDelayExponent) * time.Microsecond
@@ -46,17 +44,17 @@ func parseAckFrame(r *bytes.Reader, typ uint64, ackDelayExponent uint8, _ protoc
 
 	numBlocks, err := quicvarint.Read(r)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// read the first ACK range
 	ab, err := quicvarint.Read(r)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	ackBlock := protocol.PacketNumber(ab)
 	if ackBlock > largestAcked {
-		return nil, errors.New("invalid first ACK range")
+		return errors.New("invalid first ACK range")
 	}
 	smallest := largestAcked - ackBlock
 
@@ -65,50 +63,50 @@ func parseAckFrame(r *bytes.Reader, typ uint64, ackDelayExponent uint8, _ protoc
 	for i := uint64(0); i < numBlocks; i++ {
 		g, err := quicvarint.Read(r)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		gap := protocol.PacketNumber(g)
 		if smallest < gap+2 {
-			return nil, errInvalidAckRanges
+			return errInvalidAckRanges
 		}
 		largest := smallest - gap - 2
 
 		ab, err := quicvarint.Read(r)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		ackBlock := protocol.PacketNumber(ab)
 
 		if ackBlock > largest {
-			return nil, errInvalidAckRanges
+			return errInvalidAckRanges
 		}
 		smallest = largest - ackBlock
 		frame.AckRanges = append(frame.AckRanges, AckRange{Smallest: smallest, Largest: largest})
 	}
 
 	if !frame.validateAckRanges() {
-		return nil, errInvalidAckRanges
+		return errInvalidAckRanges
 	}
 
 	if ecn {
 		ect0, err := quicvarint.Read(r)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		frame.ECT0 = ect0
 		ect1, err := quicvarint.Read(r)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		frame.ECT1 = ect1
 		ecnce, err := quicvarint.Read(r)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		frame.ECNCE = ecnce
 	}
 
-	return frame, nil
+	return nil
 }
 
 // Append appends an ACK frame.
@@ -249,6 +247,18 @@ func (f *AckFrame) AcksPacket(p protocol.PacketNumber) bool {
 	})
 	// i will always be < len(f.AckRanges), since we checked above that p is not bigger than the largest acked
 	return p <= f.AckRanges[i].Largest
+}
+
+func (f *AckFrame) Reset() {
+	f.DelayTime = 0
+	f.ECT0 = 0
+	f.ECT1 = 0
+	f.ECNCE = 0
+	for _, r := range f.AckRanges {
+		r.Largest = 0
+		r.Smallest = 0
+	}
+	f.AckRanges = f.AckRanges[:0]
 }
 
 func encodeAckDelay(delay time.Duration) uint64 {

--- a/internal/wire/frame_parser.go
+++ b/internal/wire/frame_parser.go
@@ -39,9 +39,12 @@ const (
 type frameParser struct {
 	r bytes.Reader // cached bytes.Reader, so we don't have to repeatedly allocate them
 
-	ackDelayExponent uint8
-
+	ackDelayExponent  uint8
 	supportsDatagrams bool
+
+	// To avoid allocating when parsing, keep a single ACK frame struct.
+	// It is used over and over again.
+	ackFrame *AckFrame
 }
 
 var _ FrameParser = &frameParser{}
@@ -51,6 +54,7 @@ func NewFrameParser(supportsDatagrams bool) *frameParser {
 	return &frameParser{
 		r:                 *bytes.NewReader(nil),
 		supportsDatagrams: supportsDatagrams,
+		ackFrame:          &AckFrame{},
 	}
 }
 
@@ -105,7 +109,9 @@ func (p *frameParser) parseFrame(r *bytes.Reader, typ uint64, encLevel protocol.
 			if encLevel != protocol.Encryption1RTT {
 				ackDelayExponent = protocol.DefaultAckDelayExponent
 			}
-			frame, err = parseAckFrame(r, typ, ackDelayExponent, v)
+			p.ackFrame.Reset()
+			err = parseAckFrame(p.ackFrame, r, typ, ackDelayExponent, v)
+			frame = p.ackFrame
 		case resetStreamFrameType:
 			frame, err = parseResetStreamFrame(r, v)
 		case stopSendingFrameType:


### PR DESCRIPTION
Depends on #3829. Part of #3822.