### PR TITLE
fix serialization of connection ID in filenames of qlog files

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ quic.Config{
     if p == logging.PerspectiveClient {
       role = "client"
     }
-    filename := fmt.Sprintf("./log_%x_%s.qlog", connID, role)
+    filename := fmt.Sprintf("./log_%s_%s.qlog", connID, role)
     f, err := os.Create(filename)
     // handle the error
     return qlog.NewConnectionTracer(f, p, connID)

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -59,7 +59,7 @@ func main() {
 	var qconf quic.Config
 	if *enableQlog {
 		qconf.Tracer = func(ctx context.Context, p logging.Perspective, connID quic.ConnectionID) *logging.ConnectionTracer {
-			filename := fmt.Sprintf("client_%x.qlog", connID)
+			filename := fmt.Sprintf("client_%s.qlog", connID)
 			f, err := os.Create(filename)
 			if err != nil {
 				log.Fatal(err)

--- a/example/main.go
+++ b/example/main.go
@@ -164,7 +164,7 @@ func main() {
 	quicConf := &quic.Config{}
 	if *enableQlog {
 		quicConf.Tracer = func(ctx context.Context, p logging.Perspective, connID quic.ConnectionID) *logging.ConnectionTracer {
-			filename := fmt.Sprintf("server_%x.qlog", connID)
+			filename := fmt.Sprintf("server_%s.qlog", connID)
 			f, err := os.Create(filename)
 			if err != nil {
 				log.Fatal(err)

--- a/integrationtests/tools/qlog.go
+++ b/integrationtests/tools/qlog.go
@@ -20,7 +20,7 @@ func NewQlogger(logger io.Writer) func(context.Context, logging.Perspective, qui
 		if p == logging.PerspectiveClient {
 			role = "client"
 		}
-		filename := fmt.Sprintf("log_%x_%s.qlog", connID.Bytes(), role)
+		filename := fmt.Sprintf("log_%s_%s.qlog", connID, role)
 		fmt.Fprintf(logger, "Creating %s.\n", filename)
 		f, err := os.Create(filename)
 		if err != nil {

--- a/interop/utils/logging.go
+++ b/interop/utils/logging.go
@@ -39,7 +39,7 @@ func NewQLOGConnectionTracer(_ context.Context, p logging.Perspective, connID qu
 			log.Fatalf("failed to create qlog dir %s: %v", qlogDir, err)
 		}
 	}
-	path := fmt.Sprintf("%s/%x.qlog", strings.TrimRight(qlogDir, "/"), connID)
+	path := fmt.Sprintf("%s/%s.qlog", strings.TrimRight(qlogDir, "/"), connID)
 	f, err := os.Create(path)
 	if err != nil {
 		log.Printf("Failed to create qlog file %s: %s", path, err.Error())


### PR DESCRIPTION
Connection IDs should be printed in hexadecimal. It's best to just the `fmt.Stringer` representation everywhere.

I noticed this when looking at the qlogs in #4169.