### PR TITLE
use new value for SETTINGS_H3_DATAGRAM (according to RFC9297)

### DIFF
--- a/http3/frames.go
+++ b/http3/frames.go
@@ -88,7 +88,7 @@ func (f *headersFrame) Append(b []byte) []byte {
 	return quicvarint.Append(b, f.Length)
 }
 
-const settingDatagram = 0xffd277
+const settingDatagram = 0x33
 
 type settingsFrame struct {
 	Datagram bool


### PR DESCRIPTION
Hello, while using the quic-go library I noticed that according to the [RFC9297](https://www.rfc-editor.org/rfc/rfc9297.html#name-the-settings_h3_datagram-ht) the correct value for settingsDatagram is `0x33` (also mentioned [here](https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml)), the value `0xffd277` was used in [draft](https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram-07#name-http-3-settings-parameter). I gave it a shot and tried to fix it myself, let me know if I am missing something 🙂. Otherwise thanks for the great work on this project!

RFC9297
> An endpoint can indicate to its peer that it is willing to receive HTTP/3 Datagrams by sending the SETTINGS_H3_DATAGRAM (0x33) setting with a value of 1.

old draft IANA consideration:
>[HTTP/3 SETTINGS Parameter](https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram-07#name-http-3-settings-parameter)
This document will request IANA to register the following entry in the "HTTP/3 Settings" registry:
Value:
0xffd277 (note that this will switch to a lower value before publication)
Setting Name:
H3_DATAGRAM