### PR TITLE
fuzzing: update Go version to 1.21

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -3,7 +3,7 @@ FROM gcr.io/oss-fuzz-base/base-builder-go:v1
 ARG TARGETPLATFORM
 RUN echo "TARGETPLATFORM: ${TARGETPLATFORM}"
 
-ENV GOVERSION=1.20.7
+ENV GOVERSION=1.21.5
 
 RUN platform=$(echo ${TARGETPLATFORM} | tr '/' '-') && \
   filename="go${GOVERSION}.${platform}.tar.gz" && \

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -3,12 +3,12 @@
 # Install Go manually, since oss-fuzz ships with an outdated Go version.
 # See https://github.com/google/oss-fuzz/pull/10643.
 export CXX="${CXX} -lresolv" # required by Go 1.20
-wget https://go.dev/dl/go1.20.5.linux-amd64.tar.gz \
+wget https://go.dev/dl/go1.21.5.linux-amd64.tar.gz \
   && mkdir temp-go \
   && rm -rf /root/.go/* \
-  && tar -C temp-go/ -xzf go1.20.5.linux-amd64.tar.gz \
+  && tar -C temp-go/ -xzf go1.21.5.linux-amd64.tar.gz \
   && mv temp-go/go/* /root/.go/ \
-  && rm -rf temp-go go1.20.5.linux-amd64.tar.gz
+  && rm -rf temp-go go1.21.5.linux-amd64.tar.gz
 
 (
 # fuzz qpack


### PR DESCRIPTION
In preparation for dropping Go 1.20 support.