### PR TITLE
use unix.IPV6_RECVPKTINFO and unix.IPV6_PKTINFO on all platforms

### DIFF
--- a/sys_conn_helper_darwin.go
+++ b/sys_conn_helper_darwin.go
@@ -4,16 +4,10 @@ package quic
 
 import "golang.org/x/sys/unix"
 
-const msgTypeIPTOS = unix.IP_RECVTOS
-
 const (
-	ipv4RECVPKTINFO = unix.IP_RECVPKTINFO
-	ipv6RECVPKTINFO = 0x3d
-)
-
-const (
+	msgTypeIPTOS       = unix.IP_RECVTOS
+	ipv4RECVPKTINFO    = unix.IP_RECVPKTINFO
 	msgTypeIPv4PKTINFO = unix.IP_PKTINFO
-	msgTypeIPv6PKTINFO = 0x2e
 )
 
 // ReadBatch only returns a single packet on OSX,

--- a/sys_conn_helper_freebsd.go
+++ b/sys_conn_helper_freebsd.go
@@ -5,17 +5,9 @@ package quic
 import "golang.org/x/sys/unix"
 
 const (
-	msgTypeIPTOS = unix.IP_RECVTOS
-)
-
-const (
-	ipv4RECVPKTINFO = 0x7
-	ipv6RECVPKTINFO = 0x24
-)
-
-const (
+	msgTypeIPTOS       = unix.IP_RECVTOS
+	ipv4RECVPKTINFO    = 0x7
 	msgTypeIPv4PKTINFO = 0x7
-	msgTypeIPv6PKTINFO = 0x2e
 )
 
 const batchSize = 8

--- a/sys_conn_helper_linux.go
+++ b/sys_conn_helper_linux.go
@@ -8,16 +8,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const msgTypeIPTOS = unix.IP_TOS
-
 const (
-	ipv4RECVPKTINFO = unix.IP_PKTINFO
-	ipv6RECVPKTINFO = unix.IPV6_RECVPKTINFO
-)
-
-const (
+	msgTypeIPTOS       = unix.IP_TOS
+	ipv4RECVPKTINFO    = unix.IP_PKTINFO
 	msgTypeIPv4PKTINFO = unix.IP_PKTINFO
-	msgTypeIPv6PKTINFO = unix.IPV6_PKTINFO
 )
 
 const batchSize = 8 // needs to smaller than MaxUint8 (otherwise the type of oobConn.readPos has to be changed)

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -88,7 +88,7 @@ func newConn(c OOBCapablePacketConn, supportsDF bool) (*oobConn, error) {
 
 		if needsPacketInfo {
 			errPIIPv4 = unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, ipv4RECVPKTINFO, 1)
-			errPIIPv6 = unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, ipv6RECVPKTINFO, 1)
+			errPIIPv6 = unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_RECVPKTINFO, 1)
 		}
 	}); err != nil {
 		return nil, err
@@ -210,7 +210,7 @@ func (c *oobConn) ReadPacket() (receivedPacket, error) {
 			switch hdr.Type {
 			case unix.IPV6_TCLASS:
 				p.ecn = protocol.ECN(body[0] & ecnMask)
-			case msgTypeIPv6PKTINFO:
+			case unix.IPV6_PKTINFO:
 				// struct in6_pktinfo {
 				// 	struct in6_addr ipi6_addr;    /* src/dst IPv6 address */
 				// 	unsigned int    ipi6_ifindex; /* send/recv interface index */


### PR DESCRIPTION
Turns out that this constant is defined on Linux, FreeBSD and OSX.

No functional change expected.