### PR TITLE
http3: return http.ErrContentLength when writing too large response

### DIFF
--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -167,4 +167,15 @@ var _ = Describe("Response Writer", func() {
 		Expect(rw.SetReadDeadline(time.Now().Add(1 * time.Second))).To(BeNil())
 		Expect(rw.SetWriteDeadline(time.Now().Add(1 * time.Second))).To(BeNil())
 	})
+
+	It(`checks Content-Length header`, func() {
+		rw.Header().Set("Content-Length", "6")
+		n, err := rw.Write([]byte("foobar"))
+		Expect(n).To(Equal(6))
+		Expect(err).To(BeNil())
+
+		n, err = rw.Write([]byte("foobar"))
+		Expect(n).To(Equal(0))
+		Expect(err).To(Equal(http.ErrContentLength))
+	})
 })


### PR DESCRIPTION
If handler sets a valid `Content-Length` header, it won't be able to write more than declared.