### PR TITLE
http3: add settings frame handler for client and server

### DIFF
--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Response Body", func() {
 	It("closes the reqDone channel when Read errors", func() {
 		str := mockquic.NewMockStream(mockCtrl)
 		str.EXPECT().Read(gomock.Any()).Return(0, errors.New("test error"))
-		rb := newResponseBody(str, nil, reqDone)
+		rb := newResponseBody(str, nil, nil, reqDone)
 		_, err := rb.Read([]byte{0})
 		Expect(err).To(MatchError("test error"))
 		Expect(reqDone).To(BeClosed())
@@ -28,7 +28,7 @@ var _ = Describe("Response Body", func() {
 	It("allows multiple calls to Read, when Read errors", func() {
 		str := mockquic.NewMockStream(mockCtrl)
 		str.EXPECT().Read(gomock.Any()).Return(0, errors.New("test error")).Times(2)
-		rb := newResponseBody(str, nil, reqDone)
+		rb := newResponseBody(str, nil, nil, reqDone)
 		_, err := rb.Read([]byte{0})
 		Expect(err).To(HaveOccurred())
 		Expect(reqDone).To(BeClosed())
@@ -38,14 +38,14 @@ var _ = Describe("Response Body", func() {
 
 	It("closes responses", func() {
 		str := mockquic.NewMockStream(mockCtrl)
-		rb := newResponseBody(str, nil, reqDone)
+		rb := newResponseBody(str, nil, nil, reqDone)
 		str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeRequestCanceled))
 		Expect(rb.Close()).To(Succeed())
 	})
 
 	It("allows multiple calls to Close", func() {
 		str := mockquic.NewMockStream(mockCtrl)
-		rb := newResponseBody(str, nil, reqDone)
+		rb := newResponseBody(str, nil, nil, reqDone)
 		str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeRequestCanceled)).MaxTimes(2)
 		Expect(rb.Close()).To(Succeed())
 		Expect(reqDone).To(BeClosed())

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -656,7 +656,7 @@ var _ = Describe("Client", func() {
 			buf := &bytes.Buffer{}
 			rstr := mockquic.NewMockStream(mockCtrl)
 			rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
-			rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
+			rw := newResponseWriter(rstr, nil, nil, utils.DefaultLogger)
 			rw.WriteHeader(status)
 			rw.Flush()
 			return buf.Bytes()
@@ -994,7 +994,7 @@ var _ = Describe("Client", func() {
 				buf := &bytes.Buffer{}
 				rstr := mockquic.NewMockStream(mockCtrl)
 				rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
-				rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
+				rw := newResponseWriter(rstr, nil, nil, utils.DefaultLogger)
 				rw.Header().Set("Content-Encoding", "gzip")
 				gz := gzip.NewWriter(rw)
 				gz.Write([]byte("gzipped response"))
@@ -1020,7 +1020,7 @@ var _ = Describe("Client", func() {
 				buf := &bytes.Buffer{}
 				rstr := mockquic.NewMockStream(mockCtrl)
 				rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
-				rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
+				rw := newResponseWriter(rstr, nil, nil, utils.DefaultLogger)
 				rw.Write([]byte("not gzipped"))
 				rw.Flush()
 				str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Response Writer", func() {
 		str.EXPECT().Write(gomock.Any()).DoAndReturn(strBuf.Write).AnyTimes()
 		str.EXPECT().SetReadDeadline(gomock.Any()).Return(nil).AnyTimes()
 		str.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil).AnyTimes()
-		rw = newResponseWriter(str, nil, utils.DefaultLogger)
+		rw = newResponseWriter(str, nil, nil, utils.DefaultLogger)
 	})
 
 	decodeHeader := func(str io.Reader) map[string][]string {

--- a/http3/server.go
+++ b/http3/server.go
@@ -437,7 +437,7 @@ func (s *Server) handleConn(conn quic.Connection) error {
 	b = (&settingsFrame{Datagram: s.EnableDatagrams, Other: s.AdditionalSettings}).Append(b)
 	str.Write(b)
 
-	settingsHandler := &peerSettingsHandler{}
+	settingsHandler := newPeerSettingsHandler()
 	go s.handleUnidirectionalStreams(conn, settingsHandler)
 
 	// Process all requests immediately.

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Server", func() {
 			}).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			Expect(s.handleRequest(conn, str, qpackDecoder, nil)).To(Equal(requestError{}))
+			Expect(s.handleRequest(conn, str, nil, qpackDecoder, nil)).To(Equal(requestError{}))
 			var req *http.Request
 			Eventually(requestChan).Should(Receive(&req))
 			Expect(req.Host).To(Equal("www.example.com"))
@@ -174,7 +174,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, nil, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -191,7 +191,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, nil, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -213,7 +213,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, nil, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -233,7 +233,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Context().Return(reqContext)
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, nil, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -252,7 +252,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Context().Return(reqContext)
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, nil, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -271,7 +271,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, nil, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
@@ -287,7 +287,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().Write(gomock.Any()).DoAndReturn(responseBuf.Write).AnyTimes()
 			str.EXPECT().CancelRead(gomock.Any())
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, nil, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
@@ -819,7 +819,7 @@ var _ = Describe("Server", func() {
 			}).AnyTimes()
 			str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeNoError))
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, nil, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			Eventually(handlerCalled).Should(BeClosed())
 		})
@@ -842,7 +842,7 @@ var _ = Describe("Server", func() {
 			}).AnyTimes()
 			str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeNoError))
 
-			serr := s.handleRequest(conn, str, qpackDecoder, nil)
+			serr := s.handleRequest(conn, str, nil, qpackDecoder, nil)
 			Expect(serr.err).ToNot(HaveOccurred())
 			Eventually(handlerCalled).Should(BeClosed())
 		})


### PR DESCRIPTION
Add a peerSettingsHandler on both http3 client and server side.  This allows the client (the hijackableBody) and the server (the responseWriter) to check if the settings frame from peer is received and get peer's settings. I think this is needed in implementing http/3 datagrams as well as WebTransport where the settings frame must be checked before starting the communication.

fixes #4160 