### PR TITLE
simplify syscall consts used for requesting / parsing IPv4 packet info

### DIFF
--- a/sys_conn_helper_darwin.go
+++ b/sys_conn_helper_darwin.go
@@ -5,9 +5,8 @@ package quic
 import "golang.org/x/sys/unix"
 
 const (
-	msgTypeIPTOS       = unix.IP_RECVTOS
-	ipv4RECVPKTINFO    = unix.IP_RECVPKTINFO
-	msgTypeIPv4PKTINFO = unix.IP_PKTINFO
+	msgTypeIPTOS = unix.IP_RECVTOS
+	ipv4PKTINFO  = unix.IP_RECVPKTINFO
 )
 
 // ReadBatch only returns a single packet on OSX,

--- a/sys_conn_helper_freebsd.go
+++ b/sys_conn_helper_freebsd.go
@@ -5,9 +5,8 @@ package quic
 import "golang.org/x/sys/unix"
 
 const (
-	msgTypeIPTOS       = unix.IP_RECVTOS
-	ipv4RECVPKTINFO    = 0x7
-	msgTypeIPv4PKTINFO = 0x7
+	msgTypeIPTOS = unix.IP_RECVTOS
+	ipv4PKTINFO  = 0x7
 )
 
 const batchSize = 8

--- a/sys_conn_helper_linux.go
+++ b/sys_conn_helper_linux.go
@@ -9,9 +9,8 @@ import (
 )
 
 const (
-	msgTypeIPTOS       = unix.IP_TOS
-	ipv4RECVPKTINFO    = unix.IP_PKTINFO
-	msgTypeIPv4PKTINFO = unix.IP_PKTINFO
+	msgTypeIPTOS = unix.IP_TOS
+	ipv4PKTINFO  = unix.IP_PKTINFO
 )
 
 const batchSize = 8 // needs to smaller than MaxUint8 (otherwise the type of oobConn.readPos has to be changed)

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -87,7 +87,7 @@ func newConn(c OOBCapablePacketConn, supportsDF bool) (*oobConn, error) {
 		errECNIPv6 = unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_RECVTCLASS, 1)
 
 		if needsPacketInfo {
-			errPIIPv4 = unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, ipv4RECVPKTINFO, 1)
+			errPIIPv4 = unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, ipv4PKTINFO, 1)
 			errPIIPv6 = unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_RECVPKTINFO, 1)
 		}
 	}); err != nil {
@@ -188,7 +188,7 @@ func (c *oobConn) ReadPacket() (receivedPacket, error) {
 			switch hdr.Type {
 			case msgTypeIPTOS:
 				p.ecn = protocol.ECN(body[0] & ecnMask)
-			case msgTypeIPv4PKTINFO:
+			case ipv4PKTINFO:
 				// struct in_pktinfo {
 				// 	unsigned int   ipi_ifindex;  /* Interface index */
 				// 	struct in_addr ipi_spec_dst; /* Local address */


### PR DESCRIPTION
Turns out that message type and the value used in the syscall is the same for Linux, FreeBSD and OSX.

No functional change expected.