### PR TITLE
update link to the wiki page about UDP buffer sizes

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -305,7 +305,7 @@ func (t *Transport) listen(conn rawConn) {
 				if disable, _ := strconv.ParseBool(os.Getenv("QUIC_GO_DISABLE_RECEIVE_BUFFER_WARNING")); disable {
 					return
 				}
-				log.Printf("%s. See https://github.com/quic-go/quic-go/wiki/UDP-Receive-Buffer-Size for details.", err)
+				log.Printf("%s. See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.", err)
 			})
 		}
 	}
@@ -315,7 +315,7 @@ func (t *Transport) listen(conn rawConn) {
 				if disable, _ := strconv.ParseBool(os.Getenv("QUIC_GO_DISABLE_RECEIVE_BUFFER_WARNING")); disable {
 					return
 				}
-				log.Printf("%s. See https://github.com/quic-go/quic-go/wiki/UDP-Receive-Buffer-Size for details.", err)
+				log.Printf("%s. See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.", err)
 			})
 		}
 	}


### PR DESCRIPTION
I moved the wiki page, since we're now dealing with both send and receive buffer size.