### PR TITLE
move GSO control message handling to the oobConn

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1832,7 +1832,7 @@ func (s *connection) sendPackets(now time.Time) error {
 		}
 		s.logShortHeaderPacket(p.DestConnID, p.Ack, p.Frames, p.StreamFrames, p.PacketNumber, p.PacketNumberLen, p.KeyPhase, buf.Len(), false)
 		s.registerPackedShortHeaderPacket(p, now)
-		s.sendQueue.Send(buf, buf.Len())
+		s.sendQueue.Send(buf, 0)
 		// This is kind of a hack. We need to trigger sending again somehow.
 		s.pacingDeadline = deadlineSendImmediately
 		return nil
@@ -1881,7 +1881,7 @@ func (s *connection) sendPacketsWithoutGSO(now time.Time) error {
 			return err
 		}
 
-		s.sendQueue.Send(buf, buf.Len())
+		s.sendQueue.Send(buf, 0)
 
 		if s.sendQueue.WouldBlock() {
 			return nil
@@ -1938,7 +1938,7 @@ func (s *connection) sendPacketsWithGSO(now time.Time) error {
 			continue
 		}
 
-		s.sendQueue.Send(buf, maxSize)
+		s.sendQueue.Send(buf, uint16(maxSize))
 
 		if dontSendMore {
 			return nil
@@ -1986,7 +1986,7 @@ func (s *connection) maybeSendAckOnlyPacket(now time.Time) error {
 	}
 	s.logShortHeaderPacket(p.DestConnID, p.Ack, p.Frames, p.StreamFrames, p.PacketNumber, p.PacketNumberLen, p.KeyPhase, buf.Len(), false)
 	s.registerPackedShortHeaderPacket(p, now)
-	s.sendQueue.Send(buf, buf.Len())
+	s.sendQueue.Send(buf, 0)
 	return nil
 }
 
@@ -2078,7 +2078,7 @@ func (s *connection) sendPackedCoalescedPacket(packet *coalescedPacket, now time
 		s.sentPacketHandler.SentPacket(now, p.PacketNumber, largestAcked, p.StreamFrames, p.Frames, protocol.Encryption1RTT, p.Length, p.IsPathMTUProbePacket)
 	}
 	s.connIDManager.SentPacket()
-	s.sendQueue.Send(packet.buffer, packet.buffer.Len())
+	s.sendQueue.Send(packet.buffer, 0)
 	return nil
 }
 
@@ -2101,7 +2101,7 @@ func (s *connection) sendConnectionClose(e error) ([]byte, error) {
 		return nil, err
 	}
 	s.logCoalescedPacket(packet)
-	return packet.buffer.Data, s.conn.Write(packet.buffer.Data, packet.buffer.Len())
+	return packet.buffer.Data, s.conn.Write(packet.buffer.Data, 0)
 }
 
 func (s *connection) logLongHeaderPacket(p *longHeaderPacket) {

--- a/mock_raw_conn_test.go
+++ b/mock_raw_conn_test.go
@@ -93,18 +93,18 @@ func (mr *MockRawConnMockRecorder) SetReadDeadline(arg0 interface{}) *gomock.Cal
 }
 
 // WritePacket mocks base method.
-func (m *MockRawConn) WritePacket(arg0 []byte, arg1 net.Addr, arg2 []byte) (int, error) {
+func (m *MockRawConn) WritePacket(arg0 []byte, arg1 net.Addr, arg2 []byte, arg3 uint16) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WritePacket", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "WritePacket", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WritePacket indicates an expected call of WritePacket.
-func (mr *MockRawConnMockRecorder) WritePacket(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRawConnMockRecorder) WritePacket(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePacket", reflect.TypeOf((*MockRawConn)(nil).WritePacket), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WritePacket", reflect.TypeOf((*MockRawConn)(nil).WritePacket), arg0, arg1, arg2, arg3)
 }
 
 // capabilities mocks base method.

