### PR TITLE
http3: implement FlushError for the response writer

### DIFF
--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -114,10 +114,16 @@ func (w *responseWriter) Write(p []byte) (int, error) {
 	return w.bufferedStr.Write(p)
 }
 
-func (w *responseWriter) Flush() {
+func (w *responseWriter) FlushError() error {
 	if err := w.bufferedStr.Flush(); err != nil {
 		w.logger.Errorf("could not flush to stream: %s", err.Error())
+		return err
 	}
+	return nil
+}
+
+func (w *responseWriter) Flush() {
+	w.FlushError()
 }
 
 func (w *responseWriter) StreamCreator() StreamCreator {

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -115,15 +115,13 @@ func (w *responseWriter) Write(p []byte) (int, error) {
 }
 
 func (w *responseWriter) FlushError() error {
-	if err := w.bufferedStr.Flush(); err != nil {
-		w.logger.Errorf("could not flush to stream: %s", err.Error())
-		return err
-	}
-	return nil
+	return w.bufferedStr.Flush()
 }
 
 func (w *responseWriter) Flush() {
-	w.FlushError()
+	if err := w.FlushError(); err != nil {
+		w.logger.Errorf("could not flush to stream: %s", err.Error())
+	}
 }
 
 func (w *responseWriter) StreamCreator() StreamCreator {


### PR DESCRIPTION
Move all of the logic to the new `FlushError` function and let `Flush` call it.