### PR TITLE
ackhandler: immediately acknowledge ECN-CE marked packets

### DIFF
--- a/internal/ackhandler/received_packet_tracker.go
+++ b/internal/ackhandler/received_packet_tracker.go
@@ -143,17 +143,13 @@ func (h *receivedPacketTracker) maybeQueueACK(pn protocol.PacketNumber, rcvTime 
 
 	// queue an ACK if there are new missing packets to report
 	if h.hasNewMissingPackets() {
-		if h.logger.Debug() {
-			h.logger.Debugf("\tQueuing ACK because there's a new missing packet to report.")
-		}
+		h.logger.Debugf("\tQueuing ACK because there's a new missing packet to report.")
 		h.ackQueued = true
 	}
 
 	// queue an ACK if the packet was ECN-CE marked
 	if ecn == protocol.ECNCE {
-		if h.logger.Debug() {
-			h.logger.Debugf("\tQueuing ACK because the packet was ECN-CE marked.")
-		}
+		h.logger.Debugf("\tQueuing ACK because the packet was ECN-CE marked.")
 		h.ackQueued = true
 	}
 

--- a/internal/ackhandler/received_packet_tracker.go
+++ b/internal/ackhandler/received_packet_tracker.go
@@ -58,11 +58,9 @@ func (h *receivedPacketTracker) ReceivedPacket(pn protocol.PacketNumber, ecn pro
 
 	if ackEliciting {
 		h.hasNewAck = true
+		h.maybeQueueACK(pn, rcvTime, ecn, isMissing)
 	}
-	if ackEliciting {
-		h.maybeQueueACK(pn, rcvTime, isMissing)
-	}
-	//nolint:exhaustive // Only need to count ECT(0), ECT(1) and ECNCE.
+	//nolint:exhaustive // Only need to count ECT(0), ECT(1) and ECN-CE.
 	switch ecn {
 	case protocol.ECT0:
 		h.ect0++
@@ -104,7 +102,7 @@ func (h *receivedPacketTracker) hasNewMissingPackets() bool {
 }
 
 // maybeQueueACK queues an ACK, if necessary.
-func (h *receivedPacketTracker) maybeQueueACK(pn protocol.PacketNumber, rcvTime time.Time, wasMissing bool) {
+func (h *receivedPacketTracker) maybeQueueACK(pn protocol.PacketNumber, rcvTime time.Time, ecn protocol.ECN, wasMissing bool) {
 	// always acknowledge the first packet
 	if h.lastAck == nil {
 		if !h.ackQueued {
@@ -143,9 +141,19 @@ func (h *receivedPacketTracker) maybeQueueACK(pn protocol.PacketNumber, rcvTime 
 		h.ackAlarm = rcvTime.Add(h.maxAckDelay)
 	}
 
-	// Queue an ACK if there are new missing packets to report.
+	// queue an ACK if there are new missing packets to report
 	if h.hasNewMissingPackets() {
-		h.logger.Debugf("\tQueuing ACK because there's a new missing packet to report.")
+		if h.logger.Debug() {
+			h.logger.Debugf("\tQueuing ACK because there's a new missing packet to report.")
+		}
+		h.ackQueued = true
+	}
+
+	// queue an ACK if the packet was ECN-CE marked
+	if ecn == protocol.ECNCE {
+		if h.logger.Debug() {
+			h.logger.Debugf("\tQueuing ACK because the packet was ECN-CE marked.")
+		}
 		h.ackQueued = true
 	}
 


### PR DESCRIPTION
Fixes #4146.

Sending an ACK immediately when receiving an ECN-CE marked packet allows the sender to react to the marking faster. This is expected to be crucial for L4S to work properly, especially when used in conjunction with the ACK frequency extension.