### PR TITLE
ci: fix coverage report

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: coverage.txt coverage-root.txt
+          files: coverage.txt,coverage-root.txt
           env_vars: OS=${{ matrix.os }}, GO=${{ matrix.go }}


### PR DESCRIPTION
I noticed that the coverage report is not working in quic-go since last week, due to:
https://github.com/quic-go/quic-go/blob/cec79d338c645522923c92ffc88fee580c711315/.github/workflows/unit.yml#L47
Actually we should use a comma instead of a space to separate files here.