### PR TITLE
http3: return http.ErrServerClosed instead of quic.ErrServerClosed

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -274,6 +274,14 @@ func (s *Server) ServeListener(ln QUICEarlyListener) error {
 var errServerWithoutTLSConfig = errors.New("use of http3.Server without TLSConfig")
 
 func (s *Server) serveConn(tlsConf *tls.Config, conn net.PacketConn) error {
+	err := s.serveC(tlsConf, conn)
+	// replace quic package specific error with net/http equivalent ones
+	if err == quic.ErrServerClosed {
+		err = http.ErrServerClosed
+	}
+	return err
+}
+func (s *Server) serveC(tlsConf *tls.Config, conn net.PacketConn) error {
 	if tlsConf == nil {
 		return errServerWithoutTLSConfig
 	}

--- a/http3/server.go
+++ b/http3/server.go
@@ -281,6 +281,7 @@ func (s *Server) serveConn(tlsConf *tls.Config, conn net.PacketConn) error {
 	}
 	return err
 }
+
 func (s *Server) serveC(tlsConf *tls.Config, conn net.PacketConn) error {
 	if tlsConf == nil {
 		return errServerWithoutTLSConfig


### PR DESCRIPTION
fix #3898

