### PR TITLE
http3: don't write response headers if the handler panicked

### DIFF
--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -193,8 +193,7 @@ var _ = Describe("Server", func() {
 
 			serr := s.handleRequest(conn, str, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
-			hfs := decodeHeader(responseBuf)
-			Expect(hfs).To(HaveKeyWithValue(":status", []string{"500"}))
+			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
 
 		It("handles a panicking handler", func() {
@@ -210,8 +209,7 @@ var _ = Describe("Server", func() {
 
 			serr := s.handleRequest(conn, str, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
-			hfs := decodeHeader(responseBuf)
-			Expect(hfs).To(HaveKeyWithValue(":status", []string{"500"}))
+			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
 
 		Context("hijacking bidirectional streams", func() {


### PR DESCRIPTION
Fix [5125](https://github.com/caddyserver/caddy/issues/5125).