### PR TITLE
ci: fail if any Go files contain an ignore directive

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,13 @@ jobs:
           go-version: "1.20.x"
       - name: Check that no non-test files import Ginkgo or Gomega
         run: .github/workflows/no_ginkgo.sh
+      - name: Check for //go:build ignore in .go files
+        run: |
+          IGNORED_FILES=$(grep -rl '//go:build ignore' . --include='*.go') || true
+          if [ -n "$IGNORED_FILES" ]; then
+            echo "::error::Found ignored Go files: $IGNORED_FILES"
+            exit 1
+          fi
       - name: Check that go.mod is tidied
         run: |
           cp go.mod go.mod.orig


### PR DESCRIPTION
I _almost_ accidentally committed a test file containing an ignore directive. This wouldn't have been caught by CI, the code would just have been untested.