### PR TITLE
add a method to retrieve non-QUIC packets from the Transport

### DIFF
--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -74,6 +74,10 @@ func parseArbitraryLenConnectionIDs(r *bytes.Reader) (dest, src protocol.Arbitra
 	return destConnID, srcConnID, nil
 }
 
+func IsPotentialQUICPacket(firstByte byte) bool {
+	return firstByte&0x40 > 0
+}
+
 // IsLongHeaderPacket says if this is a Long Header packet
 func IsLongHeaderPacket(firstByte byte) bool {
 	return firstByte&0x80 > 0


### PR DESCRIPTION
Fixes #3929.

Tests still missing.
Resolution to https://mailarchive.ietf.org/arch/msg/quic/oR4kxGKY6mjtPC1CZegY1ED4beg/ still missing.