### PR TITLE
assert the length of IPv4 packet info control messages, add log message

### DIFF
--- a/sys_conn_helper_darwin.go
+++ b/sys_conn_helper_darwin.go
@@ -2,7 +2,12 @@
 
 package quic
 
-import "golang.org/x/sys/unix"
+import (
+	"encoding/binary"
+	"net/netip"
+
+	"golang.org/x/sys/unix"
+)
 
 const (
 	msgTypeIPTOS = unix.IP_RECVTOS
@@ -12,3 +17,15 @@ const (
 // ReadBatch only returns a single packet on OSX,
 // see https://godoc.org/golang.org/x/net/ipv4#PacketConn.ReadBatch.
 const batchSize = 1
+
+func parseIPv4PktInfo(body []byte) (ip netip.Addr, ifIndex uint32, ok bool) {
+	// struct in_pktinfo {
+	// 	unsigned int   ipi_ifindex;  /* Interface index */
+	// 	struct in_addr ipi_spec_dst; /* Local address */
+	// 	struct in_addr ipi_addr;     /* Header Destination address */
+	// };
+	if len(body) != 12 {
+		return netip.Addr{}, 0, false
+	}
+	return netip.AddrFrom4(*(*[4]byte)(body[8:12])), binary.LittleEndian.Uint32(body), true
+}

--- a/sys_conn_helper_freebsd.go
+++ b/sys_conn_helper_freebsd.go
@@ -2,7 +2,11 @@
 
 package quic
 
-import "golang.org/x/sys/unix"
+import (
+	"net/netip"
+
+	"golang.org/x/sys/unix"
+)
 
 const (
 	msgTypeIPTOS = unix.IP_RECVTOS
@@ -10,3 +14,13 @@ const (
 )
 
 const batchSize = 8
+
+func parseIPv4PktInfo(body []byte) (ip netip.Addr, _ uint32, ok bool) {
+	// struct in_pktinfo {
+	// 	struct in_addr ipi_addr;     /* Header Destination address */
+	// };
+	if len(body) != 4 {
+		return netip.Addr{}, 0, false
+	}
+	return netip.AddrFrom4(*(*[4]byte)(body)), 0, true
+}


### PR DESCRIPTION
The current code silently fails. It's better to assert the length, and log an error if it fails. I don't expect this to happen, but as we've seen, there's a quite bit of variance in the architectures.