### PR TITLE
http3: support HTTP CONNECT and CONNECT-UDP (masque) protocols

### DIFF
--- a/example/connect-udp/main.go
+++ b/example/connect-udp/main.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/internal/testdata"
+	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/logging"
+	"github.com/quic-go/quic-go/qlog"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+func main() {
+	verbose := flag.Bool("v", false, "verbose")
+	keyLogFile := flag.String("keylog", "", "key log file")
+	insecure := flag.Bool("insecure", false, "skip certificate verification")
+	enableQlog := flag.Bool("qlog", false, "output a qlog (in the same directory)")
+	proxyServer := flag.String("proxy", "https://127.0.0.1:8765", "Proxy server address")
+	authToken := flag.String("authtoken", "", "Authorization token")
+	certFile := flag.String("certfile", "", "Cert file to load")
+	flag.Parse()
+	urls := flag.Args()
+
+	logger := utils.DefaultLogger
+
+	if *verbose {
+		logger.SetLogLevel(utils.LogLevelDebug)
+	} else {
+		logger.SetLogLevel(utils.LogLevelInfo)
+	}
+	logger.SetLogTimeFormat("")
+
+	var keyLog io.Writer
+	if len(*keyLogFile) > 0 {
+		f, err := os.Create(*keyLogFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		keyLog = f
+	}
+
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		log.Fatal(err)
+	}
+	testdata.AddRootCA(pool)
+
+	verifyPem := func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error { return nil }
+	if *certFile != "" {
+		pemData, err := ioutil.ReadFile(*certFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		block, _ := pem.Decode([]byte(pemData))
+		if block == nil {
+			log.Fatal("failed to parse certificate PEM")
+		}
+
+		fastlyCert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pool.AddCert(fastlyCert)
+
+		verifyPem = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			if len(rawCerts) < 1 {
+				return errors.New("didn't get any rawCerts")
+			}
+			peerCert, err := x509.ParseCertificate(rawCerts[0])
+			if err != nil || fastlyCert.Equal(peerCert) {
+				return nil
+			}
+			return errors.New("cert didn't matched pinned cert")
+		}
+	}
+
+	qconf := quic.Config{
+		EnableDatagrams:    true,
+		MaxIncomingStreams: 100,
+	}
+	proxyUrl, err := url.ParseRequestURI(*proxyServer)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *enableQlog {
+		qconf.Tracer = func(ctx context.Context, p logging.Perspective, connID quic.ConnectionID) logging.ConnectionTracer {
+			filename := fmt.Sprintf("client_%x.qlog", connID)
+			f, err := os.Create(filename)
+			if err != nil {
+				log.Fatal(err)
+			}
+			log.Printf("Creating qlog file %s.\n", filename)
+			return qlog.NewConnectionTracer(utils.NewBufferedWriteCloser(bufio.NewWriter(f), f), p, connID)
+		}
+	}
+	roundTripper := &http3.RoundTripper{
+		TLSClientConfig: &tls.Config{
+			RootCAs:               pool,
+			InsecureSkipVerify:    *insecure || (*certFile != ""),
+			KeyLogWriter:          keyLog,
+			VerifyPeerCertificate: verifyPem,
+		},
+		QuicConfig:      &qconf,
+		Proxy:           http.ProxyURL(proxyUrl),
+		EnableDatagrams: true,
+	}
+	defer roundTripper.Close()
+	hclient := &http.Client{
+		Transport: roundTripper,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(urls))
+	for _, addr := range urls {
+		logger.Infof("CONNECT-UDP %s", addr)
+		go func(addr string) {
+			fullAddr := fmt.Sprintf("masque://%s:443", addr)
+			req, err := http.NewRequest("CONNECT-UDP", fullAddr, nil)
+
+			// Assign a quarter stream ID (RFC 9297)
+			flowID := 4
+			sFlowID := strconv.Itoa(flowID)
+			req.Header.Add("Datagram-Flow-Id", sFlowID)
+			if *authToken != "" {
+				req.Header.Add("Proxy-Authorization", fmt.Sprintf("PrivacyToken token=%s", *authToken))
+			}
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			rsp, err := hclient.Do(req)
+			if err != nil {
+				log.Fatal(err)
+			}
+			logger.Infof("Got response from %s: %#v", addr, rsp)
+			if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
+				log.Fatalf(rsp.Status)
+			}
+
+			hstr, e := rsp.Body.(http3.HTTPStreamer)
+			if !e {
+				log.Fatal("Failed to convert Streamer")
+			}
+			str := hstr.HTTPStream()
+			conn := hstr.HTTPConnection()
+			if conn == nil {
+				log.Fatal("Failed to get connection object")
+			}
+
+			bbuf := &bytes.Buffer{}
+			wbuf := quicvarint.NewWriter(bbuf)
+			// Specify the flow ID before exchanging a message.
+			i, _ := strconv.Atoi(sFlowID)
+			b := byte(i)
+			wbuf.WriteByte(b)
+			wbuf.Write([]byte("Hello World from quic-go."))
+
+			time.Sleep(time.Second / 2)
+
+			err = conn.SendMessage(bbuf.Bytes())
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			recv, err := conn.ReceiveMessage(context.Background())
+			if err != nil && err != io.EOF {
+				log.Fatal(err)
+			}
+
+			logger.Infof("Received data:\n%s", string(recv))
+			str.Close()
+
+			wg.Done()
+		}(addr)
+	}
+	wg.Wait()
+}

