### PR TITLE
http3: add Date response header if not set

### DIFF
--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -55,6 +55,10 @@ func (w *responseWriter) WriteHeader(status int) {
 
 	if status < 100 || status >= 200 {
 		w.headerWritten = true
+		// add Date header
+		if _, ok := w.header["Date"]; !ok {
+			w.header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
+		}
 	}
 	w.status = status
 

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -55,7 +55,9 @@ func (w *responseWriter) WriteHeader(status int) {
 
 	if status < 100 || status >= 200 {
 		w.headerWritten = true
-		// add Date header
+		// Add Date header.
+		// This is what the standard library does.
+		// Can be disabled by setting the Date header to nil.
 		if _, ok := w.header["Date"]; !ok {
 			w.header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
 		}

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -65,8 +65,9 @@ var _ = Describe("Response Writer", func() {
 	It("writes status", func() {
 		rw.WriteHeader(http.StatusTeapot)
 		fields := decodeHeader(strBuf)
-		Expect(fields).To(HaveLen(1))
+		Expect(fields).To(HaveLen(2))
 		Expect(fields).To(HaveKeyWithValue(":status", []string{"418"}))
+		Expect(fields).To(HaveKey("date"))
 	})
 
 	It("writes headers", func() {
@@ -116,8 +117,9 @@ var _ = Describe("Response Writer", func() {
 		rw.WriteHeader(http.StatusOK)
 		rw.WriteHeader(http.StatusInternalServerError)
 		fields := decodeHeader(strBuf)
-		Expect(fields).To(HaveLen(1))
+		Expect(fields).To(HaveLen(2))
 		Expect(fields).To(HaveKeyWithValue(":status", []string{"200"}))
+		Expect(fields).To(HaveKey("date"))
 	})
 
 	It("allows calling WriteHeader() several times when using the 103 status code", func() {
@@ -137,8 +139,9 @@ var _ = Describe("Response Writer", func() {
 
 		// According to the spec, headers sent in the informational response must also be included in the final response
 		fields = decodeHeader(strBuf)
-		Expect(fields).To(HaveLen(2))
+		Expect(fields).To(HaveLen(3))
 		Expect(fields).To(HaveKeyWithValue(":status", []string{"200"}))
+		Expect(fields).To(HaveKey("date"))
 		Expect(fields).To(HaveKeyWithValue("link", []string{"</style.css>; rel=preload; as=style", "</script.js>; rel=preload; as=script"}))
 
 		Expect(getData(strBuf)).To(Equal([]byte("foobar")))


### PR DESCRIPTION
All response will have a `Date` header by default.