### PR TITLE
http3: set tls.Config.ServerName for outgoing requests, if unset

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -99,7 +99,6 @@ func newClient(hostname string, tlsConf *tls.Config, opts *roundTripperOpts, con
 			// It's ok if net.SplitHostPort returns an error - it could be a hostname/IP address without a port.
 			sni = hostname
 		}
-
 		tlsConf.ServerName = sni
 	}
 	// Replace existing ALPNs by H3

--- a/http3/client.go
+++ b/http3/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
 	"sync"
@@ -91,6 +92,15 @@ func newClient(hostname string, tlsConf *tls.Config, opts *roundTripperOpts, con
 		tlsConf = &tls.Config{}
 	} else {
 		tlsConf = tlsConf.Clone()
+	}
+	if tlsConf.ServerName == "" {
+		sni, _, err := net.SplitHostPort(hostname)
+		if err != nil {
+			// It's ok if net.SplitHostPort returns an error - it could be a hostname/IP address without a port.
+			sni = hostname
+		}
+
+		tlsConf.ServerName = sni
 	}
 	// Replace existing ALPNs by H3
 	tlsConf.NextProtos = []string{versionToALPN(conf.Versions[0])}

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -90,8 +90,8 @@ var _ = Describe("Client", func() {
 		Expect(dialAddrCalled).To(BeTrue())
 	})
 
-	It("set ServerName in the tls.Config, if not set", func() {
-		host := "foo.bar"
+	It("sets the ServerName in the tls.Config, if not set", func() {
+		const host = "foo.bar"
 		dialCalled := false
 		dialFunc := func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
 			Expect(tlsCfg.ServerName).To(Equal(host))

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -90,6 +90,22 @@ var _ = Describe("Client", func() {
 		Expect(dialAddrCalled).To(BeTrue())
 	})
 
+	It("set ServerName in the tls.Config, if not set", func() {
+		host := "foo.bar"
+		dialCalled := false
+		dialFunc := func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
+			Expect(tlsCfg.ServerName).To(Equal(host))
+			dialCalled = true
+			return nil, errors.New("test done")
+		}
+		client, err := newClient(host, nil, &roundTripperOpts{}, nil, dialFunc)
+		Expect(err).ToNot(HaveOccurred())
+		req, err := http.NewRequest("GET", "https://foo.bar", nil)
+		Expect(err).ToNot(HaveOccurred())
+		client.RoundTripOpt(req, RoundTripOpt{})
+		Expect(dialCalled).To(BeTrue())
+	})
+
 	It("uses the TLS config and QUIC config", func() {
 		tlsConf := &tls.Config{
 			ServerName: "foo.bar",


### PR DESCRIPTION
fix #3865
bug caused by: https://github.com/quic-go/quic-go/commit/d683b841c4aa8b8b1434ebd27cebc43be7c2ba16#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL231-L239
Copied this logic into http3 package.