--- a/mock_send_conn_test.go
+++ b/mock_send_conn_test.go
@@ -8,7 +8,6 @@ import (
 	net "net"
 	reflect "reflect"
 
-	protocol "github.com/quic-go/quic-go/internal/protocol"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -78,7 +77,7 @@ func (mr *MockSendConnMockRecorder) RemoteAddr() *gomock.Call {
 }
 
 // Write mocks base method.
-func (m *MockSendConn) Write(arg0 []byte, arg1 protocol.ByteCount) error {
+func (m *MockSendConn) Write(arg0 []byte, arg1 uint16) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/mock_sender_test.go
+++ b/mock_sender_test.go
@@ -7,7 +7,6 @@ package quic
 import (
 	reflect "reflect"
 
-	protocol "github.com/quic-go/quic-go/internal/protocol"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -75,7 +74,7 @@ func (mr *MockSenderMockRecorder) Run() *gomock.Call {
 }
 
 // Send mocks base method.
-func (m *MockSender) Send(arg0 *packetBuffer, arg1 protocol.ByteCount) {
+func (m *MockSender) Send(arg0 *packetBuffer, arg1 uint16) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Send", arg0, arg1)
 }

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -27,8 +27,9 @@ type connCapabilities struct {
 type rawConn interface {
 	ReadPacket() (receivedPacket, error)
 	// WritePacket writes a packet on the wire.
-	// If GSO is enabled, it's the caller's responsibility to set the correct control message.
-	WritePacket(b []byte, addr net.Addr, oob []byte) (int, error)
+	// gsoSize is the size of a single packet, or 0 to disable GSO.
+	// It is invalid to set gsoSize if capabilities.GSO is not set.
+	WritePacket(b []byte, addr net.Addr, packetInfoOOB []byte, gsoSize uint16) (int, error)
 	LocalAddr() net.Addr
 	SetReadDeadline(time.Time) error
 	io.Closer

--- a/send_queue.go
+++ b/send_queue.go
@@ -1,9 +1,8 @@
 package quic
 
-import "github.com/quic-go/quic-go/internal/protocol"
-
 type sender interface {
-	Send(p *packetBuffer, packetSize protocol.ByteCount)
+	// Send sends a packet. GSO is only used if gsoSize > 0.
+	Send(p *packetBuffer, gsoSize uint16)
 	Run() error
 	WouldBlock() bool
 	Available() <-chan struct{}
@@ -11,8 +10,8 @@ type sender interface {
 }
 
 type queueEntry struct {
-	buf  *packetBuffer
-	size protocol.ByteCount
+	buf     *packetBuffer
+	gsoSize uint16
 }
 
 type sendQueue struct {
@@ -40,9 +39,9 @@ func newSendQueue(conn sendConn) sender {
 // Send sends out a packet. It's guaranteed to not block.
 // Callers need to make sure that there's actually space in the send queue by calling WouldBlock.
 // Otherwise Send will panic.
-func (h *sendQueue) Send(p *packetBuffer, size protocol.ByteCount) {
+func (h *sendQueue) Send(p *packetBuffer, gsoSize uint16) {
 	select {
-	case h.queue <- queueEntry{buf: p, size: size}:
+	case h.queue <- queueEntry{buf: p, gsoSize: gsoSize}:
 		// clear available channel if we've reached capacity
 		if len(h.queue) == sendQueueCapacity {
 			select {
@@ -77,7 +76,7 @@ func (h *sendQueue) Run() error {
 			// make sure that all queued packets are actually sent out
 			shouldClose = true
 		case e := <-h.queue:
-			if err := h.conn.Write(e.buf.Data, e.size); err != nil {
+			if err := h.conn.Write(e.buf.Data, e.gsoSize); err != nil {
 				// This additional check enables:
 				// 1. Checking for "datagram too large" message from the kernel, as such,
 				// 2. Path MTU discovery,and

--- a/send_queue_test.go
+++ b/send_queue_test.go
@@ -3,8 +3,6 @@ package quic
 import (
 	"errors"
 
-	"github.com/quic-go/quic-go/internal/protocol"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -31,7 +29,7 @@ var _ = Describe("Send Queue", func() {
 		q.Send(p, 10) // make sure the packet size is passed through to the conn
 
 		written := make(chan struct{})
-		c.EXPECT().Write([]byte("foobar"), protocol.ByteCount(10)).Do(func([]byte, protocol.ByteCount) { close(written) })
+		c.EXPECT().Write([]byte("foobar"), uint16(10)).Do(func([]byte, uint16) { close(written) })
 		done := make(chan struct{})
 		go func() {
 			defer GinkgoRecover()
@@ -79,7 +77,7 @@ var _ = Describe("Send Queue", func() {
 		write := make(chan struct{}, 1)
 		written := make(chan struct{}, 100)
 		// now start sending out packets. This should free up queue space.
-		c.EXPECT().Write(gomock.Any(), gomock.Any()).DoAndReturn(func([]byte, protocol.ByteCount) error {
+		c.EXPECT().Write(gomock.Any(), gomock.Any()).DoAndReturn(func([]byte, uint16) error {
 			written <- struct{}{}
 			<-write
 			return nil
@@ -149,7 +147,7 @@ var _ = Describe("Send Queue", func() {
 
 	It("blocks Close() until the packet has been sent out", func() {
 		written := make(chan []byte)
-		c.EXPECT().Write(gomock.Any(), gomock.Any()).Do(func(p []byte, _ protocol.ByteCount) { written <- p })
+		c.EXPECT().Write(gomock.Any(), gomock.Any()).Do(func(p []byte, _ uint16) { written <- p })
 		done := make(chan struct{})
 		go func() {
 			defer GinkgoRecover()

--- a/server.go
+++ b/server.go
@@ -742,7 +742,7 @@ func (s *baseServer) sendRetry(remoteAddr net.Addr, hdr *wire.Header, info packe
 	if s.tracer != nil {
 		s.tracer.SentPacket(remoteAddr, &replyHdr.Header, protocol.ByteCount(len(buf.Data)), nil)
 	}
-	_, err = s.conn.WritePacket(buf.Data, remoteAddr, info.OOB())
+	_, err = s.conn.WritePacket(buf.Data, remoteAddr, info.OOB(), 0)
 	return err
 }
 
@@ -841,7 +841,7 @@ func (s *baseServer) sendError(remoteAddr net.Addr, hdr *wire.Header, sealer han
 	if s.tracer != nil {
 		s.tracer.SentPacket(remoteAddr, &replyHdr.Header, protocol.ByteCount(len(b.Data)), []logging.Frame{ccf})
 	}
-	_, err = s.conn.WritePacket(b.Data, remoteAddr, info.OOB())
+	_, err = s.conn.WritePacket(b.Data, remoteAddr, info.OOB(), 0)
 	return err
 }
 
@@ -879,7 +879,7 @@ func (s *baseServer) maybeSendVersionNegotiationPacket(p receivedPacket) {
 	if s.tracer != nil {
 		s.tracer.SentVersionNegotiationPacket(p.remoteAddr, src, dest, s.config.Versions)
 	}
-	if _, err := s.conn.WritePacket(data, p.remoteAddr, p.info.OOB()); err != nil {
+	if _, err := s.conn.WritePacket(data, p.remoteAddr, p.info.OOB(), 0); err != nil {
 		s.logger.Debugf("Error sending Version Negotiation: %s", err)
 	}
 }

--- a/sys_conn.go
+++ b/sys_conn.go
@@ -104,7 +104,10 @@ func (c *basicConn) ReadPacket() (receivedPacket, error) {
 	}, nil
 }
 
-func (c *basicConn) WritePacket(b []byte, addr net.Addr, _ []byte) (n int, err error) {
+func (c *basicConn) WritePacket(b []byte, addr net.Addr, _ []byte, gsoSize uint16) (n int, err error) {
+	if gsoSize != 0 {
+		panic("cannot use GSO with a basicConn")
+	}
 	return c.PacketConn.WriteTo(b, addr)
 }
 

--- a/sys_conn_helper_nonlinux_test.go
+++ b/sys_conn_helper_nonlinux_test.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package quic
+
+import "errors"
+
+var errGSO = errors.New("fake GSO error")

--- a/sys_conn_helper_nonlinux_test.go
+++ b/sys_conn_helper_nonlinux_test.go
@@ -1,7 +1,0 @@
-//go:build !linux
-
-package quic
-
-import "errors"
-
-var errGSO = errors.New("fake GSO error")

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -228,7 +228,6 @@ func (c *oobConn) ReadPacket() (receivedPacket, error) {
 }
 
 // WritePacket writes a new packet.
-// If the connection supports GSO, it's the caller's responsibility to append the right control mesage.
 func (c *oobConn) WritePacket(b []byte, addr net.Addr, packetInfoOOB []byte, gsoSize uint16) (int, error) {
 	oob := packetInfoOOB
 	if gsoSize > 0 {

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -229,7 +229,14 @@ func (c *oobConn) ReadPacket() (receivedPacket, error) {
 
 // WritePacket writes a new packet.
 // If the connection supports GSO, it's the caller's responsibility to append the right control mesage.
-func (c *oobConn) WritePacket(b []byte, addr net.Addr, oob []byte) (int, error) {
+func (c *oobConn) WritePacket(b []byte, addr net.Addr, packetInfoOOB []byte, gsoSize uint16) (int, error) {
+	oob := packetInfoOOB
+	if gsoSize > 0 {
+		if !c.capabilities().GSO {
+			panic("GSO disabled")
+		}
+		oob = appendUDPSegmentSizeMsg(oob, gsoSize)
+	}
 	n, _, err := c.OOBCapablePacketConn.WriteMsgUDP(b, oob, addr.(*net.UDPAddr))
 	return n, err
 }

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -18,6 +18,16 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+type oobRecordingConn struct {
+	*net.UDPConn
+	oobs [][]byte
+}
+
+func (c *oobRecordingConn) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
+	c.oobs = append(c.oobs, oob)
+	return c.UDPConn.WriteMsgUDP(b, oob, addr)
+}
+
 var _ = Describe("OOB Conn Test", func() {
 	runServer := func(network, address string) (*net.UDPConn, <-chan receivedPacket) {
 		addr, err := net.ResolveUDPAddr(network, address)
@@ -250,9 +260,19 @@ var _ = Describe("OOB Conn Test", func() {
 				Expect(err).ToNot(HaveOccurred())
 				udpConn, err := net.ListenUDP("udp", addr)
 				Expect(err).ToNot(HaveOccurred())
-				oobConn, err := newConn(udpConn, true)
+				c := &oobRecordingConn{UDPConn: udpConn}
+				oobConn, err := newConn(c, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(oobConn.capabilities().GSO).To(BeTrue())
+
+				oob := make([]byte, 0, 42)
+				oobConn.WritePacket([]byte("foobar"), addr, oob, 3)
+				Expect(c.oobs).To(HaveLen(1))
+				oobMsg := c.oobs[0]
+				Expect(oobMsg).ToNot(BeEmpty())
+				Expect(oobMsg).To(HaveCap(cap(oob))) // check that it appended to oob
+				expected := appendUDPSegmentSizeMsg([]byte{}, 3)
+				Expect(oobMsg).To(Equal(expected))
 			})
 		})
 	}

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -242,4 +242,18 @@ var _ = Describe("OOB Conn Test", func() {
 			}
 		})
 	})
+
+	if platformSupportsGSO {
+		Context("GSO", func() {
+			It("appends the GSO control message", func() {
+				addr, err := net.ResolveUDPAddr("udp", "localhost:0")
+				Expect(err).ToNot(HaveOccurred())
+				udpConn, err := net.ListenUDP("udp", addr)
+				Expect(err).ToNot(HaveOccurred())
+				oobConn, err := newConn(udpConn, true)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(oobConn.capabilities().GSO).To(BeTrue())
+			})
+		})
+	}
 })

--- a/transport.go
+++ b/transport.go
@@ -223,7 +223,7 @@ func (t *Transport) WriteTo(b []byte, addr net.Addr) (int, error) {
 	if err := t.init(false); err != nil {
 		return 0, err
 	}
-	return t.conn.WritePacket(b, addr, nil)
+	return t.conn.WritePacket(b, addr, nil, 0)
 }
 
 func (t *Transport) enqueueClosePacket(p closePacket) {
@@ -241,7 +241,7 @@ func (t *Transport) runSendQueue() {
 		case <-t.listening:
 			return
 		case p := <-t.closeQueue:
-			t.conn.WritePacket(p.payload, p.addr, p.info.OOB())
+			t.conn.WritePacket(p.payload, p.addr, p.info.OOB(), 0)
 		case p := <-t.statelessResetQueue:
 			t.sendStatelessReset(p)
 		}
@@ -409,7 +409,7 @@ func (t *Transport) sendStatelessReset(p receivedPacket) {
 	rand.Read(data)
 	data[0] = (data[0] & 0x7f) | 0x40
 	data = append(data, token[:]...)
-	if _, err := t.conn.WritePacket(data, p.remoteAddr, p.info.OOB()); err != nil {
+	if _, err := t.conn.WritePacket(data, p.remoteAddr, p.info.OOB(), 0); err != nil {
 		t.logger.Debugf("Error sending Stateless Reset to %s: %s", p.remoteAddr, err)
 	}
 }


### PR DESCRIPTION
For #3999. For ECN, we'll need to append even more control messages, and the current construction would get too complicated.