### PR TITLE
http3: don't use error string as a format string

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -273,7 +273,7 @@ func (s *Server) ServeListener(ln QUICEarlyListener) error {
 		}
 		go func() {
 			if err := s.handleConn(conn); err != nil {
-				s.logger.Debugf(err.Error())
+				s.logger.Debugf("handling connection failed: %s", err)
 			}
 		}()
 	}


### PR DESCRIPTION
Fixes: #4209