### PR TITLE
connection: surface connection error as connection context cancellation cause

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The `quic.Transport` contains a few configuration options that don't apply to an
 
 #### When the remote Peer closes the Connection
 
-In case the peer closes the QUIC connection, all calls to open streams, accept streams, as well as all methods on streams immediately return an error. Users can use errors assertions to find out what exactly went wrong:
+In case the peer closes the QUIC connection, all calls to open streams, accept streams, as well as all methods on streams immediately return an error. Additionally, it is set as cancellation cause of the connection context. Users can use errors assertions to find out what exactly went wrong:
 
 * `quic.VersionNegotiationError`: Happens during the handshake, if there is no overlap between our and the remote's supported QUIC versions.
 * `quic.HandshakeTimeoutError`: Happens if the QUIC handshake doesn't complete within the time specified in `quic.Config.HandshakeTimeout`.

--- a/interface.go
+++ b/interface.go
@@ -178,6 +178,8 @@ type Connection interface {
 	// The error string will be sent to the peer.
 	CloseWithError(ApplicationErrorCode, string) error
 	// Context returns a context that is cancelled when the connection is closed.
+	// The cancellation cause is set to the error that caused the connection to
+	// close, or `context.Canceled` in case the listener is closed first.
 	Context() context.Context
 	// ConnectionState returns basic details about the QUIC connection.
 	// Warning: This API should not be considered stable and might change soon.


### PR DESCRIPTION
Currently connection errors surface on stream operations, as well as `Connection`'s `AcceptStream` and `OpenStream` calls. This change introduces an additional surface point in the form of the cancellation cause of a Connection's context.

Users can learn about connection errors via
```golang
// get error
err := context.Cause(conn.Context())
```

On server side a `quic.Connection`'s cancellation cause is:
* The error passed to `conn.CloseWithError(err)`
* `qerr.TransportError` when closing the transport's `Conn`, or the transport itself
* `context.Canceled` when the listener is closed, while connections aren't explicitly closed by the user

On client side a `quic.Connection`'s cancellation cause is:
* The error passed to `conn.CloseWithError(err)`
* `qerr.TransportError` when closing the transport's `Conn`, or the transport itself

There might be a race for setting the cancellation cause when users close the transport and also close connections concurrently, but I wasn't able to confirm this. Once a context's cancellation cause is set, it can't be changed by subsequent cancelFunc calls. (While i didn't test it, the same might be the case when closing a transport's `Conn`)