### PR TITLE
http3: add Content-Length header if the handler doesn't flush to the client

### DIFF
--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -986,7 +986,7 @@ var _ = Describe("Client", func() {
 				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				buf := &bytes.Buffer{}
 				rstr := mockquic.NewMockStream(mockCtrl)
-				rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
+				rstr.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
 				rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
 				rw.Header().Set("Content-Encoding", "gzip")
 				gz := gzip.NewWriter(rw)
@@ -1012,7 +1012,7 @@ var _ = Describe("Client", func() {
 				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				buf := &bytes.Buffer{}
 				rstr := mockquic.NewMockStream(mockCtrl)
-				rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
+				rstr.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
 				rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
 				rw.Write([]byte("not gzipped"))
 				rw.Flush()

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -23,6 +23,7 @@ type responseWriter struct {
 	header        http.Header
 	status        int // status code passed to WriteHeader
 	headerWritten bool
+	headerSent    bool
 	contentLen    int64 // if handler set valid Content-Length header
 	numWritten    int64 // bytes written
 
@@ -48,6 +49,41 @@ func newResponseWriter(str quic.Stream, conn quic.Connection, logger utils.Logge
 
 func (w *responseWriter) Header() http.Header {
 	return w.header
+}
+
+// flushHeader send header frame in wire format when:
+// 1. 1XX status is written
+// 1. Flush is called
+// 2. Write can not longer buffer anymore data
+func (w *responseWriter) flushHeader() error {
+	var headers bytes.Buffer
+	// leave some room to encode frame header
+	headers.Write(w.buf[:cap(w.buf)])
+	enc := qpack.NewEncoder(&headers)
+	enc.WriteField(qpack.HeaderField{Name: ":status", Value: strconv.Itoa(w.status)})
+
+	for k, v := range w.header {
+		for index := range v {
+			enc.WriteField(qpack.HeaderField{Name: strings.ToLower(k), Value: v[index]})
+		}
+	}
+
+	buf := headers.Bytes()[:0]
+	// not counting preallocated room as length
+	buf = (&headersFrame{Length: uint64(headers.Len() - cap(w.buf))}).Append(buf)
+	w.logger.Infof("Responding with %d", w.status)
+
+	// encodes frame header to the start of the buffer
+	// abuses bytes.Buffer
+	headers.Next(cap(w.buf) - len(buf))
+	copy(headers.Bytes(), buf)
+
+	// write to quic stream directly because data may be buffered
+	_, err := headers.WriteTo(w.str)
+	if err != nil {
+		w.logger.Errorf("could not write header frame: %s", err.Error())
+	}
+	return err
 }
 
 func (w *responseWriter) WriteHeader(status int) {
@@ -76,27 +112,8 @@ func (w *responseWriter) WriteHeader(status int) {
 	}
 	w.status = status
 
-	var headers bytes.Buffer
-	enc := qpack.NewEncoder(&headers)
-	enc.WriteField(qpack.HeaderField{Name: ":status", Value: strconv.Itoa(status)})
-
-	for k, v := range w.header {
-		for index := range v {
-			enc.WriteField(qpack.HeaderField{Name: strings.ToLower(k), Value: v[index]})
-		}
-	}
-
-	w.buf = w.buf[:0]
-	w.buf = (&headersFrame{Length: uint64(headers.Len())}).Append(w.buf)
-	w.logger.Infof("Responding with %d", status)
-	if _, err := w.bufferedStr.Write(w.buf); err != nil {
-		w.logger.Errorf("could not write headers frame: %s", err.Error())
-	}
-	if _, err := w.bufferedStr.Write(headers.Bytes()); err != nil {
-		w.logger.Errorf("could not write header frame payload: %s", err.Error())
-	}
 	if !w.headerWritten {
-		w.Flush()
+		w.flushHeader()
 	}
 }
 
@@ -132,6 +149,16 @@ func (w *responseWriter) Write(p []byte) (int, error) {
 	df := &dataFrame{Length: uint64(len(p))}
 	w.buf = w.buf[:0]
 	w.buf = df.Append(w.buf)
+
+	// flush header if unable to buffer anymore
+	if !w.headerSent && len(p)+len(w.buf) > w.bufferedStr.Available() {
+		w.headerSent = true
+		err := w.flushHeader()
+		if err != nil {
+			return 0, err
+		}
+	}
+
 	if _, err := w.bufferedStr.Write(w.buf); err != nil {
 		return 0, err
 	}
@@ -139,6 +166,17 @@ func (w *responseWriter) Write(p []byte) (int, error) {
 }
 
 func (w *responseWriter) FlushError() error {
+	// write status and flush header if necessary
+	if !w.headerWritten {
+		w.WriteHeader(http.StatusOK)
+	}
+	if !w.headerSent {
+		w.headerSent = true
+		err := w.flushHeader()
+		if err != nil {
+			return err
+		}
+	}
 	return w.bufferedStr.Flush()
 }
 

--- a/http3/server.go
+++ b/http3/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -623,7 +624,12 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 
 	// only write response when there is no panic
 	if !panicked {
-		r.WriteHeader(http.StatusOK)
+		// response not written to the client yet, set Content-Length
+		if !r.headerSent {
+			if _, haveCL := r.header["Content-Length"]; !haveCL {
+				r.header.Set("Content-Length", strconv.FormatInt(r.numWritten, 10))
+			}
+		}
 		r.Flush()
 	}
 	// If the EOF was read by the handler, CancelRead() is a no-op.

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -180,6 +180,47 @@ var _ = Describe("Server", func() {
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
 		})
 
+		It("sets Content-Length when the handler doesn't flush to the client", func() {
+			s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("foobar"))
+			})
+
+			responseBuf := &bytes.Buffer{}
+			setRequest(encodeRequest(exampleGetRequest))
+			str.EXPECT().Context().Return(reqContext)
+			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
+			str.EXPECT().CancelRead(gomock.Any())
+
+			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			Expect(serr.err).ToNot(HaveOccurred())
+			hfs := decodeHeader(responseBuf)
+			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
+			Expect(hfs).To(HaveKeyWithValue("content-length", []string{"6"}))
+			// status, content-length, date, content-type
+			Expect(hfs).To(HaveLen(4))
+		})
+
+		It("not sets Content-Length when the handler flushes to the client", func() {
+			s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("foobar"))
+				// force flush
+				w.(http.Flusher).Flush()
+			})
+
+			responseBuf := &bytes.Buffer{}
+			setRequest(encodeRequest(exampleGetRequest))
+			str.EXPECT().Context().Return(reqContext)
+			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
+			str.EXPECT().CancelRead(gomock.Any())
+
+			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			Expect(serr.err).ToNot(HaveOccurred())
+			hfs := decodeHeader(responseBuf)
+			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
+			// status, date, content-type
+			Expect(hfs).To(HaveLen(3))
+		})
+
 		It("handles a aborting handler", func() {
 			s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				panic(http.ErrAbortHandler)


### PR DESCRIPTION
stdlib will add `Content-Length` if handler doesn't flush to client usually due to no data written or the amount is small.