### PR TITLE
catch EPERM sendmsg errors for the very first packet on Linux

### DIFF
--- a/sys_conn_helper_linux.go
+++ b/sys_conn_helper_linux.go
@@ -97,3 +97,14 @@ func isGSOError(err error) bool {
 	}
 	return false
 }
+
+// The first sendmsg call on a new UDP socket sometimes errors on Linux.
+// It's not clear why this happens.
+// See https://github.com/golang/go/issues/63322.
+func isPermissionError(err error) bool {
+	var serr *os.SyscallError
+	if errors.As(err, &serr) {
+		return serr.Syscall == "sendmsg" && serr.Err == unix.EPERM
+	}
+	return false
+}

--- a/sys_conn_helper_linux_test.go
+++ b/sys_conn_helper_linux_test.go
@@ -13,7 +13,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var errGSO = &os.SyscallError{Err: unix.EIO}
+var (
+	errGSO          = &os.SyscallError{Err: unix.EIO}
+	errNotPermitted = &os.SyscallError{Syscall: "sendmsg", Err: unix.EPERM}
+)
 
 var _ = Describe("forcing a change of send and receive buffer sizes", func() {
 	It("forces a change of the receive buffer size", func() {

--- a/sys_conn_helper_nonlinux.go
+++ b/sys_conn_helper_nonlinux.go
@@ -7,3 +7,4 @@ func forceSetSendBuffer(c any, bytes int) error    { return nil }
 
 func appendUDPSegmentSizeMsg([]byte, uint16) []byte { return nil }
 func isGSOError(error) bool                         { return false }
+func isPermissionError(err error) bool              { return false }

--- a/sys_conn_helper_nonlinux_test.go
+++ b/sys_conn_helper_nonlinux_test.go
@@ -4,4 +4,7 @@ package quic
 
 import "errors"
 
-var errGSO = errors.New("fake GSO error")
+var (
+	errGSO          = errors.New("fake GSO error")
+	errNotPermitted = errors.New("fake not permitted error")
+)


### PR DESCRIPTION
This is a workaround for https://github.com/golang/go/issues/63322. On Linux, we now ignore the EPERM error for the very first sendmsg call on a new connection, and retry exactly once.

This is expected to dramatically reduce the flakiness of our test suite.