### PR TITLE
http3: add remote address to request context

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -115,6 +115,16 @@ func (k *contextKey) String() string { return "quic-go/http3 context value " + k
 // type *http3.Server.
 var ServerContextKey = &contextKey{"http3-server"}
 
+// RemoteAddrContextKey is a context key. It can be used in
+// HTTP handlers with Context.Value to access the remote
+// address of the connection. The associated value will be of
+// type net.Addr.
+//
+// Use this value instead of [http.Request.RemoteAddr] if you
+// require access to the remote address of the connection rather
+// than its string representation.
+var RemoteAddrContextKey = &contextKey{"remote-addr"}
+
 type requestError struct {
 	err       error
 	streamErr ErrCode
@@ -597,6 +607,7 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 	ctx := str.Context()
 	ctx = context.WithValue(ctx, ServerContextKey, s)
 	ctx = context.WithValue(ctx, http.LocalAddrContextKey, conn.LocalAddr())
+	ctx = context.WithValue(ctx, RemoteAddrContextKey, conn.RemoteAddr())
 	req = req.WithContext(ctx)
 	r := newResponseWriter(str, conn, s.logger)
 	if req.Method == http.MethodHead {

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -481,4 +481,16 @@ var _ = Describe("HTTP tests", func() {
 		Expect(time.Now().After(expectedEnd)).To(BeTrue())
 		Expect(string(body)).To(ContainSubstring("aa"))
 	})
+
+	It("sets remote address", func() {
+		mux.HandleFunc("/remote-addr", func(w http.ResponseWriter, r *http.Request) {
+			defer GinkgoRecover()
+			_, ok := r.Context().Value(http3.RemoteAddrContextKey).(net.Addr)
+			Expect(ok).To(BeTrue())
+		})
+
+		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/remote-addr", port))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(200))
+	})
 })


### PR DESCRIPTION
Add the remote address of the underlying packet connection to the HTTP request context. This is useful for applications that need access to the actual remote address (wrapped in a net.Addr) rather than just its string representation.

Fixes #4198