### PR TITLE
ackhandler: be explicit about skipping packet numbers

### DIFF
--- a/internal/ackhandler/packet_number_generator_test.go
+++ b/internal/ackhandler/packet_number_generator_test.go
@@ -18,7 +18,9 @@ var _ = Describe("Sequential Packet Number Generator", func() {
 		for i := initialPN; i < initialPN+1000; i++ {
 			Expect(png.Peek()).To(Equal(i))
 			Expect(png.Peek()).To(Equal(i))
-			Expect(png.Pop()).To(Equal(i))
+			skipNext, pn := png.Pop()
+			Expect(skipNext).To(BeFalse())
+			Expect(pn).To(Equal(i))
 		}
 	})
 })
@@ -34,28 +36,38 @@ var _ = Describe("Skipping Packet Number Generator", func() {
 
 	It("can be initialized to return any first packet number", func() {
 		png := newSkippingPacketNumberGenerator(12345, initialPeriod, maxPeriod)
-		Expect(png.Pop()).To(Equal(protocol.PacketNumber(12345)))
+		_, pn := png.Pop()
+		Expect(pn).To(Equal(protocol.PacketNumber(12345)))
 	})
 
 	It("allows peeking", func() {
 		png := newSkippingPacketNumberGenerator(initialPN, initialPeriod, maxPeriod).(*skippingPacketNumberGenerator)
-		png.nextToSkip = 1000
 		Expect(png.Peek()).To(Equal(initialPN))
 		Expect(png.Peek()).To(Equal(initialPN))
-		Expect(png.Pop()).To(Equal(initialPN))
-		Expect(png.Peek()).To(Equal(initialPN + 1))
-		Expect(png.Peek()).To(Equal(initialPN + 1))
+		skipped, pn := png.Pop()
+		Expect(pn).To(Equal(initialPN))
+		next := initialPN + 1
+		if skipped {
+			next++
+		}
+		Expect(png.Peek()).To(Equal(next))
+		Expect(png.Peek()).To(Equal(next))
 	})
 
 	It("skips a packet number", func() {
 		png := newSkippingPacketNumberGenerator(initialPN, initialPeriod, maxPeriod)
 		var last protocol.PacketNumber
 		var skipped bool
-		for i := 0; i < 1000; i++ {
-			num := png.Pop()
-			if num > last+1 {
+		for i := 0; i < int(maxPeriod); i++ {
+			didSkip, num := png.Pop()
+			if didSkip {
 				skipped = true
+				_, nextNum := png.Pop()
+				Expect(nextNum).To(Equal(num + 1))
 				break
+			}
+			if i != 0 {
+				Expect(num).To(Equal(last + 1))
 			}
 			last = num
 		}
@@ -69,17 +81,15 @@ var _ = Describe("Skipping Packet Number Generator", func() {
 
 		for i := 0; i < rep; i++ {
 			png := newSkippingPacketNumberGenerator(initialPN, initialPeriod, maxPeriod)
-			last := initialPN
 			lastSkip := initialPN
 			for len(periods[i]) < len(expectedPeriods) {
-				next := png.Pop()
-				if next > last+1 {
-					skipped := next - 1
+				skipNext, next := png.Pop()
+				if skipNext {
+					skipped := next + 1
 					Expect(skipped).To(BeNumerically(">", lastSkip+1))
 					periods[i] = append(periods[i], skipped-lastSkip-1)
 					lastSkip = skipped
 				}
-				last = next
 			}
 		}
 


### PR DESCRIPTION
Depends on #3887.

This simplifies the logic in the packet history quite a bit. It also makes sure that we're using the packet number generator correctly.