### PR TITLE
ackhandler: unexport the packet struct

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1793,12 +1793,12 @@ func (s *connection) sendPackets(now time.Time) error {
 	// MTU probe packets per connection.
 	if s.handshakeConfirmed && s.mtuDiscoverer != nil && s.mtuDiscoverer.ShouldSendProbe(now) {
 		ping, size := s.mtuDiscoverer.GetPing()
-		p, buf, err := s.packer.PackMTUProbePacket(ping, size, now, s.version)
+		p, buf, err := s.packer.PackMTUProbePacket(ping, size, s.version)
 		if err != nil {
 			return err
 		}
 		s.logShortHeaderPacket(p.DestConnID, p.Ack, p.Frames, p.StreamFrames, p.PacketNumber, p.PacketNumberLen, p.KeyPhase, buf.Len(), false)
-		s.registerPackedShortHeaderPacket(p.Packet, now)
+		s.registerPackedShortHeaderPacket(p, now)
 		s.sendQueue.Send(buf, buf.Len())
 		// This is kind of a hack. We need to trigger sending again somehow.
 		s.pacingDeadline = deadlineSendImmediately
@@ -1811,7 +1811,7 @@ func (s *connection) sendPackets(now time.Time) error {
 	s.windowUpdateQueue.QueueAll()
 
 	if !s.handshakeConfirmed {
-		packet, err := s.packer.PackCoalescedPacket(false, s.mtuDiscoverer.CurrentSize(), now, s.version)
+		packet, err := s.packer.PackCoalescedPacket(false, s.mtuDiscoverer.CurrentSize(), s.version)
 		if err != nil || packet == nil {
 			return err
 		}
@@ -1929,7 +1929,7 @@ func (s *connection) resetPacingDeadline() {
 
 func (s *connection) maybeSendAckOnlyPacket(now time.Time) error {
 	if !s.handshakeConfirmed {
-		packet, err := s.packer.PackCoalescedPacket(true, s.mtuDiscoverer.CurrentSize(), now, s.version)
+		packet, err := s.packer.PackCoalescedPacket(true, s.mtuDiscoverer.CurrentSize(), s.version)
 		if err != nil {
 			return err
 		}
@@ -1940,7 +1940,7 @@ func (s *connection) maybeSendAckOnlyPacket(now time.Time) error {
 		return nil
 	}
 
-	p, buf, err := s.packer.PackAckOnlyPacket(s.mtuDiscoverer.CurrentSize(), now, s.version)
+	p, buf, err := s.packer.PackAckOnlyPacket(s.mtuDiscoverer.CurrentSize(), s.version)
 	if err != nil {
 		if err == errNothingToPack {
 			return nil
@@ -1948,7 +1948,7 @@ func (s *connection) maybeSendAckOnlyPacket(now time.Time) error {
 		return err
 	}
 	s.logShortHeaderPacket(p.DestConnID, p.Ack, p.Frames, p.StreamFrames, p.PacketNumber, p.PacketNumberLen, p.KeyPhase, buf.Len(), false)
-	s.registerPackedShortHeaderPacket(p.Packet, now)
+	s.registerPackedShortHeaderPacket(p, now)
 	s.sendQueue.Send(buf, buf.Len())
 	return nil
 }
@@ -1962,7 +1962,7 @@ func (s *connection) sendProbePacket(encLevel protocol.EncryptionLevel, now time
 			break
 		}
 		var err error
-		packet, err = s.packer.MaybePackProbePacket(encLevel, s.mtuDiscoverer.CurrentSize(), now, s.version)
+		packet, err = s.packer.MaybePackProbePacket(encLevel, s.mtuDiscoverer.CurrentSize(), s.version)
 		if err != nil {
 			return err
 		}
@@ -1983,7 +1983,7 @@ func (s *connection) sendProbePacket(encLevel protocol.EncryptionLevel, now time
 			panic("unexpected encryption level")
 		}
 		var err error
-		packet, err = s.packer.MaybePackProbePacket(encLevel, s.mtuDiscoverer.CurrentSize(), now, s.version)
+		packet, err = s.packer.MaybePackProbePacket(encLevel, s.mtuDiscoverer.CurrentSize(), s.version)
 		if err != nil {
 			return err
 		}
@@ -1999,22 +1999,26 @@ func (s *connection) sendProbePacket(encLevel protocol.EncryptionLevel, now time
 // If there was nothing to pack, the returned size is 0.
 func (s *connection) appendPacket(buf *packetBuffer, maxSize protocol.ByteCount, now time.Time) (protocol.ByteCount, error) {
 	startLen := buf.Len()
-	p, err := s.packer.AppendPacket(buf, maxSize, now, s.version)
+	p, err := s.packer.AppendPacket(buf, maxSize, s.version)
 	if err != nil {
 		return 0, err
 	}
 	size := buf.Len() - startLen
 	s.logShortHeaderPacket(p.DestConnID, p.Ack, p.Frames, p.StreamFrames, p.PacketNumber, p.PacketNumberLen, p.KeyPhase, size, false)
-	s.registerPackedShortHeaderPacket(p.Packet, now)
+	s.registerPackedShortHeaderPacket(p, now)
 	return size, nil
 }
 
-func (s *connection) registerPackedShortHeaderPacket(p *ackhandler.Packet, now time.Time) {
+func (s *connection) registerPackedShortHeaderPacket(p shortHeaderPacket, now time.Time) {
 	if s.firstAckElicitingPacketAfterIdleSentTime.IsZero() && (len(p.StreamFrames) > 0 || ackhandler.HasAckElicitingFrames(p.Frames)) {
 		s.firstAckElicitingPacketAfterIdleSentTime = now
 	}
 
-	s.sentPacketHandler.SentPacket(p)
+	largestAcked := protocol.InvalidPacketNumber
+	if p.Ack != nil {
+		largestAcked = p.Ack.LargestAcked()
+	}
+	s.sentPacketHandler.SentPacket(now, p.PacketNumber, largestAcked, p.StreamFrames, p.Frames, protocol.Encryption1RTT, p.Length, p.IsPathMTUProbePacket)
 	s.connIDManager.SentPacket()
 }
 
@@ -2024,13 +2028,21 @@ func (s *connection) sendPackedCoalescedPacket(packet *coalescedPacket, now time
 		if s.firstAckElicitingPacketAfterIdleSentTime.IsZero() && p.IsAckEliciting() {
 			s.firstAckElicitingPacketAfterIdleSentTime = now
 		}
-		s.sentPacketHandler.SentPacket(p.ToAckHandlerPacket(now, s.retransmissionQueue))
+		largestAcked := protocol.InvalidPacketNumber
+		if p.ack != nil {
+			largestAcked = p.ack.LargestAcked()
+		}
+		s.sentPacketHandler.SentPacket(now, p.header.PacketNumber, largestAcked, p.streamFrames, p.frames, p.EncryptionLevel(), p.length, false)
 	}
 	if p := packet.shortHdrPacket; p != nil {
 		if s.firstAckElicitingPacketAfterIdleSentTime.IsZero() && p.IsAckEliciting() {
 			s.firstAckElicitingPacketAfterIdleSentTime = now
 		}
-		s.sentPacketHandler.SentPacket(p.Packet)
+		largestAcked := protocol.InvalidPacketNumber
+		if p.Ack != nil {
+			largestAcked = p.Ack.LargestAcked()
+		}
+		s.sentPacketHandler.SentPacket(now, p.PacketNumber, largestAcked, p.StreamFrames, p.Frames, protocol.Encryption1RTT, p.Length, p.IsPathMTUProbePacket)
 	}
 	s.connIDManager.SentPacket()
 	s.sendQueue.Send(packet.buffer, packet.buffer.Len())
@@ -2042,14 +2054,14 @@ func (s *connection) sendConnectionClose(e error) ([]byte, error) {
 	var transportErr *qerr.TransportError
 	var applicationErr *qerr.ApplicationError
 	if errors.As(e, &transportErr) {
-		packet, err = s.packer.PackConnectionClose(transportErr, s.mtuDiscoverer.CurrentSize(), time.Now(), s.version)
+		packet, err = s.packer.PackConnectionClose(transportErr, s.mtuDiscoverer.CurrentSize(), s.version)
 	} else if errors.As(e, &applicationErr) {
-		packet, err = s.packer.PackApplicationClose(applicationErr, s.mtuDiscoverer.CurrentSize(), time.Now(), s.version)
+		packet, err = s.packer.PackApplicationClose(applicationErr, s.mtuDiscoverer.CurrentSize(), s.version)
 	} else {
 		packet, err = s.packer.PackConnectionClose(&qerr.TransportError{
 			ErrorCode:    qerr.InternalError,
 			ErrorMessage: fmt.Sprintf("connection BUG: unspecified error type (msg: %s)", e.Error()),
-		}, s.mtuDiscoverer.CurrentSize(), time.Now(), s.version)
+		}, s.mtuDiscoverer.CurrentSize(), s.version)
 	}
 	if err != nil {
 		return nil, err

--- a/connection.go
+++ b/connection.go
@@ -1971,17 +1971,7 @@ func (s *connection) sendProbePacket(encLevel protocol.EncryptionLevel, now time
 		}
 	}
 	if packet == nil {
-		//nolint:exhaustive // Cannot send probe packets for 0-RTT.
-		switch encLevel {
-		case protocol.EncryptionInitial:
-			s.retransmissionQueue.AddInitial(&wire.PingFrame{})
-		case protocol.EncryptionHandshake:
-			s.retransmissionQueue.AddHandshake(&wire.PingFrame{})
-		case protocol.Encryption1RTT:
-			s.retransmissionQueue.AddAppData(&wire.PingFrame{})
-		default:
-			panic("unexpected encryption level")
-		}
+		s.retransmissionQueue.AddPing(encLevel)
 		var err error
 		packet, err = s.packer.MaybePackProbePacket(encLevel, s.mtuDiscoverer.CurrentSize(), s.version)
 		if err != nil {

--- a/internal/ackhandler/interfaces.go
+++ b/internal/ackhandler/interfaces.go
@@ -10,7 +10,7 @@ import (
 // SentPacketHandler handles ACKs received for outgoing packets
 type SentPacketHandler interface {
 	// SentPacket may modify the packet
-	SentPacket(packet *Packet)
+	SentPacket(t time.Time, pn, largestAcked protocol.PacketNumber, streamFrames []StreamFrame, frames []Frame, encLevel protocol.EncryptionLevel, size protocol.ByteCount, isPathMTUProbePacket bool)
 	// ReceivedAck processes an ACK frame.
 	// It does not store a copy of the frame.
 	ReceivedAck(f *wire.AckFrame, encLevel protocol.EncryptionLevel, recvTime time.Time) (bool /* 1-RTT packet acked */, error)

--- a/internal/ackhandler/packet.go
+++ b/internal/ackhandler/packet.go
@@ -8,7 +8,7 @@ import (
 )
 
 // A Packet is a packet
-type Packet struct {
+type packet struct {
 	SendTime        time.Time
 	PacketNumber    protocol.PacketNumber
 	StreamFrames    []StreamFrame
@@ -24,14 +24,14 @@ type Packet struct {
 	skippedPacket           bool
 }
 
-func (p *Packet) outstanding() bool {
+func (p *packet) outstanding() bool {
 	return !p.declaredLost && !p.skippedPacket && !p.IsPathMTUProbePacket
 }
 
-var packetPool = sync.Pool{New: func() any { return &Packet{} }}
+var packetPool = sync.Pool{New: func() any { return &packet{} }}
 
-func GetPacket() *Packet {
-	p := packetPool.Get().(*Packet)
+func getPacket() *packet {
+	p := packetPool.Get().(*packet)
 	p.PacketNumber = 0
 	p.StreamFrames = nil
 	p.Frames = nil
@@ -48,7 +48,7 @@ func GetPacket() *Packet {
 
 // We currently only return Packets back into the pool when they're acknowledged (not when they're lost).
 // This simplifies the code, and gives the vast majority of the performance benefit we can gain from using the pool.
-func putPacket(p *Packet) {
+func putPacket(p *packet) {
 	p.Frames = nil
 	p.StreamFrames = nil
 	packetPool.Put(p)

--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -7,7 +7,7 @@ import (
 )
 
 type sentPacketHistory struct {
-	packets []*Packet
+	packets []*packet
 
 	numOutstanding int
 
@@ -16,7 +16,7 @@ type sentPacketHistory struct {
 
 func newSentPacketHistory() *sentPacketHistory {
 	return &sentPacketHistory{
-		packets:             make([]*Packet, 0, 32),
+		packets:             make([]*packet, 0, 32),
 		highestPacketNumber: protocol.InvalidPacketNumber,
 	}
 }
@@ -32,7 +32,7 @@ func (h *sentPacketHistory) checkSequentialPacketNumberUse(pn protocol.PacketNum
 func (h *sentPacketHistory) SkippedPacket(pn protocol.PacketNumber) {
 	h.checkSequentialPacketNumberUse(pn)
 	h.highestPacketNumber = pn
-	h.packets = append(h.packets, &Packet{
+	h.packets = append(h.packets, &packet{
 		PacketNumber:  pn,
 		skippedPacket: true,
 	})
@@ -46,7 +46,7 @@ func (h *sentPacketHistory) SentNonAckElicitingPacket(pn protocol.PacketNumber) 
 	}
 }
 
-func (h *sentPacketHistory) SentAckElicitingPacket(p *Packet) {
+func (h *sentPacketHistory) SentAckElicitingPacket(p *packet) {
 	h.checkSequentialPacketNumberUse(p.PacketNumber)
 	h.highestPacketNumber = p.PacketNumber
 	h.packets = append(h.packets, p)
@@ -56,7 +56,7 @@ func (h *sentPacketHistory) SentAckElicitingPacket(p *Packet) {
 }
 
 // Iterate iterates through all packets.
-func (h *sentPacketHistory) Iterate(cb func(*Packet) (cont bool, err error)) error {
+func (h *sentPacketHistory) Iterate(cb func(*packet) (cont bool, err error)) error {
 	for _, p := range h.packets {
 		if p == nil {
 			continue
@@ -73,7 +73,7 @@ func (h *sentPacketHistory) Iterate(cb func(*Packet) (cont bool, err error)) err
 }
 
 // FirstOutstanding returns the first outstanding packet.
-func (h *sentPacketHistory) FirstOutstanding() *Packet {
+func (h *sentPacketHistory) FirstOutstanding() *packet {
 	if !h.HasOutstandingPackets() {
 		return nil
 	}

--- a/internal/ackhandler/sent_packet_history_test.go
+++ b/internal/ackhandler/sent_packet_history_test.go
@@ -46,9 +46,9 @@ var _ = Describe("SentPacketHistory", func() {
 	})
 
 	It("saves sent packets", func() {
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 0})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 1})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 2})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 0})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 1})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 2})
 		expectInHistory([]protocol.PacketNumber{0, 1, 2})
 		expectSkippedInHistory(nil)
 	})
@@ -56,34 +56,34 @@ var _ = Describe("SentPacketHistory", func() {
 	It("saves non-ack-eliciting packets", func() {
 		now := time.Now()
 		hist.SentNonAckElicitingPacket(0)
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 1, SendTime: now})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 1, SendTime: now})
 		hist.SentNonAckElicitingPacket(2)
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 3, SendTime: now})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 3, SendTime: now})
 		expectInHistory([]protocol.PacketNumber{1, 3})
 	})
 
 	It("saves sent packets, with skipped packet number", func() {
 		hist.SkippedPacket(0)
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 1})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 1})
 		hist.SkippedPacket(2)
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 3})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 4})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 3})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 4})
 		expectInHistory([]protocol.PacketNumber{1, 3, 4})
 		expectSkippedInHistory([]protocol.PacketNumber{0, 2})
 	})
 
 	It("doesn't save non-ack-eliciting packets", func() {
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 1})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 1})
 		hist.SkippedPacket(2)
 		hist.SentNonAckElicitingPacket(3)
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 4})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 4})
 		expectInHistory([]protocol.PacketNumber{1, 4})
 	})
 
 	It("gets the length", func() {
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 0})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 1})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 2})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 0})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 1})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 2})
 		Expect(hist.Len()).To(Equal(3))
 	})
 
