### PR TITLE
ci: clean up Codecov ignore list

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,6 @@ coverage:
     - logging/null_tracer.go
     - fuzzing/
     - metrics/
-    - "**/mockgen.go"
   status:
     project:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,21 +1,14 @@
 coverage:
   round: nearest
   ignore:
-    - streams_map_incoming_bidi.go
-    - streams_map_incoming_uni.go
-    - streams_map_outgoing_bidi.go
-    - streams_map_outgoing_uni.go
     - http3/gzip_reader.go
     - interop/
-    - internal/ackhandler/packet_linkedlist.go
     - internal/handshake/cipher_suite.go
-    - internal/utils/byteinterval_linkedlist.go
-    - internal/utils/newconnectionid_linkedlist.go
-    - internal/utils/packetinterval_linkedlist.go
     - internal/utils/linkedlist/linkedlist.go
     - logging/null_tracer.go
     - fuzzing/
     - metrics/
+    - "**/mockgen.go"
   status:
     project:
       default:


### PR DESCRIPTION
Using generics allowed to remove a number of generated files.