### PR TITLE
http3: validate Host header before sending

### DIFF
--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -2,6 +2,7 @@ package http3
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -80,6 +81,9 @@ func (w *requestWriter) encodeHeaders(req *http.Request, addGzipHeader bool, tra
 	host, err := httpguts.PunycodeHostPort(host)
 	if err != nil {
 		return err
+	}
+	if !httpguts.ValidHostHeader(host) {
+		return errors.New("http3: invalid Host header")
 	}
 
 	// http.NewRequest sets this field to HTTP/1.1

--- a/http3/request_writer_test.go
+++ b/http3/request_writer_test.go
@@ -59,6 +59,13 @@ var _ = Describe("Request Writer", func() {
 		Expect(headerFields).ToNot(HaveKey("accept-encoding"))
 	})
 
+	It("rejects invalid host headers", func() {
+		req, err := http.NewRequest(http.MethodGet, "https://quic.clemente.io/index.html?foo=bar", nil)
+		Expect(err).ToNot(HaveOccurred())
+		req.Host = "foo@bar" // @ is invalid
+		Expect(rw.WriteRequestHeader(str, req, false)).To(MatchError("http3: invalid Host header"))
+	})
+
 	It("sends cookies", func() {
 		req, err := http.NewRequest(http.MethodGet, "https://quic.clemente.io/", nil)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Not sure if / why this is necessary, but the standard library HTTP/2 package just added this check: https://go-review.googlesource.com/c/net/+/506995

This is apparently what triggered the Go 1.20.6 patch release.