### PR TITLE
validate newly received max_datagram_frame_size parameter

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1667,6 +1667,17 @@ func (s *connection) handleTransportParameters(params *wire.TransportParameters)
 		})
 		return
 	}
+
+	// validate that the new value of the max_datagram_frame_size transport parameter sent by
+	// the server in the handshake is greater than or equal to the stored value
+	if s.perspective == protocol.PerspectiveClient && s.peerParams != nil && s.peerParams.MaxDatagramFrameSize > params.MaxDatagramFrameSize {
+		s.closeLocal(&qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "new peer max_datagram_frame_size is smaller than stored value",
+		})
+		return
+	}
+
 	s.peerParams = params
 	// On the client side we have to wait for handshake completion.
 	// During a 0-RTT connection, we are only allowed to use the new transport parameters for 1-RTT packets.

--- a/connection.go
+++ b/connection.go
@@ -1668,8 +1668,8 @@ func (s *connection) handleTransportParameters(params *wire.TransportParameters)
 		return
 	}
 
-	// validate that the new value of the max_datagram_frame_size transport parameter sent by
-	// the server in the handshake is greater than or equal to the stored value
+	// RFC 9221 requires the client to check that the server didn't decrease the
+	// max_datagram_frame_size transport parameter when doing a 0-RTT resumption.
 	if s.perspective == protocol.PerspectiveClient && s.peerParams != nil && s.peerParams.MaxDatagramFrameSize > params.MaxDatagramFrameSize {
 		s.closeLocal(&qerr.TransportError{
 			ErrorCode:    qerr.ProtocolViolation,


### PR DESCRIPTION
According to RFC 9221, a client should validate the new value of the max_datagram_frame_size transport parameter is greater than or equal to the stored value.  https://datatracker.ietf.org/doc/html/rfc9221#name-motivation:~:text=If%20a%20client,with%20error%20PROTOCOL_VIOLATION.