### PR TITLE
handshake: use the correct hash function for TLS_AES_256_GCM_SHA384

### DIFF
--- a/internal/handshake/cipher_suite.go
+++ b/internal/handshake/cipher_suite.go
@@ -30,7 +30,7 @@ func getCipherSuite(id uint16) *cipherSuite {
 	case tls.TLS_CHACHA20_POLY1305_SHA256:
 		return &cipherSuite{ID: tls.TLS_CHACHA20_POLY1305_SHA256, Hash: crypto.SHA256, KeyLen: 32, AEAD: aeadChaCha20Poly1305}
 	case tls.TLS_AES_256_GCM_SHA384:
-		return &cipherSuite{ID: tls.TLS_AES_256_GCM_SHA384, Hash: crypto.SHA256, KeyLen: 32, AEAD: aeadAESGCMTLS13}
+		return &cipherSuite{ID: tls.TLS_AES_256_GCM_SHA384, Hash: crypto.SHA384, KeyLen: 32, AEAD: aeadAESGCMTLS13}
 	default:
 		panic(fmt.Sprintf("unknown cypher suite: %d", id))
 	}


### PR DESCRIPTION
TLS_AES_128_GCM_SHA256 and TLS_CHACHA20_POLY1305_SHA256 work fine, but if TLS happens to select TLS_AES_256_GCM_SHA384 during the handshake, we're deriving the wrong keys, causing a handshake failure.

Thanks to @MarcoPolo for discovering this when interop-ing with zig-libp2p.