### PR TITLE
http3: reject header field names with invalid characters

### DIFF
--- a/http3/request.go
+++ b/http3/request.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/net/http/httpguts"
+
 	"github.com/quic-go/qpack"
 )
 
@@ -35,6 +37,9 @@ func requestFromHeaders(headers []qpack.HeaderField) (*http.Request, error) {
 			contentLengthStr = h.Value
 		default:
 			if !h.IsPseudo() {
+				if !httpguts.ValidHeaderFieldName(h.Name) {
+					return nil, fmt.Errorf("invalid header field name: %q", h.Name)
+				}
 				httpHeaders.Add(h.Name, h.Value)
 			}
 		}

--- a/http3/request_test.go
+++ b/http3/request_test.go
@@ -44,6 +44,17 @@ var _ = Describe("Request", func() {
 		Expect(err).To(MatchError("header field is not lower-case: Content-Length"))
 	})
 
+	It("rejects invalid field names", func() {
+		headers := []qpack.HeaderField{
+			{Name: ":path", Value: "/foo"},
+			{Name: ":authority", Value: "quic.clemente.io"},
+			{Name: ":method", Value: "GET"},
+			{Name: "@", Value: "42"},
+		}
+		_, err := requestFromHeaders(headers)
+		Expect(err).To(MatchError(`invalid header field name: "@"`))
+	})
+
 	It("parses path with leading double slashes", func() {
 		headers := []qpack.HeaderField{
 			{Name: ":path", Value: "//foo"},


### PR DESCRIPTION
Depends on #3964.

cc @WeidiDeng 🙏