--- a/example/connect/main.go
+++ b/example/connect/main.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"sync"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/quic-go/internal/testdata"
+	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/logging"
+	"github.com/quic-go/quic-go/qlog"
+)
+
+func main() {
+	verbose := flag.Bool("v", false, "verbose")
+	keyLogFile := flag.String("keylog", "", "key log file")
+	insecure := flag.Bool("insecure", false, "skip certificate verification")
+	enableQlog := flag.Bool("qlog", false, "output a qlog (in the same directory)")
+	proxyServer := flag.String("proxy", "https://127.0.0.1:8765", "Proxy server address")
+	authToken := flag.String("authtoken", "", "Authorization token")
+	certFile := flag.String("certfile", "", "Cert file to load")
+	flag.Parse()
+	urls := flag.Args()
+
+	logger := utils.DefaultLogger
+
+	if *verbose {
+		logger.SetLogLevel(utils.LogLevelDebug)
+	} else {
+		logger.SetLogLevel(utils.LogLevelInfo)
+	}
+	logger.SetLogTimeFormat("")
+
+	var keyLog io.Writer
+	if len(*keyLogFile) > 0 {
+		f, err := os.Create(*keyLogFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		keyLog = f
+	}
+
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		log.Fatal(err)
+	}
+	testdata.AddRootCA(pool)
+
+	verifyPem := func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error { return nil }
+	if *certFile != "" {
+		pemData, err := ioutil.ReadFile(*certFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		block, _ := pem.Decode([]byte(pemData))
+		if block == nil {
+			log.Fatal("failed to parse certificate PEM")
+		}
+
+		fastlyCert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			log.Fatal(err)
+		}
+		pool.AddCert(fastlyCert)
+
+		verifyPem = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			if len(rawCerts) < 1 {
+				return errors.New("didn't get any rawCerts")
+			}
+			peerCert, err := x509.ParseCertificate(rawCerts[0])
+			if err != nil || fastlyCert.Equal(peerCert) {
+				return nil
+			}
+			return errors.New("cert didn't matched pinned cert")
+		}
+	}
+
+	qconf := quic.Config{
+		EnableDatagrams:    true,
+		MaxIncomingStreams: 100,
+	}
+
+	proxyUrl, err := url.ParseRequestURI(*proxyServer)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *enableQlog {
+		qconf.Tracer = func(ctx context.Context, p logging.Perspective, connID quic.ConnectionID) logging.ConnectionTracer {
+			filename := fmt.Sprintf("client_%x.qlog", connID)
+			f, err := os.Create(filename)
+			if err != nil {
+				log.Fatal(err)
+			}
+			log.Printf("Creating qlog file %s.\n", filename)
+			return qlog.NewConnectionTracer(utils.NewBufferedWriteCloser(bufio.NewWriter(f), f), p, connID)
+		}
+	}
+	roundTripper := &http3.RoundTripper{
+		TLSClientConfig: &tls.Config{
+			RootCAs:               pool,
+			InsecureSkipVerify:    *insecure || (*certFile != ""),
+			KeyLogWriter:          keyLog,
+			VerifyPeerCertificate: verifyPem,
+		},
+		QuicConfig:      &qconf,
+		Proxy:           http.ProxyURL(proxyUrl),
+		EnableDatagrams: true,
+	}
+	defer roundTripper.Close()
+	hclient := &http.Client{
+		Transport: roundTripper,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(urls))
+	for _, addr := range urls {
+		logger.Infof("CONNECT %s", addr)
+		go func(addr string) {
+			req, err := http.NewRequest(http.MethodConnect, addr, nil)
+			if *authToken != "" {
+				req.Header.Add("Proxy-Authorization", fmt.Sprintf("PrivacyToken token=%s", *authToken))
+			}
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			rsp, err := hclient.Do(req)
+			if err != nil {
+				log.Fatal(err)
+			}
+			logger.Infof("Got response for %s: %#v", addr, rsp)
+			if rsp.StatusCode < 200 || rsp.StatusCode >= 300 {
+				log.Fatalf(rsp.Status)
+			}
+
+			hstr, e := rsp.Body.(http3.HTTPStreamer)
+			if !e {
+				log.Fatal("Failed to convert Streamer")
+			}
+			str := hstr.HTTPStream()
+
+			simpleGet := "GET / HTTP/1.0\r\n\r\n"
+
+			written, err := str.Write([]byte(simpleGet))
+			if err != nil {
+				log.Fatal(err)
+			} else if written < len(simpleGet) {
+				log.Fatal("Failed to write GET in one go")
+			}
+			logger.Infof("Wrote %d bytes", written)
+
+			recv := make([]byte, 4096)
+			read, err := str.Read(recv)
+			if err != nil && err != io.EOF {
+				log.Fatal(err)
+			} else if read == 0 {
+				log.Fatal("Failed to read any response data")
+			}
+
+			logger.Infof("Received data:\n%s", string(recv))
+			str.Close()
+
+			wg.Done()
+		}(addr)
+	}
+	wg.Wait()
+}

