### PR TITLE
use ackhandler.Frame directly, not as a pointer, remove its sync.Pool

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1988,7 +1988,7 @@ func (s *connection) logLongHeaderPacket(p *longHeaderPacket) {
 func (s *connection) logShortHeaderPacket(
 	destConnID protocol.ConnectionID,
 	ackFrame *wire.AckFrame,
-	frames []*ackhandler.Frame,
+	frames []ackhandler.Frame,
 	streamFrames []ackhandler.StreamFrame,
 	pn protocol.PacketNumber,
 	pnLen protocol.PacketNumberLen,

--- a/connection_test.go
+++ b/connection_test.go
@@ -310,7 +310,7 @@ var _ = Describe("Connection", func() {
 			err := conn.handleFrame(&wire.PathChallengeFrame{Data: data}, protocol.Encryption1RTT, protocol.ConnectionID{})
 			Expect(err).ToNot(HaveOccurred())
 			frames, _ := conn.framer.AppendControlFrames(nil, 1000, protocol.Version1)
-			Expect(frames).To(Equal([]*ackhandler.Frame{{Frame: &wire.PathResponseFrame{Data: data}}}))
+			Expect(frames).To(Equal([]ackhandler.Frame{{Frame: &wire.PathResponseFrame{Data: data}}}))
 		})
 
 		It("rejects NEW_TOKEN frames", func() {
@@ -1271,7 +1271,7 @@ var _ = Describe("Connection", func() {
 			conn.scheduleSending()
 			Eventually(sent).Should(BeClosed())
 			frames, _ := conn.framer.AppendControlFrames(nil, 1000, protocol.Version1)
-			Expect(frames).To(Equal([]*ackhandler.Frame{{Frame: &logging.DataBlockedFrame{MaximumData: 1337}}}))
+			Expect(frames).To(Equal([]ackhandler.Frame{{Frame: &logging.DataBlockedFrame{MaximumData: 1337}}}))
 		})
 
 		It("doesn't send when the SentPacketHandler doesn't allow it", func() {
@@ -1868,8 +1868,8 @@ var _ = Describe("Connection", func() {
 		handshakeCtx := conn.HandshakeComplete()
 		Consistently(handshakeCtx).ShouldNot(BeClosed())
 		close(finishHandshake)
-		var frames []*ackhandler.Frame
-		Eventually(func() []*ackhandler.Frame {
+		var frames []ackhandler.Frame
+		Eventually(func() []ackhandler.Frame {
 			frames, _ = conn.framer.AppendControlFrames(nil, protocol.MaxByteCount, protocol.Version1)
 			return frames
 		}).ShouldNot(BeEmpty())
@@ -1879,7 +1879,7 @@ var _ = Describe("Connection", func() {
 			if cf, ok := f.Frame.(*wire.CryptoFrame); ok {
 				count++
 				s += len(cf.Data)
-				Expect(f.Length(conn.version)).To(BeNumerically("<=", protocol.MaxPostHandshakeCryptoFrameSize))
+				Expect(f.Frame.Length(conn.version)).To(BeNumerically("<=", protocol.MaxPostHandshakeCryptoFrameSize))
 			}
 		}
 		Expect(size).To(BeEquivalentTo(s))

--- a/framer.go
+++ b/framer.go
@@ -15,7 +15,7 @@ type framer interface {
 	HasData() bool
 
 	QueueControlFrame(wire.Frame)
-	AppendControlFrames([]*ackhandler.Frame, protocol.ByteCount, protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount)
+	AppendControlFrames([]ackhandler.Frame, protocol.ByteCount, protocol.VersionNumber) ([]ackhandler.Frame, protocol.ByteCount)
 
 	AddActiveStream(protocol.StreamID)
 	AppendStreamFrames([]ackhandler.StreamFrame, protocol.ByteCount, protocol.VersionNumber) ([]ackhandler.StreamFrame, protocol.ByteCount)
@@ -63,7 +63,7 @@ func (f *framerI) QueueControlFrame(frame wire.Frame) {
 	f.controlFrameMutex.Unlock()
 }
 
-func (f *framerI) AppendControlFrames(frames []*ackhandler.Frame, maxLen protocol.ByteCount, v protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount) {
+func (f *framerI) AppendControlFrames(frames []ackhandler.Frame, maxLen protocol.ByteCount, v protocol.VersionNumber) ([]ackhandler.Frame, protocol.ByteCount) {
 	var length protocol.ByteCount
 	f.controlFrameMutex.Lock()
 	for len(f.controlFrames) > 0 {
@@ -72,9 +72,7 @@ func (f *framerI) AppendControlFrames(frames []*ackhandler.Frame, maxLen protoco
 		if length+frameLen > maxLen {
 			break
 		}
-		af := ackhandler.GetFrame()
-		af.Frame = frame
-		frames = append(frames, af)
+		frames = append(frames, ackhandler.Frame{Frame: frame})
 		length += frameLen
 		f.controlFrames = f.controlFrames[:len(f.controlFrames)-1]
 	}

--- a/framer_test.go
+++ b/framer_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Framer", func() {
 			ping := &wire.PingFrame{}
 			mdf := &wire.MaxDataFrame{MaximumData: 0x42}
 			framer.QueueControlFrame(mdf)
-			frames, length := framer.AppendControlFrames([]*ackhandler.Frame{{Frame: ping}}, 1000, protocol.Version1)
+			frames, length := framer.AppendControlFrames([]ackhandler.Frame{{Frame: ping}}, 1000, protocol.Version1)
 			Expect(frames).To(HaveLen(2))
 			Expect(frames[0].Frame).To(Equal(ping))
 			Expect(frames[1].Frame).To(Equal(mdf))

--- a/internal/ackhandler/ack_eliciting.go
+++ b/internal/ackhandler/ack_eliciting.go
@@ -10,7 +10,7 @@ func IsFrameAckEliciting(f wire.Frame) bool {
 }
 
 // HasAckElicitingFrames returns true if at least one frame is ack-eliciting.
-func HasAckElicitingFrames(fs []*Frame) bool {
+func HasAckElicitingFrames(fs []Frame) bool {
 	for _, f := range fs {
 		if IsFrameAckEliciting(f.Frame) {
 			return true

--- a/internal/ackhandler/ack_eliciting_test.go
+++ b/internal/ackhandler/ack_eliciting_test.go
@@ -29,7 +29,7 @@ var _ = Describe("ack-eliciting frames", func() {
 		})
 
 		It("HasAckElicitingFrames works for "+fName, func() {
-			Expect(HasAckElicitingFrames([]*Frame{{Frame: f}})).To(Equal(e))
+			Expect(HasAckElicitingFrames([]Frame{{Frame: f}})).To(Equal(e))
 		})
 	}
 })

--- a/internal/ackhandler/frame.go
+++ b/internal/ackhandler/frame.go
@@ -1,31 +1,13 @@
 package ackhandler
 
 import (
-	"sync"
-
 	"github.com/quic-go/quic-go/internal/wire"
 )
 
 type Frame struct {
-	wire.Frame // nil if the frame has already been acknowledged in another packet
-	OnLost     func(wire.Frame)
-	OnAcked    func(wire.Frame)
-}
-
-var framePool = sync.Pool{New: func() any { return &Frame{} }}
-
-func GetFrame() *Frame {
-	f := framePool.Get().(*Frame)
-	f.OnLost = nil
-	f.OnAcked = nil
-	return f
-}
-
-func putFrame(f *Frame) {
-	f.Frame = nil
-	f.OnLost = nil
-	f.OnAcked = nil
-	framePool.Put(f)
+	Frame   wire.Frame // nil if the frame has already been acknowledged in another packet
+	OnLost  func(wire.Frame)
+	OnAcked func(wire.Frame)
 }
 
 type StreamFrame struct {

--- a/internal/ackhandler/packet.go
+++ b/internal/ackhandler/packet.go
@@ -12,7 +12,7 @@ type Packet struct {
 	SendTime        time.Time
 	PacketNumber    protocol.PacketNumber
 	StreamFrames    []StreamFrame
-	Frames          []*Frame
+	Frames          []Frame
 	LargestAcked    protocol.PacketNumber // InvalidPacketNumber if the packet doesn't contain an ACK
 	Length          protocol.ByteCount
 	EncryptionLevel protocol.EncryptionLevel
@@ -49,9 +49,6 @@ func GetPacket() *Packet {
 // We currently only return Packets back into the pool when they're acknowledged (not when they're lost).
 // This simplifies the code, and gives the vast majority of the performance benefit we can gain from using the pool.
 func putPacket(p *Packet) {
-	for _, f := range p.Frames {
-		putFrame(f)
-	}
 	p.Frames = nil
 	p.StreamFrames = nil
 	packetPool.Put(p)

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -54,7 +54,7 @@ var _ = Describe("SentPacketHandler", func() {
 			p.SendTime = time.Now()
 		}
 		if len(p.Frames) == 0 {
-			p.Frames = []*Frame{
+			p.Frames = []Frame{
 				{Frame: &wire.PingFrame{}, OnLost: func(wire.Frame) { lostPackets = append(lostPackets, p.PacketNumber) }},
 			}
 		}
@@ -276,7 +276,7 @@ var _ = Describe("SentPacketHandler", func() {
 				ping := &wire.PingFrame{}
 				handler.SentPacket(ackElicitingPacket(&Packet{
 					PacketNumber: 13,
-					Frames: []*Frame{{
+					Frames: []Frame{{
 						Frame: ping, OnAcked: func(f wire.Frame) {
 							Expect(f).To(Equal(ping))
 							acked = true
@@ -428,20 +428,20 @@ var _ = Describe("SentPacketHandler", func() {
 					{
 						PacketNumber:    13,
 						LargestAcked:    100,
-						Frames:          []*Frame{{Frame: &streamFrame, OnLost: func(wire.Frame) {}}},
+						Frames:          []Frame{{Frame: &streamFrame, OnLost: func(wire.Frame) {}}},
 						Length:          1,
 						EncryptionLevel: protocol.Encryption1RTT,
 					},
 					{
 						PacketNumber:    14,
 						LargestAcked:    200,
-						Frames:          []*Frame{{Frame: &streamFrame, OnLost: func(wire.Frame) {}}},
+						Frames:          []Frame{{Frame: &streamFrame, OnLost: func(wire.Frame) {}}},
 						Length:          1,
 						EncryptionLevel: protocol.Encryption1RTT,
 					},
 					{
 						PacketNumber:    15,
-						Frames:          []*Frame{{Frame: &streamFrame, OnLost: func(wire.Frame) {}}},
+						Frames:          []Frame{{Frame: &streamFrame, OnLost: func(wire.Frame) {}}},
 						Length:          1,
 						EncryptionLevel: protocol.Encryption1RTT,
 					},
@@ -501,7 +501,7 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.SentPacket(&Packet{
 				PacketNumber:    1,
 				Length:          42,
-				Frames:          []*Frame{{Frame: &wire.PingFrame{}, OnLost: func(wire.Frame) {}}},
+				Frames:          []Frame{{Frame: &wire.PingFrame{}, OnLost: func(wire.Frame) {}}},
 				EncryptionLevel: protocol.Encryption1RTT,
 			})
 		})
@@ -548,7 +548,7 @@ var _ = Describe("SentPacketHandler", func() {
 				PacketNumber:         1,
 				SendTime:             time.Now().Add(-time.Hour),
 				IsPathMTUProbePacket: true,
-				Frames:               []*Frame{{Frame: &wire.PingFrame{}, OnLost: func(wire.Frame) { mtuPacketDeclaredLost = true }}},
+				Frames:               []Frame{{Frame: &wire.PingFrame{}, OnLost: func(wire.Frame) { mtuPacketDeclaredLost = true }}},
 			}))
 			handler.SentPacket(ackElicitingPacket(&Packet{PacketNumber: 2}))
 			// lose packet 1, but don't EXPECT any calls to OnPacketLost()
@@ -595,7 +595,7 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.SentPacket(&Packet{
 				Length:          42,
 				EncryptionLevel: protocol.EncryptionInitial,
-				Frames:          []*Frame{{Frame: &wire.PingFrame{}}},
+				Frames:          []Frame{{Frame: &wire.PingFrame{}}},
 				SendTime:        time.Now(),
 			})
 			cong.EXPECT().CanSend(protocol.ByteCount(42)).Return(true)
@@ -755,7 +755,7 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.SentPacket(ackElicitingPacket(&Packet{
 				PacketNumber: 1,
 				SendTime:     time.Now().Add(-time.Hour),
-				Frames: []*Frame{
+				Frames: []Frame{
 					{Frame: &wire.PingFrame{}, OnLost: func(wire.Frame) { lostPackets = append(lostPackets, 1) }},
 				},
 			}))
@@ -775,7 +775,7 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.SentPacket(ackElicitingPacket(&Packet{
 				PacketNumber: pn,
 				SendTime:     time.Now().Add(-time.Hour),
-				Frames: []*Frame{
+				Frames: []Frame{
 					{Frame: &wire.PingFrame{}, OnLost: func(wire.Frame) { lostPackets = append(lostPackets, 1) }},
 				},
 			}))
@@ -895,7 +895,7 @@ var _ = Describe("SentPacketHandler", func() {
 				PacketNumber:    1,
 				Length:          599,
 				EncryptionLevel: protocol.EncryptionInitial,
-				Frames:          []*Frame{{Frame: &wire.PingFrame{}}},
+				Frames:          []Frame{{Frame: &wire.PingFrame{}}},
 				SendTime:        time.Now(),
 			})
 			Expect(handler.SendMode()).To(Equal(SendAny))
@@ -903,7 +903,7 @@ var _ = Describe("SentPacketHandler", func() {
 				PacketNumber:    2,
 				Length:          1,
 				EncryptionLevel: protocol.EncryptionInitial,
-				Frames:          []*Frame{{Frame: &wire.PingFrame{}}},
+				Frames:          []Frame{{Frame: &wire.PingFrame{}}},
 				SendTime:        time.Now(),
 			})
 			Expect(handler.SendMode()).To(Equal(SendNone))
@@ -915,7 +915,7 @@ var _ = Describe("SentPacketHandler", func() {
 				PacketNumber:    1,
 				Length:          900,
 				EncryptionLevel: protocol.EncryptionInitial,
-				Frames:          []*Frame{{Frame: &wire.PingFrame{}}},
+				Frames:          []Frame{{Frame: &wire.PingFrame{}}},
 				SendTime:        time.Now(),
 			})
 			// Amplification limited. We don't need to set a timer now.
@@ -931,7 +931,7 @@ var _ = Describe("SentPacketHandler", func() {
 				PacketNumber:    1,
 				Length:          900,
 				EncryptionLevel: protocol.EncryptionHandshake,
-				Frames:          []*Frame{{Frame: &wire.PingFrame{}}},
+				Frames:          []Frame{{Frame: &wire.PingFrame{}}},
 				SendTime:        time.Now(),
 			})
 			// Amplification limited. We don't need to set a timer now.
@@ -965,7 +965,7 @@ var _ = Describe("SentPacketHandler", func() {
 				PacketNumber:    1,
 				Length:          900,
 				EncryptionLevel: protocol.EncryptionInitial,
-				Frames:          []*Frame{{Frame: &wire.PingFrame{}}},
+				Frames:          []Frame{{Frame: &wire.PingFrame{}}},
 				SendTime:        time.Now(),
 			})
 			Expect(handler.SendMode()).To(Equal(SendAny))
@@ -1158,7 +1158,7 @@ var _ = Describe("SentPacketHandler", func() {
 				PacketNumber:         1,
 				SendTime:             now.Add(-3 * time.Second),
 				IsPathMTUProbePacket: true,
-				Frames:               []*Frame{{Frame: &wire.PingFrame{}, OnLost: func(wire.Frame) { mtuPacketDeclaredLost = true }}},
+				Frames:               []Frame{{Frame: &wire.PingFrame{}, OnLost: func(wire.Frame) { mtuPacketDeclaredLost = true }}},
 			}))
 			handler.SentPacket(ackElicitingPacket(&Packet{PacketNumber: 2, SendTime: now.Add(-3 * time.Second)}))
 			ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 2, Largest: 2}}}
@@ -1341,7 +1341,7 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.SentPacket(&Packet{
 				PacketNumber:    13,
 				EncryptionLevel: protocol.EncryptionInitial,
-				Frames: []*Frame{
+				Frames: []Frame{
 					{Frame: &wire.CryptoFrame{Data: []byte("foobar")}, OnLost: func(wire.Frame) { lostInitial = true }},
 				},
 				Length: 100,
@@ -1350,7 +1350,7 @@ var _ = Describe("SentPacketHandler", func() {
 			handler.SentPacket(&Packet{
 				PacketNumber:    pn,
 				EncryptionLevel: protocol.Encryption0RTT,
-				Frames: []*Frame{
+				Frames: []Frame{
 					{Frame: &wire.StreamFrame{Data: []byte("foobar")}, OnLost: func(wire.Frame) { lost0RTT = true }},
 				},
 				Length: 999,

--- a/mock_frame_source_test.go
+++ b/mock_frame_source_test.go
@@ -36,10 +36,10 @@ func (m *MockFrameSource) EXPECT() *MockFrameSourceMockRecorder {
 }
 
 // AppendControlFrames mocks base method.
-func (m *MockFrameSource) AppendControlFrames(arg0 []*ackhandler.Frame, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) ([]*ackhandler.Frame, protocol.ByteCount) {
+func (m *MockFrameSource) AppendControlFrames(arg0 []ackhandler.Frame, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) ([]ackhandler.Frame, protocol.ByteCount) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppendControlFrames", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*ackhandler.Frame)
+	ret0, _ := ret[0].([]ackhandler.Frame)
 	ret1, _ := ret[1].(protocol.ByteCount)
 	return ret0, ret1
 }


### PR DESCRIPTION
Depends on #3833.

Now that STREAM frames use the `ackhandler.StreamFrame`, `ackhandler.Frame` is not used very often: only for control frames (ACKs are not saved in the `ackhandler` package anyway).

It makes more sense to pass them around by value, and not by pointer. This also allows us to get rid of the `sync.Pool` for this struct.