### PR TITLE
ackhandler: apply logic from RFC 9000 to derive packet number length

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -701,16 +701,9 @@ func (h *sentPacketHandler) GetLossDetectionTimeout() time.Time {
 
 func (h *sentPacketHandler) PeekPacketNumber(encLevel protocol.EncryptionLevel) (protocol.PacketNumber, protocol.PacketNumberLen) {
 	pnSpace := h.getPacketNumberSpace(encLevel)
-
-	var lowestUnacked protocol.PacketNumber
-	if p := pnSpace.history.FirstOutstanding(); p != nil {
-		lowestUnacked = p.PacketNumber
-	} else {
-		lowestUnacked = pnSpace.largestAcked + 1
-	}
-
 	pn := pnSpace.pns.Peek()
-	return pn, protocol.GetPacketNumberLengthForHeader(pn, lowestUnacked)
+	// See section 17.1 of RFC 9000.
+	return pn, protocol.GetPacketNumberLengthForHeader(pn, pnSpace.largestAcked)
 }
 
 func (h *sentPacketHandler) PopPacketNumber(encLevel protocol.EncryptionLevel) protocol.PacketNumber {


### PR DESCRIPTION
Splitting this out of #3841.