### PR TITLE
ci: build interop Docker image for pushes to master, and for releases

### DIFF
--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - build-interop-docker-image-for-tags
     tags:
       - 'v*'
   

--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -1,11 +1,17 @@
 name: Build interop Docker image
 on: 
   push:
-    branches: [ interop ]
+    branches:
+      - master
+      - build-interop-docker-image-for-tags # TODO: remove
+    tags:
+      - 'v*'
   
 jobs:
   interop:
     runs-on: ubuntu-latest
+    env:
+      TAG: "latest"
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU
@@ -19,9 +25,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: set tag name
+        if: github.event_name == 'tag'
+        run: echo "TAG=${{ github.event.release.tag_name }}"
       - uses: docker/build-push-action@v4
         with:
           context: "{{defaultContext}}:interop"
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: martenseemann/quic-go-interop:latest
+          tags: martenseemann/quic-go-interop:${{ env.TAG }}

--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -10,8 +10,6 @@ on:
 jobs:
   interop:
     runs-on: ${{ fromJSON(vars['DOCKER_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}
-    env:
-      TAG: "latest"
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU
@@ -26,13 +24,18 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: set tag name
-        if: github.event_name == 'tag'
+        id: tag
         # Tagged releases won't be picked up by the interop runner automatically,
         # but they can be useful when debugging regressions.
-        run: echo "TAG=${{ github.event.release.tag_name }}"
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" | tee -a $GITHUB_OUTPUT;
+          else
+            echo 'tag=latest' | tee -a $GITHUB_OUTPUT;
+          fi
       - uses: docker/build-push-action@v4
         with:
           context: "{{defaultContext}}:interop"
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: martenseemann/quic-go-interop:${{ env.TAG }}
+          tags: martenseemann/quic-go-interop:${{ steps.tag.outputs.tag }}

--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - build-interop-docker-image-for-tags
     tags:
       - 'v*'
   
@@ -29,12 +30,16 @@ jobs:
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             echo "tag=${GITHUB_REF#refs/tags/}" | tee -a $GITHUB_OUTPUT;
+            echo "gitref=${GITHUB_REF#refs/tags/}" | tee -a $GITHUB_OUTPUT;
           else
             echo 'tag=latest' | tee -a $GITHUB_OUTPUT;
+            echo 'gitref=${{ github.sha }}' | tee -a $GITHUB_OUTPUT;
           fi
       - uses: docker/build-push-action@v4
         with:
           context: "{{defaultContext}}:interop"
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            GITREF=${{ steps.tag.outputs.gitref }}
           tags: martenseemann/quic-go-interop:${{ steps.tag.outputs.tag }}

--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -9,7 +9,7 @@ on:
   
 jobs:
   interop:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars['DOCKER_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}
     env:
       TAG: "latest"
     steps:
@@ -27,6 +27,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: set tag name
         if: github.event_name == 'tag'
+        # Tagged releases won't be picked up by the interop runner automatically,
+        # but they can be useful when debugging regressions.
         run: echo "TAG=${{ github.event.release.tag_name }}"
       - uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - build-interop-docker-image-for-tags # TODO: remove
     tags:
       - 'v*'
   

--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -5,7 +5,7 @@ RUN echo "TARGETPLATFORM: ${TARGETPLATFORM}"
 
 RUN apt-get update && apt-get install -y wget tar git
 
-ENV GOVERSION=1.20.2
+ENV GOVERSION=1.20.7
 
 RUN platform=$(echo ${TARGETPLATFORM} | tr '/' '-') && \
   filename="go${GOVERSION}.${platform}.tar.gz" && \
@@ -18,14 +18,15 @@ ENV PATH="/go/bin:${PATH}"
 # build with --build-arg CACHEBUST=$(date +%s)
 ARG CACHEBUST=1
 
-RUN git clone https://github.com/quic-go/quic-go && \
-  cd quic-go && \
-  git fetch origin interop && git checkout -t origin/interop && \
-  go get ./...
+# build other branches / commits / tags using --build-arg GITREF="<git reference>"
+ARG GITREF="master"
 
+RUN git clone https://github.com/quic-go/quic-go
 WORKDIR /quic-go
+RUN git checkout ${GITREF}
+RUN go get ./...
 
-RUN git rev-parse HEAD > commit.txt
+RUN git rev-parse HEAD | tee commit.txt
 RUN go build -o server -ldflags="-X github.com/quic-go/quic-go/qlog.quicGoVersion=$(git describe --always --long --dirty)" interop/server/main.go
 RUN go build -o client -ldflags="-X github.com/quic-go/quic-go/qlog.quicGoVersion=$(git describe --always --long --dirty)" interop/client/main.go
 


### PR DESCRIPTION
This PR:
1. Builds a new interop Docker image for every push to master, so that the interop runner can always test the most recent image
2. Tags an image for releases. Those won't be picked up by the interop runner, but can be useful for debugging.