### PR TITLE
add parity to stdlib response writer

### DIFF
--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -986,7 +986,7 @@ var _ = Describe("Client", func() {
 				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				buf := &bytes.Buffer{}
 				rstr := mockquic.NewMockStream(mockCtrl)
-				rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
+				rstr.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
 				rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
 				rw.Header().Set("Content-Encoding", "gzip")
 				gz := gzip.NewWriter(rw)
@@ -1012,7 +1012,7 @@ var _ = Describe("Client", func() {
 				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				buf := &bytes.Buffer{}
 				rstr := mockquic.NewMockStream(mockCtrl)
-				rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
+				rstr.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
 				rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
 				rw.Write([]byte("not gzipped"))
 				rw.Flush()

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -65,8 +65,9 @@ var _ = Describe("Response Writer", func() {
 	It("writes status", func() {
 		rw.WriteHeader(http.StatusTeapot)
 		fields := decodeHeader(strBuf)
-		Expect(fields).To(HaveLen(1))
+		Expect(fields).To(HaveLen(2))
 		Expect(fields).To(HaveKeyWithValue(":status", []string{"418"}))
+		Expect(fields).To(HaveKey("date"))
 	})
 
 	It("writes headers", func() {
@@ -116,8 +117,9 @@ var _ = Describe("Response Writer", func() {
 		rw.WriteHeader(http.StatusOK)
 		rw.WriteHeader(http.StatusInternalServerError)
 		fields := decodeHeader(strBuf)
-		Expect(fields).To(HaveLen(1))
+		Expect(fields).To(HaveLen(2))
 		Expect(fields).To(HaveKeyWithValue(":status", []string{"200"}))
+		Expect(fields).To(HaveKey("date"))
 	})
 
 	It("allows calling WriteHeader() several times when using the 103 status code", func() {
@@ -137,8 +139,9 @@ var _ = Describe("Response Writer", func() {
 
 		// According to the spec, headers sent in the informational response must also be included in the final response
 		fields = decodeHeader(strBuf)
-		Expect(fields).To(HaveLen(2))
+		Expect(fields).To(HaveLen(3))
 		Expect(fields).To(HaveKeyWithValue(":status", []string{"200"}))
+		Expect(fields).To(HaveKey("date"))
 		Expect(fields).To(HaveKeyWithValue("link", []string{"</style.css>; rel=preload; as=style", "</script.js>; rel=preload; as=script"}))
 
 		Expect(getData(strBuf)).To(Equal([]byte("foobar")))

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -193,8 +193,7 @@ var _ = Describe("Server", func() {
 
 			serr := s.handleRequest(conn, str, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
-			hfs := decodeHeader(responseBuf)
-			Expect(hfs).To(HaveKeyWithValue(":status", []string{"500"}))
+			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
 
 		It("handles a panicking handler", func() {
@@ -210,8 +209,7 @@ var _ = Describe("Server", func() {
 
 			serr := s.handleRequest(conn, str, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
-			hfs := decodeHeader(responseBuf)
-			Expect(hfs).To(HaveKeyWithValue(":status", []string{"500"}))
+			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
 
 		Context("hijacking bidirectional streams", func() {


### PR DESCRIPTION
This pr makes http3 response writer behave more closely like stdlib ones by doing the following:

1. Implement `FlushError` interface
2. Automatically add `Date` header
3. Check `Content-Length` like stdlib does
4. Add `Content-Length` when body is small enough
5. Fix [panic handling](https://github.com/caddyserver/caddy/issues/5125).

~~Automatically setting `Content-Length` when body is small enough is not done since it requires too much change to the current handling logic.~~