### PR TITLE
packet packer: don't try packing a 0-RTT packet with only an ACK

### DIFF
--- a/packet_packer.go
+++ b/packet_packer.go
@@ -417,7 +417,7 @@ func (p *packetPacker) PackCoalescedPacket(onlyAck bool, v protocol.VersionNumbe
 			if oneRTTPayload.length > 0 {
 				size += p.shortHeaderPacketLength(connID, oneRTTPacketNumberLen, oneRTTPayload) + protocol.ByteCount(oneRTTSealer.Overhead())
 			}
-		} else if p.perspective == protocol.PerspectiveClient { // 0-RTT
+		} else if p.perspective == protocol.PerspectiveClient && !onlyAck { // 0-RTT packets can't contain ACK frames
 			var err error
 			zeroRTTSealer, err = p.cryptoSetup.Get0RTTSealer()
 			if err != nil && err != handshake.ErrKeysDropped && err != handshake.ErrKeysNotYetAvailable {

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -316,6 +316,12 @@ var _ = Describe("Packet packer", func() {
 				Expect(p.longHdrPackets[0].EncryptionLevel()).To(Equal(protocol.Encryption0RTT))
 				Expect(p.longHdrPackets[0].frames).To(Equal([]*ackhandler.Frame{cf}))
 			})
+
+			It("doesn't add an ACK-only 0-RTT packet", func() { // ACK frames cannot be sent in 0-RTT packets
+				p, err := packer.PackCoalescedPacket(true, protocol.Version1)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(p).To(BeNil())
+			})
 		})
 
 		Context("packing CONNECTION_CLOSE", func() {


### PR DESCRIPTION
0-RTT packets can't contain ACK frames. This was correctly reflected in the code path for packing a 0-RTT packet, but we would ignore the ACK-only flag when packing the coalesced packet, leading to a full-size 0-RTT packet being sent out when we're only allowed to send an ACK-only packet.