### PR TITLE
qtls: only attempt 0-RTT resumption for 0-RTT enabled session tickets

### DIFF
--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -692,6 +692,49 @@ var _ = Describe("0-RTT", func() {
 		Expect(get0RTTPackets(counter.getRcvdLongHeaderPackets())).To(BeEmpty())
 	})
 
+	It("doesn't use 0-RTT, if the server didn't enable it", func() {
+		server, err := quic.ListenAddr("localhost:0", getTLSConfig(), getQuicConfig(nil))
+		Expect(err).ToNot(HaveOccurred())
+		defer server.Close()
+
+		gets := make(chan string, 100)
+		puts := make(chan string, 100)
+		cache := newClientSessionCache(tls.NewLRUClientSessionCache(10), gets, puts)
+		tlsConf := getTLSClientConfig()
+		tlsConf.ClientSessionCache = cache
+		conn1, err := quic.DialAddr(
+			context.Background(),
+			fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
+			tlsConf,
+			getQuicConfig(nil),
+		)
+		Expect(err).ToNot(HaveOccurred())
+		defer conn1.CloseWithError(0, "")
+		var sessionKey string
+		Eventually(puts).Should(Receive(&sessionKey))
+		Expect(conn1.ConnectionState().TLS.DidResume).To(BeFalse())
+
+		serverConn, err := server.Accept(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(serverConn.ConnectionState().TLS.DidResume).To(BeFalse())
+
+		conn2, err := quic.DialAddrEarly(
+			context.Background(),
+			fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
+			tlsConf,
+			getQuicConfig(nil),
+		)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gets).To(Receive(Equal(sessionKey)))
+		Expect(conn2.ConnectionState().TLS.DidResume).To(BeTrue())
+
+		serverConn, err = server.Accept(context.Background())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(serverConn.ConnectionState().TLS.DidResume).To(BeTrue())
+		Expect(serverConn.ConnectionState().Used0RTT).To(BeFalse())
+		conn2.CloseWithError(0, "")
+	})
+
 	DescribeTable("flow control limits",
 		func(addFlowControlLimit func(*quic.Config, uint64)) {
 			counter, tracer := newPacketTracer()

--- a/internal/qtls/client_session_cache.go
+++ b/internal/qtls/client_session_cache.go
@@ -7,8 +7,8 @@ import (
 )
 
 type clientSessionCache struct {
-	getData func() []byte
-	setData func([]byte) (allowEarlyData bool)
+	getData func(earlyData bool) []byte
+	setData func(data []byte, earlyData bool) (allowEarlyData bool)
 	wrapped tls.ClientSessionCache
 }
 
@@ -24,7 +24,7 @@ func (c clientSessionCache) Put(key string, cs *tls.ClientSessionState) {
 		c.wrapped.Put(key, cs)
 		return
 	}
-	state.Extra = append(state.Extra, addExtraPrefix(c.getData()))
+	state.Extra = append(state.Extra, addExtraPrefix(c.getData(state.EarlyData)))
 	newCS, err := tls.NewResumptionState(ticket, state)
 	if err != nil {
 		// It's not clear why this would error. Just save the original state.
@@ -46,12 +46,13 @@ func (c clientSessionCache) Get(key string) (*tls.ClientSessionState, bool) {
 		c.wrapped.Put(key, nil)
 		return nil, false
 	}
-	var earlyData bool
 	// restore QUIC transport parameters and RTT stored in state.Extra
 	if extra := findExtraData(state.Extra); extra != nil {
-		earlyData = c.setData(extra)
+		earlyData := c.setData(extra, state.EarlyData)
+		if state.EarlyData {
+			state.EarlyData = earlyData
+		}
 	}
-	state.EarlyData = earlyData
 	session, err := tls.NewResumptionState(ticket, state)
 	if err != nil {
 		// It's not clear why this would error.

--- a/internal/qtls/client_session_cache_test.go
+++ b/internal/qtls/client_session_cache_test.go
@@ -40,8 +40,9 @@ var _ = Describe("Client Session Cache", func() {
 			RootCAs: testdata.GetRootCA(),
 			ClientSessionCache: &clientSessionCache{
 				wrapped: tls.NewLRUClientSessionCache(10),
-				getData: func() []byte { return []byte("session") },
-				setData: func(data []byte) bool {
+				getData: func(bool) []byte { return []byte("session") },
+				setData: func(data []byte, earlyData bool) bool {
+					Expect(earlyData).To(BeFalse()) // running on top of TCP, we can only test non-0-RTT here
 					restored <- data
 					return true
 				},

--- a/internal/qtls/go121.go
+++ b/internal/qtls/go121.go
@@ -93,7 +93,11 @@ func SetupConfigForServer(qconf *QUICConfig, _ bool, getData func() []byte, hand
 	}
 }
 
-func SetupConfigForClient(qconf *QUICConfig, getData func() []byte, setData func([]byte) bool) {
+func SetupConfigForClient(
+	qconf *QUICConfig,
+	getData func(earlyData bool) []byte,
+	setData func(data []byte, earlyData bool) (allowEarlyData bool),
+) {
 	conf := qconf.TLSConfig
 	if conf.ClientSessionCache != nil {
 		origCache := conf.ClientSessionCache


### PR DESCRIPTION
In specific, these lines would overwrite the `EarlyData` property from `false` to `true`, when doing session resumption using `DialEarly` (code from master):
https://github.com/quic-go/quic-go/blob/2d7ea376729d317e2fbce7ff5ae44ad180ffefdb/internal/qtls/client_session_cache.go#L49-L54

In addition to fixing that, we now also avoid saving the transport parameters into the session ticket for non-0-RTT tickets (code from this PR): https://github.com/quic-go/quic-go/blob/3e984c14b18ee61a830cef348832f56bda45eab0/internal/handshake/crypto_setup.go#L320-L324