### PR TITLE
http3: reset stream when a handler panics

### DIFF
--- a/http3/frames.go
+++ b/http3/frames.go
@@ -19,6 +19,8 @@ type frame interface{}
 
 var errHijacked = errors.New("hijacked")
 
+var errPanicked = errors.New("panicked")
+
 func parseNextFrame(r io.Reader, unknownFrameHandler unknownFrameHandlerFunc) (frame, error) {
 	qr := quicvarint.NewReader(r)
 	for {

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -19,8 +19,6 @@ type frame interface{}
 
 var errHijacked = errors.New("hijacked")
 
-var errPanicked = errors.New("panicked")
-
 func parseNextFrame(r io.Reader, unknownFrameHandler unknownFrameHandlerFunc) (frame, error) {
 	qr := quicvarint.NewReader(r)
 	for {

--- a/http3/server.go
+++ b/http3/server.go
@@ -641,6 +641,11 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 	}
 	// If the EOF was read by the handler, CancelRead() is a no-op.
 	str.CancelRead(quic.StreamErrorCode(ErrCodeNoError))
+
+	// abort the stream when there is a panic
+	if panicked {
+		return newStreamError(ErrCodeInternalError, errPanicked)
+	}
 	return requestError{}
 }
 

--- a/http3/server.go
+++ b/http3/server.go
@@ -30,6 +30,7 @@ var (
 	quicListenAddr = func(addr string, tlsConf *tls.Config, config *quic.Config) (QUICEarlyListener, error) {
 		return quic.ListenAddrEarly(addr, tlsConf, config)
 	}
+	errPanicked = errors.New("panicked")
 )
 
 // NextProtoH3 is the ALPN protocol negotiated during the TLS handshake, for QUIC v1 and v2.

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().CancelRead(gomock.Any())
 
 			serr := s.handleRequest(conn, str, qpackDecoder, nil)
-			Expect(serr.err).ToNot(HaveOccurred())
+			Expect(serr.err).To(HaveOccurred())
 			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
 
@@ -288,7 +288,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().CancelRead(gomock.Any())
 
 			serr := s.handleRequest(conn, str, qpackDecoder, nil)
-			Expect(serr.err).ToNot(HaveOccurred())
+			Expect(serr.err).To(HaveOccurred())
 			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
 

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().CancelRead(gomock.Any())
 
 			serr := s.handleRequest(conn, str, qpackDecoder, nil)
-			Expect(serr.err).To(Equal(errPanicked))
+			Expect(serr.err).To(MatchError(errPanicked))
 			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
 
@@ -288,7 +288,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().CancelRead(gomock.Any())
 
 			serr := s.handleRequest(conn, str, qpackDecoder, nil)
-			Expect(serr.err).To(HaveOccurred())
+			Expect(serr.err).To(MatchError(errPanicked))
 			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
 

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Server", func() {
 			str.EXPECT().CancelRead(gomock.Any())
 
 			serr := s.handleRequest(conn, str, qpackDecoder, nil)
-			Expect(serr.err).To(HaveOccurred())
+			Expect(serr.err).To(Equal(errPanicked))
 			Expect(responseBuf.Bytes()).To(HaveLen(0))
 		})
 

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -154,8 +154,8 @@ var _ = Describe("HTTP tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		body, err := io.ReadAll(resp.Body)
 		Expect(err).To(HaveOccurred())
-		// in reality the parts of the body is undetermined, but it's a test
-		Expect(body).To(Equal([]byte("foobar")))
+		// the body will be a prefix of what's written
+		Expect(bytes.HasPrefix([]byte("foobar"), body)).To(BeTrue())
 	})
 
 	It("requests to different servers with the same udpconn", func() {


### PR DESCRIPTION
When debugging an [issue](https://github.com/caddyserver/caddy/issues/5951) for caddy, I found http3 server handler will not correctly propagate stream error. Code example [here](https://github.com/caddyserver/caddy/issues/5951#issuecomment-1823731441).

In this case `Content-Length` is set, http3 may use that info to infer the stream doesn't terminate properly. But in a streaming environment if there is an error upstream, client should be able to know there is an error at a stream level just like http2 regardless of the presence of `Content-Length`.