### PR TITLE
randomize the serialization order of control frames

### DIFF
--- a/packet_packer.go
+++ b/packet_packer.go
@@ -841,6 +841,8 @@ func (p *packetPacker) appendShortHeaderPacket(
 	}, nil
 }
 
+// appendPacketPayload serializes the payload of a packet into the raw byte slice.
+// It modifies the order of payload.frames.
 func (p *packetPacker) appendPacketPayload(raw []byte, pl payload, paddingLen protocol.ByteCount, v protocol.VersionNumber) ([]byte, error) {
 	payloadOffset := len(raw)
 	if pl.ack != nil {


### PR DESCRIPTION
We recently discovered a bug where the receiver relied on frames being sent in a particular order. This PR randomizes the order of what we call control frames (all frames other than ACK or STREAM frames) when packing the packet.

I'd like to randomize the order of the ACK as well (currently it's always serialized first). We could do this, but we wouldn't have a way to (q)log this without changing the tracer call, so this would be a bigger change: https://github.com/quic-go/quic-go/blob/591d864e5ee1953b181644f15abc5fecda2b9fdc/logging/interface.go#L117