### PR TITLE
examples: close listener, connection and stream in echo client and server

### DIFF
--- a/example/echo/echo.go
+++ b/example/echo/echo.go
@@ -42,11 +42,14 @@ func echoServer() error {
 	if err != nil {
 		return err
 	}
+	defer conn.CloseWithError(0, "")
+
 	stream, err := conn.AcceptStream(context.Background())
 	if err != nil {
 		panic(err)
 	}
 	defer stream.Close()
+
 	// Echo through the loggingWriter
 	_, err = io.Copy(loggingWriter{stream}, stream)
 	return err
@@ -61,6 +64,7 @@ func clientMain() error {
 	if err != nil {
 		return err
 	}
+	defer conn.CloseWithError(0, "")
 
 	stream, err := conn.OpenStreamSync(context.Background())
 	if err != nil {

--- a/example/echo/echo.go
+++ b/example/echo/echo.go
@@ -36,6 +36,8 @@ func echoServer() error {
 	if err != nil {
 		return err
 	}
+	defer listener.Close()
+
 	conn, err := listener.Accept(context.Background())
 	if err != nil {
 		return err
@@ -44,6 +46,7 @@ func echoServer() error {
 	if err != nil {
 		panic(err)
 	}
+	defer stream.Close()
 	// Echo through the loggingWriter
 	_, err = io.Copy(loggingWriter{stream}, stream)
 	return err
@@ -63,6 +66,7 @@ func clientMain() error {
 	if err != nil {
 		return err
 	}
+	defer stream.Close()
 
 	fmt.Printf("Client: Sending '%s'\n", message)
 	_, err = stream.Write([]byte(message))

--- a/example/echo/echo.go
+++ b/example/echo/echo.go
@@ -42,7 +42,6 @@ func echoServer() error {
 	if err != nil {
 		return err
 	}
-	defer conn.CloseWithError(0, "")
 
 	stream, err := conn.AcceptStream(context.Background())
 	if err != nil {


### PR DESCRIPTION
### summary

I think close resource when server/client exit in example, This will help you to better use `quic-go`. I didn't close the resource at the beginning. 😅 