### PR TITLE
http3: reject responses that don't set the :status header

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -170,6 +170,9 @@ func responseFromHeaders(headerFields []qpack.HeaderField) (*http.Response, erro
 	if err != nil {
 		return nil, err
 	}
+	if hdr.Status == "" {
+		return nil, errors.New("missing status field")
+	}
 	rsp := &http.Response{
 		Proto:         "HTTP/3.0",
 		ProtoMajor:    3,

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -291,6 +291,14 @@ var _ = Describe("Response", func() {
 		Expect(err).To(MatchError("received pseudo header :status after a regular header field"))
 	})
 
+	It("rejects response with no status field", func() {
+		headers := []qpack.HeaderField{
+			{Name: "content-length", Value: "42"},
+		}
+		_, err := responseFromHeaders(headers)
+		Expect(err).To(MatchError("missing status field"))
+	})
+
 	It("rejects invalid status codes", func() {
 		headers := []qpack.HeaderField{
 			{Name: ":status", Value: "foobar"},


### PR DESCRIPTION
Thank you @sukunrt for noticing this and providing a test case in https://github.com/quic-go/quic-go/pull/3971#discussion_r1267252159.