### PR TITLE
disable GSO unless QUIC_GO_ENABLE_GSO is set

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Run self tests, using QUIC v2
         if: success() || failure() # run this step even if the previous one failed
         run: go run github.com/onsi/ginkgo/v2/ginkgo -r -v -randomize-all -randomize-suites -trace integrationtests/self -- -version=2 ${{ env.QLOGFLAG }}
-      - name: Run set tests, with GSO disabled
+      - name: Run set tests, with GSO enabled
         if: success() || failure() # run this step even if the previous one failed
         env:
-          QUIC_GO_DISABLE_GSO: true
+          QUIC_GO_ENABLE_GSO: true
         run: go run github.com/onsi/ginkgo/v2/ginkgo -r -v -randomize-all -randomize-suites -trace integrationtests/self -- -version=1 ${{ env.QLOGFLAG }}
       - name: Run tests (32 bit)
         if: success() || failure() # run this step even if the previous one failed

--- a/sys_conn_df_linux.go
+++ b/sys_conn_df_linux.go
@@ -39,8 +39,8 @@ func setDF(rawConn syscall.RawConn) (bool, error) {
 }
 
 func maybeSetGSO(rawConn syscall.RawConn) bool {
-	disable, _ := strconv.ParseBool(os.Getenv("QUIC_GO_DISABLE_GSO"))
-	if disable {
+	enable, _ := strconv.ParseBool(os.Getenv("QUIC_GO_ENABLE_GSO"))
+	if !enable {
 		return false
 	}
 


### PR DESCRIPTION
Looks like the proper fix for #3911 is not easy. This PR disables GSO unless the user explicitly enables it by setting the QUIC_GO_ENABLE_GSO environment variable.

This could be included in a v0.36.1 patch release.