### PR TITLE
http3: redial for unresolved or staled connections

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -245,6 +245,16 @@ func (c *client) Close() error {
 	return (*conn).CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
 }
 
+func (c *client) IsClosed() bool {
+	conn := c.conn.Load()
+	b := false
+	if conn != nil {
+		b = (*conn).Context().Err() != nil
+	}
+	c.logger.Infof("Connection closed: %v", b)
+	return b
+}
+
 func (c *client) maxHeaderBytes() uint64 {
 	if c.opts.MaxHeaderBytes <= 0 {
 		return defaultMaxResponseHeaderBytes

--- a/http3/mock_roundtripcloser_test.go
+++ b/http3/mock_roundtripcloser_test.go
@@ -62,6 +62,20 @@ func (mr *MockRoundTripCloserMockRecorder) HandshakeComplete() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandshakeComplete", reflect.TypeOf((*MockRoundTripCloser)(nil).HandshakeComplete))
 }
 
+// IsClosed mocks base method.
+func (m *MockRoundTripCloser) IsClosed() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsClosed")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsClosed indicates an expected call of IsClosed.
+func (mr *MockRoundTripCloserMockRecorder) IsClosed() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsClosed", reflect.TypeOf((*MockRoundTripCloser)(nil).IsClosed))
+}
+
 // RoundTripOpt mocks base method.
 func (m *MockRoundTripCloser) RoundTripOpt(arg0 *http.Request, arg1 RoundTripOpt) (*http.Response, error) {
 	m.ctrl.T.Helper()

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -178,13 +178,14 @@ func (r *RoundTripper) getClient(hostname string, onlyCached bool) (rtc *roundTr
 		if onlyCached {
 			return nil, false, ErrNoCachedConn
 		}
-	} else if client.HandshakeComplete() && !client.IsClosed() {
-		isReused = true
-	} else {
+	} else if client.IsClosed() {
+		client = nil
 		delete(r.clients, hostname)
+	} else if client.HandshakeComplete() {
+		isReused = true
 	}
 
-	if !isReused {
+	if client == nil {
 		var err error
 		newCl := newClient
 		if r.newClient != nil {

--- a/http3/roundtrip_test.go
+++ b/http3/roundtrip_test.go
@@ -193,7 +193,6 @@ var _ = Describe("RoundTripper", func() {
 				cl1.EXPECT().IsClosed().Return(true)
 				return &http.Response{Request: req}, nil
 			}).Times(1)
-			cl1.EXPECT().HandshakeComplete().Return(true)
 			cl2 := NewMockRoundTripCloser(mockCtrl)
 			cl2.EXPECT().RoundTripOpt(gomock.Any(), gomock.Any()).DoAndReturn(func(req *http.Request, _ RoundTripOpt) (*http.Response, error) {
 				Expect(req.URL).To(Equal(req2.URL))


### PR DESCRIPTION
unresolved:
Valid parameters, but handshake is not completed successfully.

staled:
A server may close the connection after requests are responsed, that stops to reuse it.

Complement #3684 (89769f40).