### PR TITLE
set a net.Conn for tls.ClientHelloInfo.Conn used by GetCertificate

### DIFF
--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Handshake tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("has the right local and remote address on the ClientHelloInfo.Conn", func() {
+		It("has the right local and remote address on the tls.Config.GetConfigForClient ClientHelloInfo.Conn", func() {
 			var local, remote net.Addr
 			done := make(chan struct{})
 			tlsConf := &tls.Config{
@@ -150,6 +150,30 @@ var _ = Describe("Handshake tests", func() {
 					remote = info.Conn.RemoteAddr()
 					return getTLSConfig(), nil
 				},
+			}
+			runServer(tlsConf)
+			conn, err := quic.DialAddr(
+				context.Background(),
+				fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
+				getTLSClientConfig(),
+				getQuicConfig(nil),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(done).Should(BeClosed())
+			Expect(server.Addr()).To(Equal(local))
+			Expect(conn.LocalAddr().(*net.UDPAddr).Port).To(Equal(remote.(*net.UDPAddr).Port))
+		})
+
+		It("has the right local and remote address on the tls.Config.GetCertificate ClientHelloInfo.Conn", func() {
+			var local, remote net.Addr
+			done := make(chan struct{})
+			tlsConf := getTLSConfig()
+			tlsConf.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				defer close(done)
+				local = info.Conn.LocalAddr()
+				remote = info.Conn.RemoteAddr()
+				cert := tlsConf.Certificates[0]
+				return &cert, nil
 			}
 			runServer(tlsConf)
 			conn, err := quic.DialAddr(

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -134,6 +134,13 @@ func NewCryptoSetupServer(
 			return gcfc(info)
 		}
 	}
+	if quicConf.TLSConfig.GetCertificate != nil {
+		gc := quicConf.TLSConfig.GetCertificate
+		quicConf.TLSConfig.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			info.Conn = &conn{localAddr: localAddr, remoteAddr: remoteAddr}
+			return gc(info)
+		}
+	}
 
 	cs.tlsConf = quicConf.TLSConfig
 	cs.conn = qtls.QUICServer(quicConf)


### PR DESCRIPTION
`tls.ClientHelloInfo` is not only used for `GetConfigForClient` (which we fixed in #4001), but also in `GetGertificate`. See https://github.com/caddyserver/caddy/issues/5680#issuecomment-1664407962 for details.

@mholt, would you mind taking a look?