### PR TITLE
http3: don't send more than http.Request.ContentLength bytes

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -327,31 +327,43 @@ func (c *client) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Respon
 	return rsp, rerr.err
 }
 
-func (c *client) sendRequestBody(str Stream, body io.ReadCloser) error {
-	defer body.Close()
-	b := make([]byte, bodyCopyBufferSize)
-	for {
-		n, rerr := body.Read(b)
-		if n == 0 {
-			if rerr == nil {
-				continue
-			}
-			if rerr == io.EOF {
-				break
-			}
-		}
-		if _, err := str.Write(b[:n]); err != nil {
-			return err
-		}
-		if rerr != nil {
-			if rerr == io.EOF {
-				break
-			}
-			str.CancelWrite(quic.StreamErrorCode(ErrCodeRequestCanceled))
-			return rerr
-		}
+// cancelingReader reads from the io.Reader.
+// It cancels writing on the stream if any error other than io.EOF occurs.
+type cancelingReader struct {
+	r   io.Reader
+	str Stream
+}
+
+func (r *cancelingReader) Read(b []byte) (int, error) {
+	n, err := r.r.Read(b)
+	if err != nil && err != io.EOF {
+		r.str.CancelWrite(quic.StreamErrorCode(ErrCodeRequestCanceled))
 	}
-	return nil
+	return n, err
+}
+
+func (c *client) sendRequestBody(str Stream, body io.ReadCloser, contentLength int64) error {
+	defer body.Close()
+	buf := make([]byte, bodyCopyBufferSize)
+	sr := &cancelingReader{str: str, r: body}
+	if contentLength == -1 {
+		_, err := io.CopyBuffer(str, sr, buf)
+		return err
+	}
+
+	// make sure we don't send more bytes than the content length
+	n, err := io.CopyBuffer(str, io.LimitReader(sr, contentLength), buf)
+	if err != nil {
+		return err
+	}
+	var extra int64
+	extra, err = io.CopyBuffer(io.Discard, sr, buf)
+	n += extra
+	if n > contentLength {
+		str.CancelWrite(quic.StreamErrorCode(ErrCodeRequestCanceled))
+		return fmt.Errorf("http: ContentLength=%d with Body length %d", contentLength, n)
+	}
+	return err
 }
 
 func (c *client) doRequest(req *http.Request, conn quic.EarlyConnection, str quic.Stream, opt RoundTripOpt, reqDone chan<- struct{}) (*http.Response, requestError) {
@@ -371,7 +383,13 @@ func (c *client) doRequest(req *http.Request, conn quic.EarlyConnection, str qui
 	if req.Body != nil {
 		// send the request body asynchronously
 		go func() {
-			if err := c.sendRequestBody(hstr, req.Body); err != nil {
+			contentLength := int64(-1)
+			// According to the documentation for http.Request.ContentLength,
+			// a value of 0 with a non-nil Body is also treated as unknown content length.
+			if req.ContentLength > 0 {
+				contentLength = req.ContentLength
+			}
+			if err := c.sendRequestBody(hstr, req.Body, contentLength); err != nil {
 				c.logger.Errorf("Error writing request: %s", err)
 			}
 			if !opt.DontCloseRequestStream {


### PR DESCRIPTION
The standard library HTTP/1.1 returns an error here (https://sourcegraph.com/github.com/golang/go/-/blob/src/net/http/transfer.go?L389-391), but we can't do this, since we're sending the request body async. Instead, the stream will be reset, which also means that there's no guarantee that the server will even receive the request (if packets for a reset stream are lost, they're not even retransmitted by the QUIC layer).

That's probably fine, since it's clearly an error to provide a `http.Request.Body` that reads more bytes than set on `http.Request.ContentLength`.

@WeidiDeng, could you take a look at this PR? Is this what you suggested in https://github.com/quic-go/quic-go/pull/3953#issuecomment-1636064584?