@@ -93,8 +93,8 @@ var _ = Describe("SentPacketHistory", func() {
 		})
 
 		It("gets the first outstanding packet", func() {
-			hist.SentAckElicitingPacket(&Packet{PacketNumber: 2})
-			hist.SentAckElicitingPacket(&Packet{PacketNumber: 3})
+			hist.SentAckElicitingPacket(&packet{PacketNumber: 2})
+			hist.SentAckElicitingPacket(&packet{PacketNumber: 3})
 			front := hist.FirstOutstanding()
 			Expect(front).ToNot(BeNil())
 			Expect(front.PacketNumber).To(Equal(protocol.PacketNumber(2)))
@@ -105,9 +105,9 @@ var _ = Describe("SentPacketHistory", func() {
 		})
 
 		It("doesn't regard path MTU packets as outstanding", func() {
-			hist.SentAckElicitingPacket(&Packet{PacketNumber: 2})
+			hist.SentAckElicitingPacket(&packet{PacketNumber: 2})
 			hist.SkippedPacket(3)
-			hist.SentAckElicitingPacket(&Packet{PacketNumber: 4, IsPathMTUProbePacket: true})
+			hist.SentAckElicitingPacket(&packet{PacketNumber: 4, IsPathMTUProbePacket: true})
 			front := hist.FirstOutstanding()
 			Expect(front).ToNot(BeNil())
 			Expect(front.PacketNumber).To(Equal(protocol.PacketNumber(2)))
@@ -115,20 +115,20 @@ var _ = Describe("SentPacketHistory", func() {
 	})
 
 	It("removes packets", func() {
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 0})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 1})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 2})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 3})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 0})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 1})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 2})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 3})
 		Expect(hist.Remove(2)).To(Succeed())
 		expectInHistory([]protocol.PacketNumber{0, 1, 3})
 	})
 
 	It("also removes skipped packets before the removed packet", func() {
 		hist.SkippedPacket(0)
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 1})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 1})
 		hist.SkippedPacket(2)
 		hist.SkippedPacket(3)
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 4})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 4})
 		expectSkippedInHistory([]protocol.PacketNumber{0, 2, 3})
 		Expect(hist.Remove(4)).To(Succeed())
 		expectSkippedInHistory([]protocol.PacketNumber{0})
