### PR TITLE
add HTTP3 datagram support

### DIFF
--- a/http3/datagram.go
+++ b/http3/datagram.go
@@ -1,0 +1,193 @@
+package http3
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+const DatagramRcvQueueLen = 128
+
+type datagrammerMap struct {
+	mutex   sync.RWMutex
+	conn    quic.Connection
+	streams map[protocol.StreamID]*streamAssociatedDatagrammer
+
+	// supported means HTTP/3 datagram is supported on both sides
+	supported                   bool
+	settingNegotiationCtx       context.Context
+	settingNegotiationCtxCancel context.CancelFunc
+
+	logger utils.Logger
+
+	runReceivingOnce sync.Once
+}
+
+func newDatagramManager(conn quic.Connection, logger utils.Logger) *datagrammerMap {
+	m := &datagrammerMap{
+		conn:    conn,
+		streams: make(map[protocol.StreamID]*streamAssociatedDatagrammer),
+		logger:  logger,
+	}
+	m.settingNegotiationCtx, m.settingNegotiationCtxCancel = context.WithCancel(context.Background())
+
+	return m
+}
+
+func (m *datagrammerMap) runReceiving() {
+	for {
+		data, err := m.conn.ReceiveDatagram(context.Background())
+		if err != nil {
+			m.logger.Debugf("Stop receiving datagram: %s", err)
+			return
+		}
+		buf := bytes.NewBuffer(data)
+		quarterStreamID, err := quicvarint.Read(buf)
+		if err != nil {
+			m.logger.Debugf("Reading datagram Quarter Stream ID failed: %s", err)
+			continue
+		}
+		streamID := quarterStreamID * 4
+		m.mutex.RLock()
+		stream, ok := m.streams[protocol.StreamID(streamID)]
+		m.mutex.RUnlock()
+		if !ok {
+			m.logger.Debugf("Received datagram for unknown stream: %d", streamID)
+			continue
+		}
+		stream.handleDatagram(buf.Bytes())
+	}
+}
+
+func (m *datagrammerMap) OnSettingReiceived(setting bool) {
+	m.supported = setting
+
+	if setting {
+		m.runReceivingOnce.Do(func() {
+			go m.runReceiving()
+		})
+	}
+	m.settingNegotiationCtxCancel()
+}
+
+func (m *datagrammerMap) SettingNegotiationComplete() <-chan struct{} {
+	return m.settingNegotiationCtx.Done()
+}
+
+func (m *datagrammerMap) Supported() bool {
+	return m.supported
+}
+
+// Datagrammer is an interface that can send and receive HTTP datagrams
+type Datagrammer interface {
+	// SendMessage sends an HTTP Datagram associated with an HTTP request.
+	// It must only be called while the send side of the stream is still open, i.e.
+	// * on the client side: before calling Close on the request body
+	// * on the server side: before calling Close on the response body
+	SendMessage([]byte) error
+	// SendMessage receives an HTTP Datagram associated with an HTTP request:
+	// * on the server side: datagrams can be received while the request handler hasn't returned, AND
+	//      the client hasn't close the request stream yet
+	// * on the client side: datagrams can be received with the server hasn't close the response stream
+	ReceiveMessage(context.Context) ([]byte, error)
+}
+
+// streamAssociatedDatagrammer allows sending and receiving HTTP/3 datagrams before the associated quic
+// stream is closed
+type streamAssociatedDatagrammer struct {
+	str  quic.Stream
+	conn quic.Connection
+
+	buf      []byte
+	rcvMx    sync.Mutex
+	rcvQueue [][]byte
+	rcvd     chan struct{}
+
+	manager *datagrammerMap
+}
+
+func (m *datagrammerMap) newStreamAssociatedDatagrammer(conn quic.Connection, str quic.Stream) *streamAssociatedDatagrammer {
+	d := &streamAssociatedDatagrammer{
+		str:     str,
+		conn:    conn,
+		rcvd:    make(chan struct{}),
+		manager: m,
+	}
+	m.mutex.Lock()
+	m.streams[str.StreamID()] = d
+	m.mutex.Unlock()
+	go func() {
+		<-str.Context().Done()
+		m.mutex.Lock()
+		delete(m.streams, str.StreamID())
+		m.mutex.Unlock()
+	}()
+	return d
+}
+
+func (d *streamAssociatedDatagrammer) SendMessage(data []byte) error {
+	select {
+	case <-d.str.Context().Done():
+		return fmt.Errorf("the corresponding stream is closed")
+	case <-d.manager.SettingNegotiationComplete():
+	}
+
+	if !d.manager.Supported() {
+		return errors.New("datagram is not supported by peer")
+	}
+	d.buf = d.buf[:0]
+	d.buf = (&datagramFrame{QuarterStreamID: uint64(d.str.StreamID() / 4)}).Append(d.buf)
+	d.buf = append(d.buf, data...)
+	return d.conn.SendDatagram(d.buf)
+}
+
+func (d *streamAssociatedDatagrammer) ReceiveMessage(ctx context.Context) ([]byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-d.str.Context().Done():
+		return nil, fmt.Errorf("the corresponding stream is closed")
+	case <-d.manager.SettingNegotiationComplete():
+	}
+
+	if !d.manager.Supported() {
+		return nil, errors.New("datagram is not supported by peer")
+	}
+	for {
+		d.rcvMx.Lock()
+		if len(d.rcvQueue) > 0 {
+			data := d.rcvQueue[0]
+			d.rcvQueue = d.rcvQueue[1:]
+			d.rcvMx.Unlock()
+			return data, nil
+		}
+		d.rcvMx.Unlock()
+		select {
+		case <-d.rcvd:
+			continue
+		case <-d.str.Context().Done():
+			return nil, fmt.Errorf("the corresponding stream is closed")
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (d *streamAssociatedDatagrammer) handleDatagram(data []byte) {
+	d.rcvMx.Lock()
+	if len(d.rcvQueue) < DatagramRcvQueueLen {
+		d.rcvQueue = append(d.rcvQueue, data)
+		select {
+		case d.rcvd <- struct{}{}:
+		default:
+		}
+	}
+	d.rcvMx.Unlock()
+}

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -162,3 +162,12 @@ func (f *settingsFrame) Append(b []byte) []byte {
 	}
 	return b
 }
+
+type datagramFrame struct {
+	QuarterStreamID uint64
+}
+
+func (f *datagramFrame) Append(b []byte) []byte {
+	b = quicvarint.Append(b, f.QuarterStreamID)
+	return b
+}

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
@@ -18,6 +19,26 @@ type unknownFrameHandlerFunc func(FrameType, error) (processed bool, err error)
 type frame interface{}
 
 var errHijacked = errors.New("hijacked")
+
+type PeerSettingsHandler interface {
+	HandleSettings(*settingsFrame)
+	GetPeerSettings() *settingsFrame
+}
+
+type peerSettingsHandler struct {
+	settings atomic.Pointer[settingsFrame]
+}
+
+func (m *peerSettingsHandler) HandleSettings(settings *settingsFrame) {
+	if m.settings.Load() != nil {
+		return
+	}
+	m.settings.Store(settings)
+}
+
+func (m *peerSettingsHandler) GetPeerSettings() *settingsFrame {
+	return m.settings.Load()
+}
 
 func parseNextFrame(r io.Reader, unknownFrameHandler unknownFrameHandlerFunc) (frame, error) {
 	qr := quicvarint.NewReader(r)

--- a/http3/mock_roundtripcloser_test.go
+++ b/http3/mock_roundtripcloser_test.go
@@ -152,3 +152,43 @@ func (c *RoundTripCloserRoundTripOptCall) DoAndReturn(f func(*http.Request, Roun
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// RoundTripOptWithDatagrams mocks base method.
+func (m *MockRoundTripCloser) RoundTripOptWithDatagrams(arg0 *http.Request, arg1 RoundTripOpt) (Datagrammer, <-chan RoundTripResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RoundTripOptWithDatagrams", arg0, arg1)
+	ret0, _ := ret[0].(Datagrammer)
+	ret1, _ := ret[1].(<-chan RoundTripResult)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// RoundTripOptWithDatagrams indicates an expected call of RoundTripOptWithDatagrams.
+func (mr *MockRoundTripCloserMockRecorder) RoundTripOptWithDatagrams(arg0, arg1 any) *RoundTripCloserRoundTripOptWithDatagramsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RoundTripOptWithDatagrams", reflect.TypeOf((*MockRoundTripCloser)(nil).RoundTripOptWithDatagrams), arg0, arg1)
+	return &RoundTripCloserRoundTripOptWithDatagramsCall{Call: call}
+}
+
+// RoundTripCloserRoundTripOptWithDatagramsCall wrap *gomock.Call
+type RoundTripCloserRoundTripOptWithDatagramsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *RoundTripCloserRoundTripOptWithDatagramsCall) Return(arg0 Datagrammer, arg1 <-chan RoundTripResult, arg2 error) *RoundTripCloserRoundTripOptWithDatagramsCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *RoundTripCloserRoundTripOptWithDatagramsCall) Do(f func(*http.Request, RoundTripOpt) (Datagrammer, <-chan RoundTripResult, error)) *RoundTripCloserRoundTripOptWithDatagramsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *RoundTripCloserRoundTripOptWithDatagramsCall) DoAndReturn(f func(*http.Request, RoundTripOpt) (Datagrammer, <-chan RoundTripResult, error)) *RoundTripCloserRoundTripOptWithDatagramsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -215,6 +215,8 @@ func (w *requestWriter) encodeHeaders(req *http.Request, addGzipHeader bool, tra
 
 // authorityAddr returns a given authority (a host/IP, or host:port / ip:port)
 // and returns a host:port. The port 443 is added if needed.
+//
+//nolint:unparam
 func authorityAddr(scheme string, authority string) (addr string) {
 	host, port, err := net.SplitHostPort(authority)
 	if err != nil { // authority didn't have a port

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -19,6 +19,7 @@ import (
 
 type roundTripCloser interface {
 	RoundTripOpt(*http.Request, RoundTripOpt) (*http.Response, error)
+	RoundTripOptWithDatagrams(req *http.Request, opt RoundTripOpt) (Datagrammer, <-chan RoundTripResult, error)
 	HandshakeComplete() bool
 	io.Closer
 }
@@ -109,36 +110,8 @@ var ErrNoCachedConn = errors.New("http3: no cached connection was available")
 
 // RoundTripOpt is like RoundTrip, but takes options.
 func (r *RoundTripper) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
-	if req.URL == nil {
-		closeRequestBody(req)
-		return nil, errors.New("http3: nil Request.URL")
-	}
-	if req.URL.Scheme != "https" {
-		closeRequestBody(req)
-		return nil, fmt.Errorf("http3: unsupported protocol scheme: %s", req.URL.Scheme)
-	}
-	if req.URL.Host == "" {
-		closeRequestBody(req)
-		return nil, errors.New("http3: no Host in request URL")
-	}
-	if req.Header == nil {
-		closeRequestBody(req)
-		return nil, errors.New("http3: nil Request.Header")
-	}
-	for k, vv := range req.Header {
-		if !httpguts.ValidHeaderFieldName(k) {
-			return nil, fmt.Errorf("http3: invalid http header field name %q", k)
-		}
-		for _, v := range vv {
-			if !httpguts.ValidHeaderFieldValue(v) {
-				return nil, fmt.Errorf("http3: invalid http header field value %q for key %v", v, k)
-			}
-		}
-	}
-
-	if req.Method != "" && !validMethod(req.Method) {
-		closeRequestBody(req)
-		return nil, fmt.Errorf("http3: invalid method %q", req.Method)
+	if err := validateRequest(req); err != nil {
+		return nil, err
 	}
 
 	hostname := authorityAddr("https", hostnameFromRequest(req))
@@ -298,4 +271,69 @@ func (r *RoundTripper) CloseIdleConnections() {
 			delete(r.clients, hostname)
 		}
 	}
+}
+
+// RoundTripResult is the result of a HTTP RoundTrip execuation
+type RoundTripResult struct {
+	Resp *http.Response
+	Err  error
+}
+
+// RoundTripOptWithDatagrams sends a request and immediately returns a Datagrammer and a channel for receiving the response
+func (r *RoundTripper) RoundTripWithDatagrams(req *http.Request, opt RoundTripOpt) (Datagrammer, <-chan RoundTripResult, error) {
+	if err := validateRequest(req); err != nil {
+		return nil, nil, err
+	}
+	// TODO: check the http method for datagrams, see RFC9297 Section 2
+
+	hostname := authorityAddr("https", hostnameFromRequest(req))
+	cl, isReused, err := r.getClient(hostname, opt.OnlyCachedConn)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer cl.useCount.Add(-1)
+	datagramer, rspChan, err := cl.RoundTripOptWithDatagrams(req, opt)
+	if err != nil {
+		r.removeClient(hostname)
+		if isReused {
+			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+				return r.RoundTripWithDatagrams(req, opt)
+			}
+		}
+	}
+	return datagramer, rspChan, err
+}
+
+func validateRequest(req *http.Request) error {
+	if req.URL == nil {
+		closeRequestBody(req)
+		return errors.New("http3: nil Request.URL")
+	}
+	if req.URL.Scheme != "https" {
+		closeRequestBody(req)
+		return fmt.Errorf("http3: unsupported protocol scheme: %s", req.URL.Scheme)
+	}
+	if req.URL.Host == "" {
+		closeRequestBody(req)
+		return errors.New("http3: no Host in request URL")
+	}
+	if req.Header == nil {
+		closeRequestBody(req)
+		return errors.New("http3: nil Request.Header")
+	}
+	for k, vv := range req.Header {
+		if !httpguts.ValidHeaderFieldName(k) {
+			return fmt.Errorf("http3: invalid http header field name %q", k)
+		}
+		for _, v := range vv {
+			if !httpguts.ValidHeaderFieldValue(v) {
+				return fmt.Errorf("http3: invalid http header field value %q for key %v", v, k)
+			}
+		}
+	}
+	if req.Method != "" && !validMethod(req.Method) {
+		closeRequestBody(req)
+		return fmt.Errorf("http3: invalid method %q", req.Method)
+	}
+	return nil
 }

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Server", func() {
 			}).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			Expect(s.handleRequest(conn, str, qpackDecoder, nil)).To(Equal(requestError{}))
+			Expect(s.handleRequest(conn, str, qpackDecoder, newResponseWriter, nil)).To(Equal(requestError{}))
 			var req *http.Request
 			Eventually(requestChan).Should(Receive(&req))
 			Expect(req.Host).To(Equal("www.example.com"))
@@ -174,7 +174,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, qpackDecoder, newResponseWriter, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -191,7 +191,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, qpackDecoder, newResponseWriter, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -213,7 +213,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, qpackDecoder, newResponseWriter, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -233,7 +233,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Context().Return(reqContext)
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, qpackDecoder, newResponseWriter, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -252,7 +252,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Context().Return(reqContext)
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, qpackDecoder, newResponseWriter, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -271,7 +271,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, qpackDecoder, newResponseWriter, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
@@ -287,7 +287,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, qpackDecoder, newResponseWriter, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
@@ -819,7 +819,7 @@ var _ = Describe("Server", func() {
 			}).AnyTimes()
 			str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeNoError))
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, qpackDecoder, newResponseWriter, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			Eventually(handlerCalled).Should(BeClosed())
 		})
