### PR TITLE
http3: discard negative content-length header when writing response

### DIFF
--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -64,9 +64,11 @@ func (w *responseWriter) WriteHeader(status int) {
 			w.header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
 		}
 		// Content-Length checking
+		// use ParseUint instead of ParseInt, as negative values are invalid and will
+		// be discarded with a warning
 		if clen := w.header.Get("Content-Length"); clen != "" {
-			if cl, err := strconv.ParseInt(clen, 10, 64); err == nil {
-				w.contentLen = cl
+			if cl, err := strconv.ParseUint(clen, 10, 63); err == nil {
+				w.contentLen = int64(cl)
 			} else {
 				// emit a warning for malformed Content-Length and remove it
 				w.logger.Errorf("Malformed Content-Length %s", clen)

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -64,8 +64,7 @@ func (w *responseWriter) WriteHeader(status int) {
 			w.header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
 		}
 		// Content-Length checking
-		// use ParseUint instead of ParseInt, as negative values are invalid and will
-		// be discarded with a warning
+		// use ParseUint instead of ParseInt, as negative values are invalid
 		if clen := w.header.Get("Content-Length"); clen != "" {
 			if cl, err := strconv.ParseUint(clen, 10, 63); err == nil {
 				w.contentLen = int64(cl)


### PR DESCRIPTION
Similar to [3966](https://github.com/quic-go/quic-go/pull/3966), but for response writer.