### PR TITLE
don't set the TLS version in the transport

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -191,7 +191,6 @@ func (t *Transport) dial(ctx context.Context, addr net.Addr, host string, tlsCon
 		onClose = func() { t.Close() }
 	}
 	tlsConf = tlsConf.Clone()
-	tlsConf.MinVersion = tls.VersionTLS13
 	setTLSConfigServerName(tlsConf, addr, host)
 	return dial(ctx, newSendConn(t.conn, addr, packetInfo{}, utils.DefaultLogger), t.connIDGenerator, t.handlerMap, tlsConf, conf, onClose, use0RTT)
 }


### PR DESCRIPTION
This is already done in the crypto setup:
https://github.com/quic-go/quic-go/blob/5311f8178c285a2e081319f4b6a892967dd090e6/internal/handshake/crypto_setup.go#L95