--- a/http3/body.go
+++ b/http3/body.go
@@ -15,6 +15,7 @@ import (
 // When a stream is taken over, it's the caller's responsibility to close the stream.
 type HTTPStreamer interface {
 	HTTPStream() Stream
+	HTTPConnection() quic.Connection
 }
 
 type StreamCreator interface {
@@ -56,6 +57,10 @@ func newRequestBody(str Stream) *body {
 func (r *body) HTTPStream() Stream {
 	r.wasHijacked = true
 	return r.str
+}
+
+func (r *body) HTTPConnection() quic.Connection {
+	return nil
 }
 
 func (r *body) wasStreamHijacked() bool {
@@ -132,4 +137,8 @@ func (r *hijackableBody) Close() error {
 
 func (r *hijackableBody) HTTPStream() Stream {
 	return r.str
+}
+
+func (r *hijackableBody) HTTPConnection() quic.Connection {
+	return r.conn
 }

--- a/http3/client.go
+++ b/http3/client.go
@@ -254,7 +254,7 @@ func (c *client) maxHeaderBytes() uint64 {
 
 // RoundTripOpt executes a request and returns a response
 func (c *client) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
-	if authorityAddr("https", hostnameFromRequest(req)) != c.hostname {
+	if !validProxyMethod(req.Method) && authorityAddr("https", hostnameFromRequest(req)) != c.hostname {
 		return nil, fmt.Errorf("http3 client BUG: RoundTripOpt called for the wrong client (expected %s, got %s)", c.hostname, req.Host)
 	}
 

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -88,7 +88,10 @@ func (f *headersFrame) Append(b []byte) []byte {
 	return quicvarint.Append(b, f.Length)
 }
 
-const settingDatagram = 0xffd277
+// This value is used when the client negotiates with a HTTP server
+// to use H3 datagram on top of QUIC datagram.
+// Source: https://github.com/h2o/h2o/blob/398ea25c008f3b1b1beb48a14d6ca61c8bb0aaa7/include/h2o/http3_common.h#L53
+const settingDatagram = 0x276
 
 type settingsFrame struct {
 	Datagram bool


### PR DESCRIPTION
This commit makes changes to the HTTP3 stack so that HTTP CONNECT and CONNECT-UDP requests will not fail due to internal checks. Also, it modifies the HTTP3 setting frame code to reflect the up-to-date setting for HTTP3 datagram over QUIC datagram. Finally, it adds two examples to run proxies TCP and UDP connections via HTTP3.