### PR TITLE
handshake: set MinVersion on the Config returned by GetConfigForClient

### DIFF
--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -148,6 +148,8 @@ func addConnToClientHelloInfo(conf *tls.Config, localAddr, remoteAddr net.Addr) 
 			c, err := gcfc(info)
 			if c != nil {
 				c = c.Clone()
+				// This won't be necessary anymore once https://github.com/golang/go/issues/63722 is accepted.
+				c.MinVersion = tls.VersionTLS13
 				// We're returning a tls.Config here, so we need to apply this recursively.
 				addConnToClientHelloInfo(c, localAddr, remoteAddr)
 			}


### PR DESCRIPTION
Depends on #4133. Fixes #4131.