### PR TITLE
fix comment claiming ParseConnectionID reuses the data slice

### DIFF
--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -13,8 +13,6 @@ import (
 )
 
 // ParseConnectionID parses the destination connection ID of a packet.
-// It uses the data slice for the connection ID.
-// That means that the connection ID must not be used after the packet buffer is released.
 func ParseConnectionID(data []byte, shortHeaderConnIDLen int) (protocol.ConnectionID, error) {
 	if len(data) == 0 {
 		return protocol.ConnectionID{}, io.EOF


### PR DESCRIPTION
This is protocol.ParseConnectionID. It copies data from b.
```
func ParseConnectionID(b []byte) ConnectionID {
	if len(b) > maxConnectionIDLen {
		panic("invalid conn id length")
	}
	var c ConnectionID
	c.l = uint8(len(b))
	copy(c.b[:c.l], b)
	return c
}
```

Feel free to close if this is too small etc. Apologies if this is just plain mistaken. 