@@ -139,57 +139,57 @@ var _ = Describe("SentPacketHistory", func() {
 	})
 
 	It("panics on non-sequential packet number use", func() {
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 100})
-		Expect(func() { hist.SentAckElicitingPacket(&Packet{PacketNumber: 102}) }).To(Panic())
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 100})
+		Expect(func() { hist.SentAckElicitingPacket(&packet{PacketNumber: 102}) }).To(Panic())
 	})
 
 	It("removes and adds packets", func() {
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 0})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 1})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 0})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 1})
 		hist.SkippedPacket(2)
 		hist.SkippedPacket(3)
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 4})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 4})
 		hist.SkippedPacket(5)
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 6})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 6})
 		Expect(hist.Remove(0)).To(Succeed())
 		Expect(hist.Remove(1)).To(Succeed())
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 7})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 7})
 		expectInHistory([]protocol.PacketNumber{4, 6, 7})
 	})
 
 	It("removes the last packet, then adds more", func() {
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 0})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 1})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 0})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 1})
 		Expect(hist.Remove(0)).To(Succeed())
 		Expect(hist.Remove(1)).To(Succeed())
 		expectInHistory([]protocol.PacketNumber{})
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 2})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 2})
 		expectInHistory([]protocol.PacketNumber{2})
 		Expect(hist.Remove(2)).To(Succeed())
 		expectInHistory(nil)
 	})
 
 	It("errors when trying to remove a non existing packet", func() {
-		hist.SentAckElicitingPacket(&Packet{PacketNumber: 1})
+		hist.SentAckElicitingPacket(&packet{PacketNumber: 1})
 		Expect(hist.Remove(2)).To(MatchError("packet 2 not found in sent packet history"))
 	})
 
 	Context("iterating", func() {
 		BeforeEach(func() {
 			hist.SkippedPacket(0)
-			hist.SentAckElicitingPacket(&Packet{PacketNumber: 1})
+			hist.SentAckElicitingPacket(&packet{PacketNumber: 1})
 			hist.SkippedPacket(2)
 			hist.SkippedPacket(3)
-			hist.SentAckElicitingPacket(&Packet{PacketNumber: 4})
+			hist.SentAckElicitingPacket(&packet{PacketNumber: 4})
 			hist.SkippedPacket(5)
 			hist.SkippedPacket(6)
 			hist.SkippedPacket(7)
-			hist.SentAckElicitingPacket(&Packet{PacketNumber: 8})
+			hist.SentAckElicitingPacket(&packet{PacketNumber: 8})
 		})
 
 		It("iterates over all packets", func() {
 			var iterations []protocol.PacketNumber
-			Expect(hist.Iterate(func(p *Packet) (bool, error) {
+			Expect(hist.Iterate(func(p *packet) (bool, error) {
 				if p.skippedPacket {
 					return true, nil
 				}
@@ -201,7 +201,7 @@ var _ = Describe("SentPacketHistory", func() {
 
 		It("also iterates over skipped packets", func() {
 			var packets, skippedPackets, allPackets []protocol.PacketNumber
-			Expect(hist.Iterate(func(p *Packet) (bool, error) {
+			Expect(hist.Iterate(func(p *packet) (bool, error) {
 				if p.skippedPacket {
 					skippedPackets = append(skippedPackets, p.PacketNumber)
 				} else {
@@ -217,7 +217,7 @@ var _ = Describe("SentPacketHistory", func() {
 
 		It("stops iterating", func() {
 			var iterations []protocol.PacketNumber
-			Expect(hist.Iterate(func(p *Packet) (bool, error) {
+			Expect(hist.Iterate(func(p *packet) (bool, error) {
 				if p.skippedPacket {
 					return true, nil
 				}
@@ -230,7 +230,7 @@ var _ = Describe("SentPacketHistory", func() {
 		It("returns the error", func() {
 			testErr := errors.New("test error")
 			var iterations []protocol.PacketNumber
-			Expect(hist.Iterate(func(p *Packet) (bool, error) {
+			Expect(hist.Iterate(func(p *packet) (bool, error) {
 				if p.skippedPacket {
 					return true, nil
 				}
@@ -246,7 +246,7 @@ var _ = Describe("SentPacketHistory", func() {
 		It("doesn't iterate over deleted packets", func() {
 			hist.Remove(4)
 			var iterations []protocol.PacketNumber
-			Expect(hist.Iterate(func(p *Packet) (bool, error) {
+			Expect(hist.Iterate(func(p *packet) (bool, error) {
 				if p.skippedPacket {
 					return true, nil
 				}
@@ -261,7 +261,7 @@ var _ = Describe("SentPacketHistory", func() {
 
 		It("allows deletions", func() {
 			var iterations []protocol.PacketNumber
-			Expect(hist.Iterate(func(p *Packet) (bool, error) {
+			Expect(hist.Iterate(func(p *packet) (bool, error) {
 				if p.skippedPacket {
 					return true, nil
 				}
@@ -279,12 +279,12 @@ var _ = Describe("SentPacketHistory", func() {
 	Context("outstanding packets", func() {
 		It("says if it has outstanding packets", func() {
 			Expect(hist.HasOutstandingPackets()).To(BeFalse())
-			hist.SentAckElicitingPacket(&Packet{EncryptionLevel: protocol.Encryption1RTT, PacketNumber: 0})
+			hist.SentAckElicitingPacket(&packet{EncryptionLevel: protocol.Encryption1RTT, PacketNumber: 0})
 			Expect(hist.HasOutstandingPackets()).To(BeTrue())
 		})
 
 		It("accounts for deleted packets", func() {
-			hist.SentAckElicitingPacket(&Packet{
+			hist.SentAckElicitingPacket(&packet{
 				PacketNumber:    10,
 				EncryptionLevel: protocol.Encryption1RTT,
 			})
@@ -294,11 +294,11 @@ var _ = Describe("SentPacketHistory", func() {
 		})
 
 		It("counts the number of packets", func() {
-			hist.SentAckElicitingPacket(&Packet{
+			hist.SentAckElicitingPacket(&packet{
 				PacketNumber:    10,
 				EncryptionLevel: protocol.Encryption1RTT,
 			})
-			hist.SentAckElicitingPacket(&Packet{
+			hist.SentAckElicitingPacket(&packet{
 				PacketNumber:    11,
 				EncryptionLevel: protocol.Encryption1RTT,
 			})

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -176,15 +176,15 @@ func (mr *MockSentPacketHandlerMockRecorder) SendMode(arg0 interface{}) *gomock.
 }
 
 // SentPacket mocks base method.
-func (m *MockSentPacketHandler) SentPacket(arg0 *ackhandler.Packet) {
+func (m *MockSentPacketHandler) SentPacket(arg0 time.Time, arg1, arg2 protocol.PacketNumber, arg3 []ackhandler.StreamFrame, arg4 []ackhandler.Frame, arg5 protocol.EncryptionLevel, arg6 protocol.ByteCount, arg7 bool) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SentPacket", arg0)
+	m.ctrl.Call(m, "SentPacket", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // SentPacket indicates an expected call of SentPacket.
-func (mr *MockSentPacketHandlerMockRecorder) SentPacket(arg0 interface{}) *gomock.Call {
+func (mr *MockSentPacketHandlerMockRecorder) SentPacket(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SentPacket", reflect.TypeOf((*MockSentPacketHandler)(nil).SentPacket), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SentPacket", reflect.TypeOf((*MockSentPacketHandler)(nil).SentPacket), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // SetHandshakeConfirmed mocks base method.

--- a/mock_packer_test.go
+++ b/mock_packer_test.go
@@ -6,7 +6,6 @@ package quic
 
 import (
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	ackhandler "github.com/quic-go/quic-go/internal/ackhandler"
@@ -38,39 +37,39 @@ func (m *MockPacker) EXPECT() *MockPackerMockRecorder {
 }
 
 // AppendPacket mocks base method.
-func (m *MockPacker) AppendPacket(arg0 *packetBuffer, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (shortHeaderPacket, error) {
+func (m *MockPacker) AppendPacket(arg0 *packetBuffer, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (shortHeaderPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendPacket", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AppendPacket", arg0, arg1, arg2)
 	ret0, _ := ret[0].(shortHeaderPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AppendPacket indicates an expected call of AppendPacket.
-func (mr *MockPackerMockRecorder) AppendPacket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) AppendPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendPacket", reflect.TypeOf((*MockPacker)(nil).AppendPacket), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendPacket", reflect.TypeOf((*MockPacker)(nil).AppendPacket), arg0, arg1, arg2)
 }
 
 // MaybePackProbePacket mocks base method.
-func (m *MockPacker) MaybePackProbePacket(arg0 protocol.EncryptionLevel, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (*coalescedPacket, error) {
+func (m *MockPacker) MaybePackProbePacket(arg0 protocol.EncryptionLevel, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MaybePackProbePacket", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "MaybePackProbePacket", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MaybePackProbePacket indicates an expected call of MaybePackProbePacket.
-func (mr *MockPackerMockRecorder) MaybePackProbePacket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) MaybePackProbePacket(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybePackProbePacket", reflect.TypeOf((*MockPacker)(nil).MaybePackProbePacket), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybePackProbePacket", reflect.TypeOf((*MockPacker)(nil).MaybePackProbePacket), arg0, arg1, arg2)
 }
 
 // PackAckOnlyPacket mocks base method.
-func (m *MockPacker) PackAckOnlyPacket(arg0 protocol.ByteCount, arg1 time.Time, arg2 protocol.VersionNumber) (shortHeaderPacket, *packetBuffer, error) {
+func (m *MockPacker) PackAckOnlyPacket(arg0 protocol.ByteCount, arg1 protocol.VersionNumber) (shortHeaderPacket, *packetBuffer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackAckOnlyPacket", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PackAckOnlyPacket", arg0, arg1)
 	ret0, _ := ret[0].(shortHeaderPacket)
 	ret1, _ := ret[1].(*packetBuffer)
 	ret2, _ := ret[2].(error)
@@ -78,60 +77,60 @@ func (m *MockPacker) PackAckOnlyPacket(arg0 protocol.ByteCount, arg1 time.Time, 
 }
 
 // PackAckOnlyPacket indicates an expected call of PackAckOnlyPacket.
-func (mr *MockPackerMockRecorder) PackAckOnlyPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackAckOnlyPacket(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackAckOnlyPacket", reflect.TypeOf((*MockPacker)(nil).PackAckOnlyPacket), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackAckOnlyPacket", reflect.TypeOf((*MockPacker)(nil).PackAckOnlyPacket), arg0, arg1)
 }
 
 // PackApplicationClose mocks base method.
-func (m *MockPacker) PackApplicationClose(arg0 *qerr.ApplicationError, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (*coalescedPacket, error) {
+func (m *MockPacker) PackApplicationClose(arg0 *qerr.ApplicationError, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackApplicationClose", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "PackApplicationClose", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PackApplicationClose indicates an expected call of PackApplicationClose.
-func (mr *MockPackerMockRecorder) PackApplicationClose(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackApplicationClose(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackApplicationClose", reflect.TypeOf((*MockPacker)(nil).PackApplicationClose), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackApplicationClose", reflect.TypeOf((*MockPacker)(nil).PackApplicationClose), arg0, arg1, arg2)
 }
 
 // PackCoalescedPacket mocks base method.
-func (m *MockPacker) PackCoalescedPacket(arg0 bool, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (*coalescedPacket, error) {
+func (m *MockPacker) PackCoalescedPacket(arg0 bool, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackCoalescedPacket", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "PackCoalescedPacket", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PackCoalescedPacket indicates an expected call of PackCoalescedPacket.
-func (mr *MockPackerMockRecorder) PackCoalescedPacket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackCoalescedPacket(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackCoalescedPacket", reflect.TypeOf((*MockPacker)(nil).PackCoalescedPacket), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackCoalescedPacket", reflect.TypeOf((*MockPacker)(nil).PackCoalescedPacket), arg0, arg1, arg2)
 }
 
 // PackConnectionClose mocks base method.
-func (m *MockPacker) PackConnectionClose(arg0 *qerr.TransportError, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (*coalescedPacket, error) {
+func (m *MockPacker) PackConnectionClose(arg0 *qerr.TransportError, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackConnectionClose", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "PackConnectionClose", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*coalescedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PackConnectionClose indicates an expected call of PackConnectionClose.
-func (mr *MockPackerMockRecorder) PackConnectionClose(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackConnectionClose(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackConnectionClose", reflect.TypeOf((*MockPacker)(nil).PackConnectionClose), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackConnectionClose", reflect.TypeOf((*MockPacker)(nil).PackConnectionClose), arg0, arg1, arg2)
 }
 
 // PackMTUProbePacket mocks base method.
-func (m *MockPacker) PackMTUProbePacket(arg0 ackhandler.Frame, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.VersionNumber) (shortHeaderPacket, *packetBuffer, error) {
+func (m *MockPacker) PackMTUProbePacket(arg0 ackhandler.Frame, arg1 protocol.ByteCount, arg2 protocol.VersionNumber) (shortHeaderPacket, *packetBuffer, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackMTUProbePacket", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "PackMTUProbePacket", arg0, arg1, arg2)
 	ret0, _ := ret[0].(shortHeaderPacket)
 	ret1, _ := ret[1].(*packetBuffer)
 	ret2, _ := ret[2].(error)
@@ -139,9 +138,9 @@ func (m *MockPacker) PackMTUProbePacket(arg0 ackhandler.Frame, arg1 protocol.Byt
 }
 
 // PackMTUProbePacket indicates an expected call of PackMTUProbePacket.
-func (mr *MockPackerMockRecorder) PackMTUProbePacket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockPackerMockRecorder) PackMTUProbePacket(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackMTUProbePacket", reflect.TypeOf((*MockPacker)(nil).PackMTUProbePacket), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackMTUProbePacket", reflect.TypeOf((*MockPacker)(nil).PackMTUProbePacket), arg0, arg1, arg2)
 }
 
 // SetToken mocks base method.

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Packet packer", func() {
 			expectAppendControlFrames()
 			f := &wire.StreamFrame{Data: []byte{0xde, 0xca, 0xfb, 0xad}}
 			expectAppendStreamFrames(ackhandler.StreamFrame{Frame: f})
-			p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+			p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(p).ToNot(BeNil())
 			Expect(p.longHdrPackets).To(BeEmpty())
@@ -207,7 +207,7 @@ var _ = Describe("Packet packer", func() {
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionInitial, true)
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionHandshake, true)
 				ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, true)
-				p, err := packer.PackCoalescedPacket(true, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(true, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p).To(BeNil())
 			})
@@ -219,7 +219,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().GetInitialSealer().Return(getSealer(), nil)
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 10}}}
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionInitial, true).Return(ack)
-				p, err := packer.PackCoalescedPacket(true, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(true, maxPacketSize, protocol.Version1)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(p).ToNot(BeNil())
 				Expect(p.longHdrPackets).To(HaveLen(1))
@@ -236,7 +236,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().GetInitialSealer().Return(getSealer(), nil)
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 10}}}
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionInitial, true).Return(ack)
-				p, err := packer.PackCoalescedPacket(true, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(true, maxPacketSize, protocol.Version1)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(p).ToNot(BeNil())
 				Expect(p.longHdrPackets).To(HaveLen(1))
@@ -256,7 +256,7 @@ var _ = Describe("Packet packer", func() {
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 10}}}
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionHandshake, true)
 				ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, true).Return(ack)
-				p, err := packer.PackCoalescedPacket(true, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(true, maxPacketSize, protocol.Version1)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(p).ToNot(BeNil())
 				Expect(p.longHdrPackets).To(BeEmpty())
@@ -272,7 +272,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().Get1RTTSealer().Return(getSealer(), nil)
 				ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 10}}}
 				ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, true).Return(ack)
-				p, buffer, err := packer.PackAckOnlyPacket(maxPacketSize, time.Now(), protocol.Version1)
+				p, buffer, err := packer.PackAckOnlyPacket(maxPacketSize, protocol.Version1)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(p).ToNot(BeNil())
 				Expect(p.Ack).To(Equal(ack))
@@ -308,17 +308,19 @@ var _ = Describe("Packet packer", func() {
 				framer.EXPECT().AppendStreamFrames(gomock.Any(), gomock.Any(), protocol.Version1).DoAndReturn(func(frames []ackhandler.StreamFrame, _ protocol.ByteCount, _ protocol.VersionNumber) ([]ackhandler.StreamFrame, protocol.ByteCount) {
 					return frames, 0
 				})
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(p).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(1))
 				Expect(p.longHdrPackets[0].header.Type).To(Equal(protocol.PacketType0RTT))
 				Expect(p.longHdrPackets[0].EncryptionLevel()).To(Equal(protocol.Encryption0RTT))
-				Expect(p.longHdrPackets[0].frames).To(Equal([]ackhandler.Frame{cf}))
+				Expect(p.longHdrPackets[0].frames).To(HaveLen(1))
+				Expect(p.longHdrPackets[0].frames[0].Frame).To(Equal(cf.Frame))
+				Expect(p.longHdrPackets[0].frames[0].Handler).ToNot(BeNil())
 			})
 
 			It("doesn't add an ACK-only 0-RTT packet", func() { // ACK frames cannot be sent in 0-RTT packets
-				p, err := packer.PackCoalescedPacket(true, protocol.MaxByteCount, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(true, protocol.MaxByteCount, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p).To(BeNil())
 			})
@@ -333,7 +335,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().Get1RTTSealer().Return(nil, handshake.ErrKeysNotYetAvailable)
 				quicErr := qerr.NewLocalCryptoError(0x42, "crypto error")
 				quicErr.FrameType = 0x1234
-				p, err := packer.PackConnectionClose(quicErr, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackConnectionClose(quicErr, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(1))
 				Expect(p.longHdrPackets[0].header.Type).To(Equal(protocol.PacketTypeHandshake))
@@ -353,17 +355,15 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().GetHandshakeSealer().Return(nil, handshake.ErrKeysDropped)
 				sealingManager.EXPECT().Get1RTTSealer().Return(getSealer(), nil)
 				// expect no framer.PopStreamFrames
-				now := time.Now()
 				p, err := packer.PackConnectionClose(&qerr.TransportError{
 					ErrorCode:    qerr.CryptoBufferExceeded,
 					ErrorMessage: "test error",
-				}, maxPacketSize, now, protocol.Version1)
+				}, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(BeEmpty())
 				Expect(p.shortHdrPacket.Frames).To(HaveLen(1))
 				Expect(p.shortHdrPacket.Frames[0].Frame).To(BeAssignableToTypeOf(&wire.ConnectionCloseFrame{}))
 				ccf := p.shortHdrPacket.Frames[0].Frame.(*wire.ConnectionCloseFrame)
-				Expect(p.shortHdrPacket.Packet.SendTime).To(Equal(now))
 				Expect(ccf.IsApplicationError).To(BeFalse())
 				Expect(ccf.ErrorCode).To(BeEquivalentTo(qerr.CryptoBufferExceeded))
 				Expect(ccf.ReasonPhrase).To(Equal("test error"))
@@ -382,7 +382,7 @@ var _ = Describe("Packet packer", func() {
 				p, err := packer.PackApplicationClose(&qerr.ApplicationError{
 					ErrorCode:    0x1337,
 					ErrorMessage: "test error",
-				}, maxPacketSize, time.Now(), protocol.Version1)
+				}, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(2))
 				Expect(p.longHdrPackets[0].header.Type).To(Equal(protocol.PacketTypeInitial))
@@ -424,7 +424,7 @@ var _ = Describe("Packet packer", func() {
 				p, err := packer.PackApplicationClose(&qerr.ApplicationError{
 					ErrorCode:    0x1337,
 					ErrorMessage: "test error",
-				}, maxPacketSize, time.Now(), protocol.Version1)
+				}, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(1))
 				Expect(p.buffer.Len()).To(BeNumerically("<", protocol.MinInitialPacketSize))
@@ -459,7 +459,7 @@ var _ = Describe("Packet packer", func() {
 				p, err := packer.PackApplicationClose(&qerr.ApplicationError{
 					ErrorCode:    0x1337,
 					ErrorMessage: "test error",
-				}, maxPacketSize, time.Now(), protocol.Version1)
+				}, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(2))
 				Expect(p.buffer.Len()).To(BeNumerically(">=", protocol.MinInitialPacketSize))
@@ -495,7 +495,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().Get1RTTSealer().Return(getSealer(), nil)
 				ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, true)
 				framer.EXPECT().HasData()
-				_, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, time.Now(), protocol.Version1)
+				_, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, protocol.Version1)
 				Expect(err).To(MatchError(errNothingToPack))
 			})
 
@@ -513,8 +513,7 @@ var _ = Describe("Packet packer", func() {
 				expectAppendStreamFrames(ackhandler.StreamFrame{Frame: f})
 				buffer := getPacketBuffer()
 				buffer.Data = append(buffer.Data, []byte("foobar")...)
-				now := time.Now()
-				p, err := packer.AppendPacket(buffer, maxPacketSize, now, protocol.Version1)
+				p, err := packer.AppendPacket(buffer, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p).ToNot(BeNil())
 				b, err := f.Append(nil, protocol.Version1)
@@ -522,7 +521,6 @@ var _ = Describe("Packet packer", func() {
 				Expect(p.Frames).To(BeEmpty())
 				Expect(p.StreamFrames).To(HaveLen(1))
 				Expect(p.StreamFrames[0].Frame.StreamID).To(Equal(f.StreamID))
-				Expect(p.Packet.SendTime).To(Equal(now))
 				Expect(buffer.Data[:6]).To(Equal([]byte("foobar"))) // make sure the packet was actually appended
 				Expect(buffer.Data).To(ContainSubstring(string(b)))
 			})
@@ -534,7 +532,7 @@ var _ = Describe("Packet packer", func() {
 				framer.EXPECT().HasData()
 				ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, true).Return(ack)
 				sealingManager.EXPECT().Get1RTTSealer().Return(getSealer(), nil)
-				p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, protocol.Version1)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(p).ToNot(BeNil())
 				Expect(p.Ack).To(Equal(ack))
@@ -553,7 +551,7 @@ var _ = Describe("Packet packer", func() {
 				expectAppendControlFrames(frames...)
 				expectAppendStreamFrames()
 				buffer := getPacketBuffer()
-				p, err := packer.AppendPacket(buffer, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.AppendPacket(buffer, maxPacketSize, protocol.Version1)
 				Expect(p).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.Frames).To(HaveLen(2))
@@ -583,7 +581,7 @@ var _ = Describe("Packet packer", func() {
 
 				framer.EXPECT().HasData()
 				buffer := getPacketBuffer()
-				p, err := packer.AppendPacket(buffer, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.AppendPacket(buffer, maxPacketSize, protocol.Version1)
 				Expect(p).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.Frames).To(HaveLen(1))
@@ -612,7 +610,7 @@ var _ = Describe("Packet packer", func() {
 
 				framer.EXPECT().HasData()
 				buffer := getPacketBuffer()
-				p, err := packer.AppendPacket(buffer, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.AppendPacket(buffer, maxPacketSize, protocol.Version1)
 				Expect(p).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.Ack).ToNot(BeNil())
@@ -638,7 +636,7 @@ var _ = Describe("Packet packer", func() {
 						return fs, 0
 					}),
 				)
-				_, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, time.Now(), protocol.Version1)
+				_, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, protocol.Version1)
 				Expect(err).To(MatchError(errNothingToPack))
 			})
 
@@ -652,7 +650,7 @@ var _ = Describe("Packet packer", func() {
 				packer.retransmissionQueue.AddHandshake(&wire.PingFrame{})
 				handshakeStream.EXPECT().HasData()
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionHandshake, false)
-				packet, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				packet, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(packet).ToNot(BeNil())
 				Expect(packet.longHdrPackets).To(HaveLen(1))
@@ -696,7 +694,7 @@ var _ = Describe("Packet packer", func() {
 				expectAppendControlFrames()
 				expectAppendStreamFrames(ackhandler.StreamFrame{Frame: f})
 				buffer := getPacketBuffer()
-				_, err := packer.AppendPacket(buffer, maxPacketSize, time.Now(), protocol.Version1)
+				_, err := packer.AppendPacket(buffer, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				// cut off the tag that the mock sealer added
 				buffer.Data = buffer.Data[:buffer.Len()-protocol.ByteCount(sealer.Overhead())]
@@ -745,7 +743,7 @@ var _ = Describe("Packet packer", func() {
 				ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, false)
 				expectAppendControlFrames()
 				expectAppendStreamFrames(ackhandler.StreamFrame{Frame: f1}, ackhandler.StreamFrame{Frame: f2}, ackhandler.StreamFrame{Frame: f3})
-				p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, protocol.Version1)
 				Expect(p).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.Frames).To(BeEmpty())
@@ -765,7 +763,7 @@ var _ = Describe("Packet packer", func() {
 						ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, false).Return(&wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 1}}})
 						expectAppendControlFrames()
 						expectAppendStreamFrames()
-						p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, time.Now(), protocol.Version1)
+						p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, protocol.Version1)
 						Expect(p).ToNot(BeNil())
 						Expect(err).ToNot(HaveOccurred())
 						Expect(p.Ack).ToNot(BeNil())
@@ -782,14 +780,14 @@ var _ = Describe("Packet packer", func() {
 					ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, false).Return(&wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 1}}})
 					expectAppendControlFrames()
 					expectAppendStreamFrames()
-					p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, time.Now(), protocol.Version1)
+					p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, protocol.Version1)
 					Expect(p).ToNot(BeNil())
 					Expect(err).ToNot(HaveOccurred())
 					var hasPing bool
 					for _, f := range p.Frames {
 						if _, ok := f.Frame.(*wire.PingFrame); ok {
 							hasPing = true
-							Expect(f.Handler.OnLost).ToNot(BeNil()) // make sure the PING is not retransmitted if lost
+							Expect(f.Handler).To(BeNil()) // make sure the PING is not retransmitted if lost
 						}
 					}
 					Expect(hasPing).To(BeTrue())
@@ -801,7 +799,7 @@ var _ = Describe("Packet packer", func() {
 					ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, false).Return(&wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 1}}})
 					expectAppendControlFrames()
 					expectAppendStreamFrames()
-					p, err = packer.AppendPacket(getPacketBuffer(), maxPacketSize, time.Now(), protocol.Version1)
+					p, err = packer.AppendPacket(getPacketBuffer(), maxPacketSize, protocol.Version1)
 					Expect(p).ToNot(BeNil())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(p.Ack).ToNot(BeNil())
@@ -817,7 +815,7 @@ var _ = Describe("Packet packer", func() {
 					expectAppendControlFrames()
 					expectAppendStreamFrames()
 					ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, false)
-					_, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, time.Now(), protocol.Version1)
+					_, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, protocol.Version1)
 					Expect(err).To(MatchError(errNothingToPack))
 					// now add some frame to send
 					expectAppendControlFrames()
@@ -828,14 +826,14 @@ var _ = Describe("Packet packer", func() {
 					framer.EXPECT().HasData().Return(true)
 					ack := &wire.AckFrame{AckRanges: []wire.AckRange{{Smallest: 1, Largest: 1}}}
 					ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, false).Return(ack)
-					p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, time.Now(), protocol.Version1)
+					p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, protocol.Version1)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(p.Ack).To(Equal(ack))
 					var hasPing bool
 					for _, f := range p.Frames {
 						if _, ok := f.Frame.(*wire.PingFrame); ok {
 							hasPing = true
-							Expect(f.Handler.OnLost).ToNot(BeNil()) // make sure the PING is not retransmitted if lost
+							Expect(f.Handler).To(BeNil()) // make sure the PING is not retransmitted if lost
 						}
 					}
 					Expect(hasPing).To(BeTrue())
@@ -850,7 +848,7 @@ var _ = Describe("Packet packer", func() {
 					ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, false)
 					expectAppendStreamFrames()
 					expectAppendControlFrames(ackhandler.Frame{Frame: &wire.MaxDataFrame{}})
-					p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, time.Now(), protocol.Version1)
+					p, err := packer.AppendPacket(getPacketBuffer(), maxPacketSize, protocol.Version1)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(p).ToNot(BeNil())
 					Expect(p.Frames).ToNot(ContainElement(&wire.PingFrame{}))
@@ -872,7 +870,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().GetInitialSealer().Return(nil, handshake.ErrKeysDropped)
 				sealingManager.EXPECT().GetHandshakeSealer().Return(getSealer(), nil)
 				sealingManager.EXPECT().Get1RTTSealer().Return(nil, handshake.ErrKeysNotYetAvailable)
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p).ToNot(BeNil())
 				parsePacket(p.buffer.Data)
@@ -891,7 +889,7 @@ var _ = Describe("Packet packer", func() {
 				initialStream.EXPECT().PopCryptoFrame(gomock.Any()).DoAndReturn(func(size protocol.ByteCount) *wire.CryptoFrame {
 					return &wire.CryptoFrame{Offset: 0x42, Data: []byte("initial")}
 				})
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.buffer.Len()).To(BeNumerically(">=", protocol.MinInitialPacketSize))
 				Expect(p.buffer.Len()).To(BeEquivalentTo(maxPacketSize))
@@ -921,7 +919,7 @@ var _ = Describe("Packet packer", func() {
 					Expect(f.Length(protocol.Version1)).To(Equal(size))
 					return f
 				})
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(1))
 				Expect(p.longHdrPackets[0].frames).To(HaveLen(1))
@@ -947,7 +945,7 @@ var _ = Describe("Packet packer", func() {
 				handshakeStream.EXPECT().PopCryptoFrame(gomock.Any()).DoAndReturn(func(size protocol.ByteCount) *wire.CryptoFrame {
 					return &wire.CryptoFrame{Offset: 0x1337, Data: []byte("handshake")}
 				})
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.buffer.Len()).To(BeEquivalentTo(maxPacketSize))
 				Expect(p.longHdrPackets).To(HaveLen(2))
@@ -981,7 +979,7 @@ var _ = Describe("Packet packer", func() {
 				})
 				handshakeStream.EXPECT().HasData()
 				packer.retransmissionQueue.AddHandshake(&wire.PingFrame{})
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.buffer.Len()).To(BeEquivalentTo(maxPacketSize))
 				Expect(p.longHdrPackets).To(HaveLen(2))
@@ -1012,7 +1010,7 @@ var _ = Describe("Packet packer", func() {
 				handshakeStream.EXPECT().HasData()
 				packer.retransmissionQueue.AddInitial(&wire.PingFrame{})
 				packer.retransmissionQueue.AddHandshake(&wire.PingFrame{})
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.buffer.Len()).To(BeEquivalentTo(maxPacketSize))
 				Expect(p.longHdrPackets).To(HaveLen(2))
@@ -1046,7 +1044,7 @@ var _ = Describe("Packet packer", func() {
 				expectAppendStreamFrames()
 				framer.EXPECT().HasData().Return(true)
 				packer.retransmissionQueue.AddAppData(&wire.PingFrame{})
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.buffer.Len()).To(BeEquivalentTo(maxPacketSize))
 				Expect(p.longHdrPackets).To(HaveLen(1))
@@ -1082,7 +1080,7 @@ var _ = Describe("Packet packer", func() {
 				})
 				expectAppendControlFrames()
 				expectAppendStreamFrames(ackhandler.StreamFrame{Frame: &wire.StreamFrame{Data: []byte("foobar")}})
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.buffer.Len()).To(BeNumerically(">=", protocol.MinInitialPacketSize))
 				Expect(p.buffer.Len()).To(BeEquivalentTo(maxPacketSize))
@@ -1119,7 +1117,7 @@ var _ = Describe("Packet packer", func() {
 				})
 				expectAppendControlFrames()
 				expectAppendStreamFrames(ackhandler.StreamFrame{Frame: &wire.StreamFrame{Data: []byte("foobar")}})
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.buffer.Len()).To(BeNumerically("<", 100))
 				Expect(p.longHdrPackets).To(HaveLen(1))
@@ -1152,7 +1150,7 @@ var _ = Describe("Packet packer", func() {
 					Expect(f.Length(protocol.Version1)).To(Equal(s))
 					return f
 				})
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(1))
 				Expect(p.shortHdrPacket).To(BeNil())
@@ -1171,7 +1169,7 @@ var _ = Describe("Packet packer", func() {
 				packer.retransmissionQueue.AddHandshake(&wire.PingFrame{})
 				handshakeStream.EXPECT().HasData()
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionHandshake, false)
-				packet, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				packet, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(packet).ToNot(BeNil())
 				Expect(packet.longHdrPackets).To(HaveLen(1))
@@ -1212,11 +1210,13 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().Get1RTTSealer().Return(nil, handshake.ErrKeysNotYetAvailable)
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionInitial, false)
 				initialStream.EXPECT().HasData()
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(1))
 				Expect(p.longHdrPackets[0].EncryptionLevel()).To(Equal(protocol.EncryptionInitial))
-				Expect(p.longHdrPackets[0].frames).To(Equal([]ackhandler.Frame{{Frame: f}}))
+				Expect(p.longHdrPackets[0].frames).To(HaveLen(1))
+				Expect(p.longHdrPackets[0].frames[0].Frame).To(Equal(f))
+				Expect(p.longHdrPackets[0].frames[0].Handler).ToNot(BeNil())
 			})
 
 			It("sends an Initial packet containing only an ACK", func() {
@@ -1228,7 +1228,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().Get1RTTSealer().Return(nil, handshake.ErrKeysNotYetAvailable)
 				pnManager.EXPECT().PeekPacketNumber(protocol.EncryptionInitial).Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen2)
 				pnManager.EXPECT().PopPacketNumber(protocol.EncryptionInitial).Return(protocol.PacketNumber(0x42))
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(1))
 				Expect(p.longHdrPackets[0].ack).To(Equal(ack))
@@ -1240,7 +1240,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().Get1RTTSealer().Return(nil, handshake.ErrKeysNotYetAvailable)
 				initialStream.EXPECT().HasData()
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionInitial, true)
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p).To(BeNil())
 			})
@@ -1256,7 +1256,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().Get1RTTSealer().Return(nil, handshake.ErrKeysNotYetAvailable)
 				pnManager.EXPECT().PeekPacketNumber(protocol.EncryptionHandshake).Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen2)
 				pnManager.EXPECT().PopPacketNumber(protocol.EncryptionHandshake).Return(protocol.PacketNumber(0x42))
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(1))
 				Expect(p.longHdrPackets[0].ack).To(Equal(ack))
@@ -1279,7 +1279,7 @@ var _ = Describe("Packet packer", func() {
 					initialStream.EXPECT().HasData().Return(true).Times(2)
 					initialStream.EXPECT().PopCryptoFrame(gomock.Any()).Return(f)
 					packer.perspective = protocol.PerspectiveClient
-					p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+					p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(p.buffer.Len()).To(BeNumerically(">=", protocol.MinInitialPacketSize))
 					Expect(p.buffer.Len()).To(BeEquivalentTo(maxPacketSize))
@@ -1304,7 +1304,7 @@ var _ = Describe("Packet packer", func() {
 				initialStream.EXPECT().HasData().Return(true).Times(2)
 				initialStream.EXPECT().PopCryptoFrame(gomock.Any()).Return(f)
 				packer.perspective = protocol.PerspectiveClient
-				p, err := packer.PackCoalescedPacket(false, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.longHdrPackets).To(HaveLen(1))
 				Expect(p.longHdrPackets[0].ack).To(Equal(ack))
@@ -1327,7 +1327,7 @@ var _ = Describe("Packet packer", func() {
 					pnManager.EXPECT().PeekPacketNumber(protocol.EncryptionInitial).Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen2)
 					pnManager.EXPECT().PopPacketNumber(protocol.EncryptionInitial).Return(protocol.PacketNumber(0x42))
 
-					p, err := packer.MaybePackProbePacket(protocol.EncryptionInitial, maxPacketSize, time.Now(), protocol.Version1)
+					p, err := packer.MaybePackProbePacket(protocol.EncryptionInitial, maxPacketSize, protocol.Version1)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(p).ToNot(BeNil())
 					Expect(p.longHdrPackets).To(HaveLen(1))
@@ -1349,7 +1349,7 @@ var _ = Describe("Packet packer", func() {
 					pnManager.EXPECT().PeekPacketNumber(protocol.EncryptionInitial).Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen1)
 					pnManager.EXPECT().PopPacketNumber(protocol.EncryptionInitial).Return(protocol.PacketNumber(0x42))
 
-					p, err := packer.MaybePackProbePacket(protocol.EncryptionInitial, maxPacketSize, time.Now(), protocol.Version1)
+					p, err := packer.MaybePackProbePacket(protocol.EncryptionInitial, maxPacketSize, protocol.Version1)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(err).ToNot(HaveOccurred())
 					Expect(p).ToNot(BeNil())
@@ -1373,7 +1373,7 @@ var _ = Describe("Packet packer", func() {
 				pnManager.EXPECT().PeekPacketNumber(protocol.EncryptionHandshake).Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen2)
 				pnManager.EXPECT().PopPacketNumber(protocol.EncryptionHandshake).Return(protocol.PacketNumber(0x42))
 
-				p, err := packer.MaybePackProbePacket(protocol.EncryptionHandshake, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.MaybePackProbePacket(protocol.EncryptionHandshake, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p).ToNot(BeNil())
@@ -1394,7 +1394,7 @@ var _ = Describe("Packet packer", func() {
 				pnManager.EXPECT().PeekPacketNumber(protocol.EncryptionHandshake).Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen2)
 				pnManager.EXPECT().PopPacketNumber(protocol.EncryptionHandshake).Return(protocol.PacketNumber(0x42))
 
-				p, err := packer.MaybePackProbePacket(protocol.EncryptionHandshake, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.MaybePackProbePacket(protocol.EncryptionHandshake, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p).ToNot(BeNil())
@@ -1418,7 +1418,7 @@ var _ = Describe("Packet packer", func() {
 				expectAppendControlFrames()
 				expectAppendStreamFrames(ackhandler.StreamFrame{Frame: f})
 
-				p, err := packer.MaybePackProbePacket(protocol.Encryption1RTT, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.MaybePackProbePacket(protocol.Encryption1RTT, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p).ToNot(BeNil())
 				Expect(p.longHdrPackets).To(BeEmpty())
@@ -1444,7 +1444,7 @@ var _ = Describe("Packet packer", func() {
 					return append(fs, ackhandler.StreamFrame{Frame: sf}), sf.Length(v)
 				})
 
-				p, err := packer.MaybePackProbePacket(protocol.Encryption1RTT, maxPacketSize, time.Now(), protocol.Version1)
+				p, err := packer.MaybePackProbePacket(protocol.Encryption1RTT, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p).ToNot(BeNil())
 				Expect(p.longHdrPackets).To(BeEmpty())
@@ -1461,7 +1461,7 @@ var _ = Describe("Packet packer", func() {
 				ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, true)
 				framer.EXPECT().HasData()
 
-				packet, err := packer.MaybePackProbePacket(protocol.Encryption1RTT, maxPacketSize, time.Now(), protocol.Version1)
+				packet, err := packer.MaybePackProbePacket(protocol.Encryption1RTT, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(packet).To(BeNil())
 			})
@@ -1472,7 +1472,7 @@ var _ = Describe("Packet packer", func() {
 				pnManager.EXPECT().PopPacketNumber(protocol.Encryption1RTT).Return(protocol.PacketNumber(0x43))
 				ping := ackhandler.Frame{Frame: &wire.PingFrame{}}
 				const probePacketSize = maxPacketSize + 42
-				p, buffer, err := packer.PackMTUProbePacket(ping, probePacketSize, time.Now(), protocol.Version1)
+				p, buffer, err := packer.PackMTUProbePacket(ping, probePacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.Length).To(BeEquivalentTo(probePacketSize))
 				Expect(p.PacketNumber).To(Equal(protocol.PacketNumber(0x43)))
@@ -1480,31 +1480,5 @@ var _ = Describe("Packet packer", func() {
 				Expect(p.IsPathMTUProbePacket).To(BeTrue())
 			})
 		})
-	})
-})
-
-var _ = Describe("Converting to ackhandler.Packet", func() {
-	It("convert a packet", func() {
-		packet := &longHeaderPacket{
-			header: &wire.ExtendedHeader{Header: wire.Header{Type: protocol.PacketTypeInitial}},
-			frames: []ackhandler.Frame{{Frame: &wire.MaxDataFrame{}}, {Frame: &wire.PingFrame{}}},
-			ack:    &wire.AckFrame{AckRanges: []wire.AckRange{{Largest: 100, Smallest: 80}}},
-			length: 42,
-		}
-		t := time.Now()
-		p := packet.ToAckHandlerPacket(t, nil)
-		Expect(p.Length).To(Equal(protocol.ByteCount(42)))
-		Expect(p.Frames).To(Equal(packet.frames))
-		Expect(p.LargestAcked).To(Equal(protocol.PacketNumber(100)))
-		Expect(p.SendTime).To(Equal(t))
-	})
-
-	It("sets the LargestAcked to invalid, if the packet doesn't have an ACK frame", func() {
-		packet := &longHeaderPacket{
-			header: &wire.ExtendedHeader{Header: wire.Header{Type: protocol.PacketTypeHandshake}},
-			frames: []ackhandler.Frame{{Frame: &wire.MaxDataFrame{}}, {Frame: &wire.PingFrame{}}},
-		}
-		p := packet.ToAckHandlerPacket(time.Now(), nil)
-		Expect(p.LargestAcked).To(Equal(protocol.InvalidPacketNumber))
 	})
 })

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -647,7 +647,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().GetInitialSealer().Return(nil, handshake.ErrKeysDropped)
 				sealingManager.EXPECT().GetHandshakeSealer().Return(sealer, nil)
 				sealingManager.EXPECT().Get1RTTSealer().Return(nil, handshake.ErrKeysNotYetAvailable)
-				packer.retransmissionQueue.AddHandshake(&wire.PingFrame{})
+				packer.retransmissionQueue.addHandshake(&wire.PingFrame{})
 				handshakeStream.EXPECT().HasData()
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionHandshake, false)
 				packet, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
@@ -978,7 +978,7 @@ var _ = Describe("Packet packer", func() {
 					return &wire.CryptoFrame{Offset: 0x42, Data: []byte("initial")}
 				})
 				handshakeStream.EXPECT().HasData()
-				packer.retransmissionQueue.AddHandshake(&wire.PingFrame{})
+				packer.retransmissionQueue.addHandshake(&wire.PingFrame{})
 				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.buffer.Len()).To(BeEquivalentTo(maxPacketSize))
@@ -1008,8 +1008,8 @@ var _ = Describe("Packet packer", func() {
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionInitial, gomock.Any())
 				initialStream.EXPECT().HasData()
 				handshakeStream.EXPECT().HasData()
-				packer.retransmissionQueue.AddInitial(&wire.PingFrame{})
-				packer.retransmissionQueue.AddHandshake(&wire.PingFrame{})
+				packer.retransmissionQueue.addInitial(&wire.PingFrame{})
+				packer.retransmissionQueue.addHandshake(&wire.PingFrame{})
 				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.buffer.Len()).To(BeEquivalentTo(maxPacketSize))
@@ -1043,7 +1043,7 @@ var _ = Describe("Packet packer", func() {
 				expectAppendControlFrames()
 				expectAppendStreamFrames()
 				framer.EXPECT().HasData().Return(true)
-				packer.retransmissionQueue.AddAppData(&wire.PingFrame{})
+				packer.retransmissionQueue.addAppData(&wire.PingFrame{})
 				p, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(p.buffer.Len()).To(BeEquivalentTo(maxPacketSize))
@@ -1166,7 +1166,7 @@ var _ = Describe("Packet packer", func() {
 				sealingManager.EXPECT().GetInitialSealer().Return(nil, handshake.ErrKeysDropped)
 				sealingManager.EXPECT().GetHandshakeSealer().Return(sealer, nil)
 				sealingManager.EXPECT().Get1RTTSealer().Return(nil, handshake.ErrKeysNotYetAvailable)
-				packer.retransmissionQueue.AddHandshake(&wire.PingFrame{})
+				packer.retransmissionQueue.addHandshake(&wire.PingFrame{})
 				handshakeStream.EXPECT().HasData()
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionHandshake, false)
 				packet, err := packer.PackCoalescedPacket(false, maxPacketSize, protocol.Version1)
@@ -1201,8 +1201,8 @@ var _ = Describe("Packet packer", func() {
 
 			It("adds retransmissions", func() {
 				f := &wire.CryptoFrame{Data: []byte("Initial")}
-				retransmissionQueue.AddInitial(f)
-				retransmissionQueue.AddHandshake(&wire.CryptoFrame{Data: []byte("Handshake")})
+				retransmissionQueue.addInitial(f)
+				retransmissionQueue.addHandshake(&wire.CryptoFrame{Data: []byte("Handshake")})
 				pnManager.EXPECT().PeekPacketNumber(protocol.EncryptionInitial).Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen2)
 				pnManager.EXPECT().PopPacketNumber(protocol.EncryptionInitial).Return(protocol.PacketNumber(0x42))
 				sealingManager.EXPECT().GetInitialSealer().Return(getSealer(), nil)
@@ -1320,7 +1320,7 @@ var _ = Describe("Packet packer", func() {
 				It(fmt.Sprintf("packs an Initial probe packet and pads it, for the %s", perspective), func() {
 					packer.perspective = perspective
 					f := &wire.CryptoFrame{Data: []byte("Initial")}
-					retransmissionQueue.AddInitial(f)
+					retransmissionQueue.addInitial(f)
 					sealingManager.EXPECT().GetInitialSealer().Return(getSealer(), nil)
 					ackFramer.EXPECT().GetAckFrame(protocol.EncryptionInitial, false)
 					initialStream.EXPECT().HasData()
@@ -1342,7 +1342,7 @@ var _ = Describe("Packet packer", func() {
 
 				It(fmt.Sprintf("packs an Initial probe packet with 1 byte payload, for the %s", perspective), func() {
 					packer.perspective = perspective
-					retransmissionQueue.AddInitial(&wire.PingFrame{})
+					retransmissionQueue.addInitial(&wire.PingFrame{})
 					sealingManager.EXPECT().GetInitialSealer().Return(getSealer(), nil)
 					ackFramer.EXPECT().GetAckFrame(protocol.EncryptionInitial, false)
 					initialStream.EXPECT().HasData()
@@ -1366,7 +1366,7 @@ var _ = Describe("Packet packer", func() {
 
 			It("packs a Handshake probe packet", func() {
 				f := &wire.CryptoFrame{Data: []byte("Handshake")}
-				retransmissionQueue.AddHandshake(f)
+				retransmissionQueue.addHandshake(f)
 				sealingManager.EXPECT().GetHandshakeSealer().Return(getSealer(), nil)
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionHandshake, false)
 				handshakeStream.EXPECT().HasData()
@@ -1387,7 +1387,7 @@ var _ = Describe("Packet packer", func() {
 
 			It("packs a full size  Handshake probe packet", func() {
 				f := &wire.CryptoFrame{Data: make([]byte, 2000)}
-				retransmissionQueue.AddHandshake(f)
+				retransmissionQueue.addHandshake(f)
 				sealingManager.EXPECT().GetHandshakeSealer().Return(getSealer(), nil)
 				ackFramer.EXPECT().GetAckFrame(protocol.EncryptionHandshake, false)
 				handshakeStream.EXPECT().HasData()
@@ -1409,7 +1409,7 @@ var _ = Describe("Packet packer", func() {
 
 			It("packs a 1-RTT probe packet", func() {
 				f := &wire.StreamFrame{Data: []byte("1-RTT")}
-				retransmissionQueue.AddInitial(f)
+				retransmissionQueue.addInitial(f)
 				sealingManager.EXPECT().Get1RTTSealer().Return(getSealer(), nil)
 				ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, false)
 				pnManager.EXPECT().PeekPacketNumber(protocol.Encryption1RTT).Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen2)
@@ -1431,7 +1431,7 @@ var _ = Describe("Packet packer", func() {
 
 			It("packs a full size 1-RTT probe packet", func() {
 				f := &wire.StreamFrame{Data: make([]byte, 2000)}
-				retransmissionQueue.AddInitial(f)
+				retransmissionQueue.addInitial(f)
 				sealingManager.EXPECT().Get1RTTSealer().Return(getSealer(), nil)
 				ackFramer.EXPECT().GetAckFrame(protocol.Encryption1RTT, false)
 				pnManager.EXPECT().PeekPacketNumber(protocol.Encryption1RTT).Return(protocol.PacketNumber(0x42), protocol.PacketNumberLen2)


### PR DESCRIPTION
Depends on #3888.

Containing this struct to the `ackhandler` package will allow us to do all the optimizations described in https://github.com/quic-go/quic-go/issues/3846.