### PR TITLE
integration tests: fix connection timeout in 0-RTT test

### DIFF
--- a/integrationtests/self/zero_rtt_oldgo_test.go
+++ b/integrationtests/self/zero_rtt_oldgo_test.go
@@ -852,12 +852,12 @@ var _ = Describe("0-RTT", func() {
 
 		Expect(conn.ConnectionState().Used0RTT).To(BeTrue())
 		Expect(receivedMessage).To(Equal(sentMessage))
+		Expect(conn.CloseWithError(0, "")).To(Succeed())
 		num0RTT := atomic.LoadUint32(num0RTTPackets)
 		fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
 		Expect(num0RTT).ToNot(BeZero())
 		zeroRTTPackets := get0RTTPackets(tracer.getRcvdLongHeaderPackets())
 		Expect(zeroRTTPackets).To(HaveLen(1))
-		Expect(conn.CloseWithError(0, "")).To(Succeed())
 	})
 
 	It("rejects 0-RTT datagrams when the server doesn't support datagrams anymore", func() {
@@ -907,10 +907,10 @@ var _ = Describe("0-RTT", func() {
 
 		Expect(conn.ConnectionState().SupportsDatagrams).To(BeFalse())
 		Expect(conn.ConnectionState().Used0RTT).To(BeFalse())
+		Expect(conn.CloseWithError(0, "")).To(Succeed())
 		num0RTT := atomic.LoadUint32(num0RTTPackets)
 		fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
 		Expect(num0RTT).ToNot(BeZero())
 		Expect(get0RTTPackets(tracer.getRcvdLongHeaderPackets())).To(BeEmpty())
-		Expect(conn.CloseWithError(0, "")).To(Succeed())
 	})
 })

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -989,13 +989,13 @@ var _ = Describe("0-RTT", func() {
 		<-received
 
 		Expect(conn.ConnectionState().Used0RTT).To(BeTrue())
+		Expect(conn.CloseWithError(0, "")).To(Succeed())
 		Expect(receivedMessage).To(Equal(sentMessage))
 		num0RTT := atomic.LoadUint32(num0RTTPackets)
 		fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
 		Expect(num0RTT).ToNot(BeZero())
 		zeroRTTPackets := get0RTTPackets(tracer.getRcvdLongHeaderPackets())
 		Expect(zeroRTTPackets).To(HaveLen(1))
-		Expect(conn.CloseWithError(0, "")).To(Succeed())
 	})
 
 	It("rejects 0-RTT datagrams when the server doesn't support datagrams anymore", func() {
@@ -1047,10 +1047,10 @@ var _ = Describe("0-RTT", func() {
 
 		Expect(conn.ConnectionState().SupportsDatagrams).To(BeFalse())
 		Expect(conn.ConnectionState().Used0RTT).To(BeFalse())
+		Expect(conn.CloseWithError(0, "")).To(Succeed())
 		num0RTT := atomic.LoadUint32(num0RTTPackets)
 		fmt.Fprintf(GinkgoWriter, "Sent %d 0-RTT packets.", num0RTT)
 		Expect(num0RTT).ToNot(BeZero())
 		Expect(get0RTTPackets(tracer.getRcvdLongHeaderPackets())).To(BeEmpty())
-		Expect(conn.CloseWithError(0, "")).To(Succeed())
 	})
 })


### PR DESCRIPTION
In 0-RTT datagram test the connection/tracer is not closed before fetching the traced packets, which makes it cannot return until the connection becomes timeout.
FIxes #4058 