### PR TITLE
mitm_test: ensure random corrupted packet happens at least once

### DIFF
--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -273,7 +273,7 @@ var _ = Describe("MITM test", func() {
 					defer GinkgoRecover()
 					if dir == quicproxy.DirectionIncoming {
 						atomic.AddInt32(&numPackets, 1)
-						if rand.Intn(interval) == 0 {
+						if rand.Intn(interval) == 0 || atomic.LoadInt32(&numPackets) == 1 { // at leat once
 							pos := rand.Intn(len(raw))
 							raw[pos] = byte(rand.Intn(256))
 							_, err := clientUDPConn.WriteTo(raw, serverUDPConn.LocalAddr())
@@ -293,7 +293,7 @@ var _ = Describe("MITM test", func() {
 					defer GinkgoRecover()
 					if dir == quicproxy.DirectionOutgoing {
 						atomic.AddInt32(&numPackets, 1)
-						if rand.Intn(interval) == 0 {
+						if rand.Intn(interval) == 0 || atomic.LoadInt32(&numPackets) == 1 { // at leat once
 							pos := rand.Intn(len(raw))
 							raw[pos] = byte(rand.Intn(256))
 							_, err := serverUDPConn.WriteTo(raw, clientUDPConn.LocalAddr())

--- a/transport.go
+++ b/transport.go
@@ -195,7 +195,6 @@ func (t *Transport) init(isServer bool) error {
 		t.conn = conn
 
 		t.logger = utils.DefaultLogger // TODO: make this configurable
-		t.conn = conn
 		t.handlerMap = newPacketHandlerMap(t.StatelessResetKey, t.enqueueClosePacket, t.logger)
 		t.listening = make(chan struct{})
 


### PR DESCRIPTION
I got:
```
------------------------------
MITM test unsuccessful attacks corrupting packets downloads a message when packet are corrupted towards the server
/home/runner/work/quic-go/quic-go/integrationtests/self/mitm_test.go:270
Corrupted 0 of 16 packets.  [FAILED] in [AfterEach] - /home/runner/work/quic-go/quic-go/integrationtests/self/mitm_test.go:264 @ 07/09/23 07:54:29.885
• [FAILED] [0.058 seconds]
MITM test unsuccessful attacks corrupting packets [AfterEach] downloads a message when packet are corrupted towards the server
  [AfterEach] /home/runner/work/quic-go/quic-go/integrationtests/self/mitm_test.go:261
  [It] /home/runner/work/quic-go/quic-go/integrationtests/self/mitm_test.go:270

  [FAILED] Expected
      <int32>: 0
  to be >=
      <int>: 1
  In [AfterEach] at: /home/runner/work/quic-go/quic-go/integrationtests/self/mitm_test.go:264 @ 07/09/23 07:54:29.885

  Full Stack Trace
    github.com/quic-go/quic-go/integrationtests/self_test.glob..func14.3.5.2()
    	/home/runner/work/quic-go/quic-go/integrationtests/self/mitm_test.go:264 +0x189
------------------------------
```