### PR TITLE
http3: enforce that DATA frames don't exceed Content-Length

### DIFF
--- a/http3/http_stream_test.go
+++ b/http3/http_stream_test.go
@@ -4,12 +4,18 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/quic-go/quic-go"
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func getDataFrame(data []byte) []byte {
+	b := (&dataFrame{Length: uint64(len(data))}).Append(nil)
+	return append(b, data...)
+}
 
 var _ = Describe("Stream", func() {
 	Context("reading", func() {
@@ -21,10 +27,6 @@ var _ = Describe("Stream", func() {
 		)
 
 		errorCb := func() { errorCbCalled = true }
-		getDataFrame := func(data []byte) []byte {
-			b := (&dataFrame{Length: uint64(len(data))}).Append(nil)
-			return append(b, data...)
-		}
 
 		BeforeEach(func() {
 			buf = &bytes.Buffer{}
@@ -146,5 +148,56 @@ var _ = Describe("Stream", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(b).To(Equal([]byte("foobar")))
 		})
+	})
+})
+
+var _ = Describe("length-limited streams", func() {
+	var (
+		str  *stream
+		qstr *mockquic.MockStream
+		buf  *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		buf = &bytes.Buffer{}
+		qstr = mockquic.NewMockStream(mockCtrl)
+		qstr.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
+		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+		str = newStream(qstr, func() { Fail("didn't expect error callback to be called") })
+	})
+
+	It("reads all frames", func() {
+		s := newLengthLimitedStream(str, 6)
+		buf.Write(getDataFrame([]byte("foo")))
+		buf.Write(getDataFrame([]byte("bar")))
+		data, err := io.ReadAll(s)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(Equal([]byte("foobar")))
+	})
+
+	It("errors if more data than the maximum length is sent, in the middle of a frame", func() {
+		s := newLengthLimitedStream(str, 4)
+		buf.Write(getDataFrame([]byte("foo")))
+		buf.Write(getDataFrame([]byte("bar")))
+		qstr.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeMessageError))
+		qstr.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeMessageError))
+		data, err := io.ReadAll(s)
+		Expect(err).To(MatchError(errTooMuchData))
+		Expect(data).To(Equal([]byte("foob")))
+		// check that repeated calls to Read also return the right error
+		n, err := s.Read([]byte{0})
+		Expect(n).To(BeZero())
+		Expect(err).To(MatchError(errTooMuchData))
+	})
+
+	It("errors if more data than the maximum length is sent, as an additional frame", func() {
+		s := newLengthLimitedStream(str, 3)
+		buf.Write(getDataFrame([]byte("foo")))
+		buf.Write(getDataFrame([]byte("bar")))
+		qstr.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeMessageError))
+		qstr.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeMessageError))
+		data, err := io.ReadAll(s)
+		Expect(err).To(MatchError(errTooMuchData))
+		Expect(data).To(Equal([]byte("foo")))
 	})
 })

--- a/http3/server.go
+++ b/http3/server.go
@@ -580,7 +580,16 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 	connState := conn.ConnectionState().TLS
 	req.TLS = &connState
 	req.RemoteAddr = conn.RemoteAddr().String()
-	body := newRequestBody(newStream(str, onFrameError))
+
+	// Check that the client doesn't send more data in DATA frames than indicated by the Content-Length header (if set).
+	// See section 4.1.2 of RFC 9114.
+	var httpStr Stream
+	if _, ok := req.Header["Content-Length"]; ok && req.ContentLength >= 0 {
+		httpStr = newLengthLimitedStream(newStream(str, onFrameError), req.ContentLength)
+	} else {
+		httpStr = newStream(str, onFrameError)
+	}
+	body := newRequestBody(httpStr)
 	req.Body = body
 
 	if s.logger.Debug() {


### PR DESCRIPTION
cc @Mephue @mholt 

I'm not sure if we have to deal with requests / responses that don't set the Content-Length field, but where we could derive from the request / response type that it doesn't have a body.

This PR:
1. Limits `http.Request.Body.Read` and `http.Response.Body.Read` to never read more bytes than set by the Content-Length header (if it's set).
2. Resets the stream with a H3_MESSAGE_ERROR if the peer violates that requirement.