### PR TITLE
ackhandler: optimize memory layout of ackhandler.Packet

### DIFF
--- a/internal/ackhandler/packet.go
+++ b/internal/ackhandler/packet.go
@@ -9,12 +9,12 @@ import (
 
 // A Packet is a packet
 type Packet struct {
+	SendTime        time.Time
 	PacketNumber    protocol.PacketNumber
 	Frames          []*Frame
 	LargestAcked    protocol.PacketNumber // InvalidPacketNumber if the packet doesn't contain an ACK
 	Length          protocol.ByteCount
 	EncryptionLevel protocol.EncryptionLevel
-	SendTime        time.Time
 
 	IsPathMTUProbePacket bool // We don't report the loss of Path MTU probe packets to the congestion controller.
 


### PR DESCRIPTION
Before: 88 bytes. After: 80 bytes.

As a followup to this PR, we can tackle https://github.com/quic-go/quic-go/issues/3843. This would bring the size down to 72 bytes.