### PR TITLE
send large max_datagram_frame size, introduce a DatagramTooLargeError error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -61,3 +61,15 @@ func (e *StreamError) Error() string {
 	}
 	return fmt.Sprintf("stream %d canceled by %s with error code %d", e.StreamID, pers, e.ErrorCode)
 }
+
+// DatagramTooLargeError is returned from Connection.SendDatagram if the payload is too large to be sent.
+type DatagramTooLargeError struct {
+	PeerMaxDatagramFrameSize int64
+}
+
+func (e *DatagramTooLargeError) Is(target error) bool {
+	_, ok := target.(*DatagramTooLargeError)
+	return ok
+}
+
+func (e *DatagramTooLargeError) Error() string { return "DATAGRAM frame too large" }

--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -129,10 +129,6 @@ const MaxPostHandshakeCryptoFrameSize = 1000
 // but must ensure that a maximum size ACK frame fits into one packet.
 const MaxAckFrameSize ByteCount = 1000
 
-// MaxDatagramFrameSize is the maximum size of a DATAGRAM frame (RFC 9221).
-// The size is chosen such that a DATAGRAM frame fits into a QUIC packet.
-const MaxDatagramFrameSize ByteCount = 1200
-
 // DatagramRcvQueueLen is the length of the receive queue for DATAGRAM frames (RFC 9221)
 const DatagramRcvQueueLen = 128
 

--- a/internal/wire/datagram_frame.go
+++ b/internal/wire/datagram_frame.go
@@ -8,6 +8,12 @@ import (
 	"github.com/quic-go/quic-go/quicvarint"
 )
 
+// MaxDatagramSize is the maximum size of a DATAGRAM frame (RFC 9221).
+// By setting it to a large value, we allow all datagrams that fit into a QUIC packet.
+// The value is chosen such that it can still be encoded as a 2 byte varint.
+// This is a var and not a const so it can be set in tests.
+var MaxDatagramSize protocol.ByteCount = 16383
+
 // A DatagramFrame is a DATAGRAM frame
 type DatagramFrame struct {
 	DataLenPresent bool

--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -503,7 +503,7 @@ var _ = Describe("Transport Parameters", func() {
 				MaxBidiStreamNum:               protocol.StreamNum(getRandomValueUpTo(int64(protocol.MaxStreamCount))),
 				MaxUniStreamNum:                protocol.StreamNum(getRandomValueUpTo(int64(protocol.MaxStreamCount))),
 				ActiveConnectionIDLimit:        2 + getRandomValueUpTo(math.MaxInt64-2),
-				MaxDatagramFrameSize:           protocol.ByteCount(getRandomValueUpTo(int64(protocol.MaxDatagramFrameSize))),
+				MaxDatagramFrameSize:           protocol.ByteCount(getRandomValueUpTo(int64(MaxDatagramSize))),
 			}
 			Expect(params.ValidFor0RTT(params)).To(BeTrue())
 			b := params.MarshalForSessionTicket(nil)


### PR DESCRIPTION
The size can be overwritten to a lower value for testing. This implements the suggestion from https://github.com/quic-go/quic-go/issues/3300#issuecomment-1642475753.