@@ -842,7 +842,7 @@ var _ = Describe("Server", func() {
 			}).AnyTimes()
 			str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeNoError))
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, qpackDecoder, newResponseWriter, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			Eventually(handlerCalled).Should(BeClosed())
 		})

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -638,6 +638,10 @@ var _ = Describe("Server", func() {
 				r := bytes.NewReader(b)
 				controlStr := mockquic.NewMockStream(mockCtrl)
 				controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(r.Read).AnyTimes()
+				conn.EXPECT().ReceiveDatagram(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]byte, error) {
+					<-testDone
+					return []byte{}, nil
+				}).AnyTimes()
 				conn.EXPECT().AcceptUniStream(gomock.Any()).DoAndReturn(func(context.Context) (quic.ReceiveStream, error) {
 					return controlStr, nil
 				})


### PR DESCRIPTION
Implement HTTP/3 datagrams described in RFC9297 Section 2.1.
solves #3522.


Example for client side API:
```golang
req, _ := http.NewRequest("GET-DATAGRAM", "https://127.0.0.1:443/datagram", nil)
datagrammer, respChan, err := client.Transport.(*http3.RoundTripper).RoundTripWithDatagrams(req)
data, _ := datagrammer.ReceiveMessage(context.Background())
datagrammer.SendMessage(data)
```

Example for server side API:
```golang
server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
    datagrammer := w.(http3.Datagrammer)

    data, _ := datagrammer.ReceiveMessage(context.Background())
    datagrammer.SendMessage(data)
})
```