### PR TITLE
http3: refactor header field processing into a separate function

### DIFF
--- a/http3/request_test.go
+++ b/http3/request_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var _ = Describe("Request", func() {
-	It("populates request", func() {
+	It("populates requests", func() {
 		headers := []qpack.HeaderField{
 			{Name: ":path", Value: "/foo"},
 			{Name: ":authority", Value: "quic.clemente.io"},
@@ -87,6 +87,17 @@ var _ = Describe("Request", func() {
 		_, err := requestFromHeaders(headers)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("invalid content length"))
+	})
+
+	It("rejects pseudo header fields defined for responses", func() {
+		headers := []qpack.HeaderField{
+			{Name: ":path", Value: "/foo"},
+			{Name: ":authority", Value: "quic.clemente.io"},
+			{Name: ":method", Value: "GET"},
+			{Name: ":status", Value: "404"},
+		}
+		_, err := requestFromHeaders(headers)
+		Expect(err).To(MatchError("invalid request pseudo header: :status"))
 	})
 
 	It("parses path with leading double slashes", func() {


### PR DESCRIPTION
Splitting this commit out of #3969, to allow git to preserve the blame history.

This also changes the structure of the `if`, as suggested by @sukunrt in https://github.com/quic-go/quic-go/pull/3968#pullrequestreview-1534409408.