### PR TITLE
http3: panic in ResponseWriter.WriteHeader for invalid status codes

### DIFF
--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -3,6 +3,7 @@ package http3
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -55,7 +56,12 @@ func (w *responseWriter) WriteHeader(status int) {
 		return
 	}
 
-	if status < 100 || status >= 200 {
+	// http status must be 3 digits
+	if status < 100 || status > 999 {
+		panic(fmt.Sprintf("invalid WriteHeader code %v", status))
+	}
+
+	if status >= 200 {
 		w.headerWritten = true
 		// Add Date header.
 		// This is what the standard library does.

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -9,8 +9,11 @@ import (
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
 	"github.com/quic-go/quic-go/internal/utils"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+    "github.com/golang/mock/gomock"
+	"github.com/quic-go/qpack"
+
+	"github.com/golang/mock/gomock"
+	"github.com/quic-go/qpack"
 )
 
 var _ = Describe("Response Writer", func() {

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -9,11 +9,11 @@ import (
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
 	"github.com/quic-go/quic-go/internal/utils"
 
-    "github.com/golang/mock/gomock"
-	"github.com/quic-go/qpack"
-
 	"github.com/golang/mock/gomock"
 	"github.com/quic-go/qpack"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Response Writer", func() {

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -9,8 +9,8 @@ import (
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
 	"github.com/quic-go/quic-go/internal/utils"
 
-	"github.com/golang/mock/gomock"
-	"github.com/quic-go/qpack"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Response Writer", func() {

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -11,9 +11,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/quic-go/qpack"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Response Writer", func() {
@@ -177,5 +174,10 @@ var _ = Describe("Response Writer", func() {
 		n, err = rw.Write([]byte("foobar"))
 		Expect(n).To(Equal(0))
 		Expect(err).To(Equal(http.ErrContentLength))
+	})
+
+	It(`panics when writing invalid status`, func() {
+		Expect(func() { rw.WriteHeader(99) }).To(Panic())
+		Expect(func() { rw.WriteHeader(1000) }).To(Panic())
 	})
 })


### PR DESCRIPTION
panic for status codes that aren't 3 digits. As there is no way to propagate this information to caller.