### PR TITLE
check for uninitialized fields when closing the Transport

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -244,7 +244,7 @@ func (t *Transport) runSendQueue() {
 func (t *Transport) Close() error {
 	t.close(errors.New("closing"))
 	if t.createdConn {
-		if err := t.conn.Close(); err != nil {
+		if err := t.Conn.Close(); err != nil {
 			return err
 		}
 	} else if t.conn != nil {

--- a/transport.go
+++ b/transport.go
@@ -247,11 +247,13 @@ func (t *Transport) Close() error {
 		if err := t.conn.Close(); err != nil {
 			return err
 		}
-	} else {
+	} else if t.conn != nil {
 		t.conn.SetReadDeadline(time.Now())
 		defer func() { t.conn.SetReadDeadline(time.Time{}) }()
 	}
-	<-t.listening // wait until listening returns
+	if t.listening != nil {
+		<-t.listening // wait until listening returns
+	}
 	return nil
 }
 
@@ -280,7 +282,9 @@ func (t *Transport) close(e error) {
 		return
 	}
 
-	t.handlerMap.Close(e)
+	if t.handlerMap != nil {
+		t.handlerMap.Close(e)
+	}
 	if t.server != nil {
 		t.server.setCloseError(e)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -291,4 +291,20 @@ var _ = Describe("Transport", func() {
 		close(packetChan)
 		tr.Close()
 	})
+
+	It("closes uninitialized Transport and closes underlying PacketConn", func() {
+		packetChan := make(chan packetToRead)
+		pconn := newMockPacketConn(packetChan)
+
+		tr := &Transport{
+			Conn:        pconn,
+			createdConn: true, // owns pconn
+		}
+		// NO init
+
+		// shutdown
+		close(packetChan)
+		pconn.EXPECT().Close()
+		Expect(tr.Close()).To(Succeed())
+	})
 })


### PR DESCRIPTION
The underlying observation that motivates this patch is that `(*Transport.)Close` and `(*Transport.)close` try to access possibly uninitialized fields of the `Transport` which can lead to nil pointer dereference failures (#3906) when the Transport's `init` function is not (fully) executed.

To fix this, I added respective checks in `(*Transport.)Close` and `(*Transport.)close`, so that the robustness of calling `(*Transport.)Close` does not depend on whether or how much of `(Transport.)init` was executed before. 
However, it might be that the underlying issue needs to be addressed at another place (I am not familiar enough with the code base to fully evaluate this).