### PR TITLE
send stream: surface error as stream context cancellation cause

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -122,6 +122,8 @@ type SendStream interface {
 	// The Context is canceled as soon as the write-side of the stream is closed.
 	// This happens when Close() or CancelWrite() is called, or when the peer
 	// cancels the read-side of their stream.
+	// The cancellation cause is set to the error that caused the stream to
+	// close, or `context.Canceled` in case the stream is closed without error.
 	Context() context.Context
 	// SetWriteDeadline sets the deadline for future Write calls
 	// and any currently-blocked Write call.

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -2,6 +2,7 @@ package quic
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	mrand "math/rand"
@@ -318,6 +319,7 @@ var _ = Describe("Send Stream", func() {
 			Expect(str.Context().Done()).ToNot(BeClosed())
 			Expect(str.Close()).To(Succeed())
 			Expect(str.Context().Done()).To(BeClosed())
+			Expect(context.Cause(str.Context())).To(MatchError(context.Canceled))
 		})
 
 		Context("flow control blocking", func() {
@@ -668,6 +670,7 @@ var _ = Describe("Send Stream", func() {
 				Expect(str.Context().Done()).ToNot(BeClosed())
 				str.closeForShutdown(testErr)
 				Expect(str.Context().Done()).To(BeClosed())
+				Expect(context.Cause(str.Context())).To(MatchError(testErr))
 			})
 		})
 	})
@@ -846,6 +849,8 @@ var _ = Describe("Send Stream", func() {
 				Expect(str.Context().Done()).ToNot(BeClosed())
 				str.CancelWrite(1234)
 				Expect(str.Context().Done()).To(BeClosed())
+				Expect(context.Cause(str.Context())).To(BeAssignableToTypeOf(&StreamError{}))
+				Expect(context.Cause(str.Context())).To(HaveField("ErrorCode", StreamErrorCode(1234)))
 			})
 
 			It("doesn't allow further calls to Write", func() {


### PR DESCRIPTION
Currently stream errors surface on stream operations only. This change introduces an additional surface point in the form of the cancellation cause of a SendStream's context.

Users can learn about stream errors via

```
// wait for stream to finish
<-str.Context().Done()

// get stream error
err := context.Cause(str.Context())
```