### PR TITLE
Transport: Remove t.Conn from multiplexer when init fails

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -187,6 +187,7 @@ func (t *Transport) init(isServer bool) error {
 			conn, err = wrapConn(t.Conn)
 			if err != nil {
 				t.initErr = err
+				getMultiplexer().RemoveConn(t.Conn)
 				return
 			}
 		}

--- a/transport_test.go
+++ b/transport_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"net"
+	"syscall"
 	"time"
 
 	mocklogging "github.com/quic-go/quic-go/internal/mocks/logging"
@@ -307,4 +308,27 @@ var _ = Describe("Transport", func() {
 		pconn.EXPECT().Close()
 		Expect(tr.Close()).To(Succeed())
 	})
+
+	It("removes underlying PacketConn from multiplexer after (*Transport).init failed", func() {
+		packetChan := make(chan packetToRead)
+		pconn := newMockPacketConn(packetChan)
+		syscallconn := &mockSyscallConn{pconn}
+
+		tr := &Transport{
+			Conn: syscallconn,
+		}
+
+		err := tr.init(false)
+		Expect(err).To(HaveOccurred())
+		conns := getMultiplexer().(*connMultiplexer).conns
+		Expect(len(conns)).To(BeZero())
+	})
 })
+
+type mockSyscallConn struct {
+	net.PacketConn
+}
+
+func (c *mockSyscallConn) SyscallConn() (syscall.RawConn, error) {
+	return nil, errors.New("mocked")
+}


### PR DESCRIPTION
This diff removes a net.PacketConn from the multiplexer when (*Transport).init fails.

Background: As far as I am aware, a PacketConn is only removed from the multiplexer, [when (*Transport).listen returns](https://github.com/quic-go/quic-go/blob/435444af7eb81b922a412ee80d4caddff26744de/transport.go#L300).
If (*Transport).init [returns early](https://github.com/quic-go/quic-go/blob/435444af7eb81b922a412ee80d4caddff26744de/transport.go#L190), the listen() goroutine is not started, while the PacketConn was already added to the multiplexer, which results in the inability of the Transport to remove the PacketConn entry from the multiplexer.
