### PR TITLE
http3: unify handling of request and response headers

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -419,27 +419,13 @@ func (c *client) doRequest(req *http.Request, conn quic.EarlyConnection, str qui
 		return nil, newConnError(ErrCodeGeneralProtocolError, err)
 	}
 
+	res, err := responseFromHeaders(hfs)
+	if err != nil {
+		return nil, newStreamError(ErrCodeMessageError, err)
+	}
 	connState := conn.ConnectionState().TLS
-	res := &http.Response{
-		Proto:      "HTTP/3.0",
-		ProtoMajor: 3,
-		Header:     http.Header{},
-		TLS:        &connState,
-		Request:    req,
-	}
-	for _, hf := range hfs {
-		switch hf.Name {
-		case ":status":
-			status, err := strconv.Atoi(hf.Value)
-			if err != nil {
-				return nil, newStreamError(ErrCodeGeneralProtocolError, errors.New("malformed non-numeric status pseudo header"))
-			}
-			res.StatusCode = status
-			res.Status = hf.Value + " " + http.StatusText(status)
-		default:
-			res.Header.Add(hf.Name, hf.Value)
-		}
-	}
+	res.TLS = &connState
+	res.Request = req
 	respBody := newResponseBody(hstr, conn, reqDone)
 
 	// Rules for when to set Content-Length are defined in https://tools.ietf.org/html/rfc7230#section-3.3.2.

--- a/http3/headers.go
+++ b/http3/headers.go
@@ -164,3 +164,23 @@ func hostnameFromRequest(req *http.Request) string {
 	}
 	return ""
 }
+
+func responseFromHeaders(headerFields []qpack.HeaderField) (*http.Response, error) {
+	hdr, err := parseHeaders(headerFields, false)
+	if err != nil {
+		return nil, err
+	}
+	rsp := &http.Response{
+		Proto:         "HTTP/3.0",
+		ProtoMajor:    3,
+		Header:        hdr.Headers,
+		ContentLength: hdr.ContentLength,
+	}
+	status, err := strconv.Atoi(hdr.Status)
+	if err != nil {
+		return nil, fmt.Errorf("invalid status code: %w", err)
+	}
+	rsp.StatusCode = status
+	rsp.Status = hdr.Status + " " + http.StatusText(status)
+	return rsp, nil
+}


### PR DESCRIPTION
Depends on #3968.

A lot of the validation logic introduced in the previous PRs applies to both request and response headers. This PR reuses the same code path for processing of both.

cc @WeidiDeng 🙏