### PR TITLE
Greasing QUIC bit (RFC 9287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ quic-go is an implementation of the QUIC protocol ([RFC 9000](https://datatracke
 In addition to these base RFCs, it also implements the following RFCs: 
 * Unreliable Datagram Extension ([RFC 9221](https://datatracker.ietf.org/doc/html/rfc9221))
 * Datagram Packetization Layer Path MTU Discovery (DPLPMTUD, [RFC 8899](https://datatracker.ietf.org/doc/html/rfc8899))
+* Greasing the QUIC Bit ([RFC 9287](https://datatracker.ietf.org/doc/html/rfc9287))
 * QUIC Version 2 ([RFC 9369](https://datatracker.ietf.org/doc/html/rfc9369))
 * QUIC Event Logging using qlog ([draft-ietf-quic-qlog-main-schema](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-main-schema/) and [draft-ietf-quic-qlog-quic-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-quic-events/))
 

--- a/config.go
+++ b/config.go
@@ -124,6 +124,7 @@ func populateConfig(config *Config) *Config {
 		EnableDatagrams:                config.EnableDatagrams,
 		DisablePathMTUDiscovery:        config.DisablePathMTUDiscovery,
 		Allow0RTT:                      config.Allow0RTT,
+		DisableQUICBitGreasing:         config.DisableQUICBitGreasing,
 		Tracer:                         config.Tracer,
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -104,6 +104,8 @@ var _ = Describe("Config", func() {
 				f.Set(reflect.ValueOf(true))
 			case "Allow0RTT":
 				f.Set(reflect.ValueOf(true))
+			case "DisableQUICBitGreasing":
+				f.Set(reflect.ValueOf(true))
 			default:
 				Fail(fmt.Sprintf("all fields must be accounted for, but saw unknown field %q", fn))
 			}
@@ -185,6 +187,7 @@ var _ = Describe("Config", func() {
 			Expect(c.MaxIncomingUniStreams).To(BeEquivalentTo(protocol.DefaultMaxIncomingUniStreams))
 			Expect(c.DisablePathMTUDiscovery).To(BeFalse())
 			Expect(c.GetConfigForClient).To(BeNil())
+			Expect(c.DisableQUICBitGreasing).To(BeFalse())
 		})
 
 		It("populates empty fields with default values, for the server", func() {

--- a/connection.go
+++ b/connection.go
@@ -331,7 +331,7 @@ var newConnection = func(
 	)
 	s.cryptoStreamHandler = cs
 	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, s.receivedPacketHandler, s.datagramQueue, s.perspective)
-	s.unpacker = newPacketUnpacker(cs, s.srcConnIDLen)
+	s.unpacker = newPacketUnpacker(cs, s.srcConnIDLen, s.quicBitGreasingEnabled)
 	s.cryptoStreamManager = newCryptoStreamManager(cs, s.initialStream, s.handshakeStream, s.oneRTTStream)
 	return s
 }
@@ -437,7 +437,7 @@ var newClientConnection = func(
 	)
 	s.cryptoStreamHandler = cs
 	s.cryptoStreamManager = newCryptoStreamManager(cs, s.initialStream, s.handshakeStream, oneRTTStream)
-	s.unpacker = newPacketUnpacker(cs, s.srcConnIDLen)
+	s.unpacker = newPacketUnpacker(cs, s.srcConnIDLen, s.quicBitGreasingEnabled)
 	s.packer = newPacketPacker(srcConnID, s.connIDManager.Get, s.initialStream, s.handshakeStream, s.sentPacketHandler, s.retransmissionQueue, cs, s.framer, s.receivedPacketHandler, s.datagramQueue, s.perspective)
 	if len(tlsConf.ServerName) > 0 {
 		s.tokenStoreKey = tlsConf.ServerName

--- a/connection.go
+++ b/connection.go
@@ -495,7 +495,6 @@ func (s *connection) preSetup() {
 	s.connState.Version = s.version
 	// Even if greasing is enabled, we don't always enable it.
 	// That way, we grease the greasing mechanism.
-	// Essentially setting QUIC Bit to an unpredictable value (RFC9287)
 	if !s.config.DisableQUICBitGreasing {
 		s.quicBitGreasingEnabled = rand.Intn(5) != 0
 	}

--- a/fuzzing/header/cmd/corpus.go
+++ b/fuzzing/header/cmd/corpus.go
@@ -85,7 +85,7 @@ func main() {
 			PacketNumberLen: protocol.PacketNumberLen(rand.Intn(4) + 1),
 			PacketNumber:    protocol.PacketNumber(rand.Uint64()),
 		}
-		b, err := extHdr.Append(nil, version)
+		b, err := extHdr.Append(nil, true, version)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -102,7 +102,7 @@ func main() {
 	}
 
 	// short header
-	b, err := wire.AppendShortHeader(nil, protocol.ParseConnectionID(getRandomData(8)), 1337, protocol.PacketNumberLen2, protocol.KeyPhaseOne)
+	b, err := wire.AppendShortHeader(nil, true, protocol.ParseConnectionID(getRandomData(8)), 1337, protocol.PacketNumberLen2, protocol.KeyPhaseOne)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/fuzzing/header/fuzz.go
+++ b/fuzzing/header/fuzz.go
@@ -32,12 +32,12 @@ func Fuzz(data []byte) int {
 	}
 
 	if !wire.IsLongHeaderPacket(data[0]) {
-		wire.ParseShortHeader(data, connIDLen)
+		wire.ParseShortHeader(data, false, connIDLen)
 		return 1
 	}
 
 	is0RTTPacket := wire.Is0RTTPacket(data)
-	hdr, _, _, err := wire.ParsePacket(data)
+	hdr, _, _, err := wire.ParsePacket(data, false)
 	if err != nil {
 		return 0
 	}
@@ -64,7 +64,7 @@ func Fuzz(data []byte) int {
 	if hdr.Length > 16383 {
 		return 1
 	}
-	b, err := extHdr.Append(nil, version)
+	b, err := extHdr.Append(nil, true, version)
 	if err != nil {
 		// We are able to parse packets with connection IDs longer than 20 bytes,
 		// but in QUIC version 1, we don't write headers with longer connection IDs.

--- a/integrationtests/self/grease_quic_bit_test.go
+++ b/integrationtests/self/grease_quic_bit_test.go
@@ -1,0 +1,158 @@
+package self_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+
+	"github.com/lucas-clemente/quic-go"
+	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
+	"github.com/lucas-clemente/quic-go/internal/protocol"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("QUIC Bit Greasing", func() {
+	type counter struct {
+		incomingQUICBitSet, outgoingQUICBitSet       uint32
+		incomingQUICBitNotSet, outgoingQUICBitNotSet uint32
+	}
+
+	runProxy := func(serverAddr string) (*counter, *quicproxy.QuicProxy) {
+		var c counter
+		proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
+			RemoteAddr: serverAddr,
+			DropPacket: func(dir quicproxy.Direction, packet []byte) bool {
+				set := packet[0]&0x40 > 0
+				switch {
+				case dir == quicproxy.DirectionIncoming && set:
+					atomic.AddUint32(&c.incomingQUICBitSet, 1)
+				case dir == quicproxy.DirectionIncoming && !set:
+					atomic.AddUint32(&c.incomingQUICBitNotSet, 1)
+				case dir == quicproxy.DirectionOutgoing && set:
+					atomic.AddUint32(&c.outgoingQUICBitSet, 1)
+				case dir == quicproxy.DirectionOutgoing && !set:
+					atomic.AddUint32(&c.outgoingQUICBitNotSet, 1)
+				}
+				return false
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		return &c, proxy
+	}
+
+	runTransfer := func(ln quic.Listener, clientConf *quic.Config, proxyPort int) {
+		go func() {
+			defer GinkgoRecover()
+			conn, err := ln.Accept(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			str, err := conn.AcceptStream(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			defer str.Close()
+			_, err = io.Copy(str, str)
+			Expect(err).ToNot(HaveOccurred())
+		}()
+
+		conn, err := quic.DialAddr(fmt.Sprintf("localhost:%d", proxyPort), tlsClientConfig, clientConf)
+		Expect(err).ToNot(HaveOccurred())
+		str, err := conn.OpenStream()
+		Expect(err).ToNot(HaveOccurred())
+		_, err = str.Write(PRData)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(str.Close()).To(Succeed())
+		_, err = io.Copy(io.Discard, str)
+		Expect(err).ToNot(HaveOccurred())
+		conn.CloseWithError(0, "")
+	}
+
+	for _, v := range protocol.SupportedVersions {
+		version := v
+
+		Context(fmt.Sprintf("with QUIC version %s", version), func() {
+			It("disables QUIC bit greasing on both sides", func() {
+				ln, err := quic.ListenAddr(
+					"localhost:0",
+					tlsConfig,
+					getQuicConfig(&quic.Config{
+						DisableQUICBitGreasing: true,
+						Versions:               []protocol.VersionNumber{version},
+					}),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer ln.Close()
+				c, proxy := runProxy(fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port))
+				defer proxy.Close()
+				runTransfer(
+					ln,
+					getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{version}, DisableQUICBitGreasing: true}),
+					proxy.LocalPort(),
+				)
+
+				Expect(atomic.LoadUint32(&c.incomingQUICBitSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.outgoingQUICBitSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.incomingQUICBitNotSet)).To(BeZero())
+				Expect(atomic.LoadUint32(&c.outgoingQUICBitNotSet)).To(BeZero())
+			})
+
+			It("enables QUIC bit greasing on the server side", func() {
+				ln, err := quic.ListenAddr(
+					"localhost:0",
+					tlsConfig,
+					getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{version}}),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer ln.Close()
+				c, proxy := runProxy(fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port))
+				defer proxy.Close()
+
+				// When greasing is enabled by the quic.Config, we occasionally disable it to grease the greasing mechanism.
+				// If we hit one of those cases, just rerun the transfer.
+				for i := 0; i < 10; i++ {
+					runTransfer(
+						ln,
+						getQuicConfig(&quic.Config{
+							DisableQUICBitGreasing: true,
+							Versions:               []protocol.VersionNumber{version},
+						}),
+						proxy.LocalPort(),
+					)
+					if atomic.LoadUint32(&c.incomingQUICBitNotSet) > 0 {
+						break
+					}
+				}
+
+				Expect(atomic.LoadUint32(&c.outgoingQUICBitSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.incomingQUICBitNotSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.outgoingQUICBitNotSet)).To(BeZero())
+			})
+
+			It("enables QUIC bit greasing on the client side", func() {
+				ln, err := quic.ListenAddr(
+					"localhost:0",
+					tlsConfig,
+					getQuicConfig(&quic.Config{DisableQUICBitGreasing: true}),
+				)
+				Expect(err).ToNot(HaveOccurred())
+				defer ln.Close()
+				c, proxy := runProxy(fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port))
+				defer proxy.Close()
+
+				// When greasing is enabled by the quic.Config, we occasionally disable it to grease the greasing mechanism.
+				// If we hit one of those cases, just rerun the transfer.
+				for i := 0; i < 10; i++ {
+					runTransfer(ln, getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{version}}), proxy.LocalPort())
+					if atomic.LoadUint32(&c.outgoingQUICBitNotSet) > 0 {
+						break
+					}
+				}
+
+				Expect(atomic.LoadUint32(&c.outgoingQUICBitNotSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.incomingQUICBitSet)).ToNot(BeZero())
+				Expect(atomic.LoadUint32(&c.incomingQUICBitNotSet)).To(BeZero())
+			})
+		})
+	}
+})

--- a/integrationtests/self/grease_quic_bit_test.go
+++ b/integrationtests/self/grease_quic_bit_test.go
@@ -7,11 +7,11 @@ import (
 	"net"
 	"sync/atomic"
 
-	"github.com/lucas-clemente/quic-go"
-	quicproxy "github.com/lucas-clemente/quic-go/integrationtests/tools/proxy"
-	"github.com/lucas-clemente/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go"
+	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
+	"github.com/quic-go/quic-go/internal/protocol"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
@@ -56,7 +56,7 @@ var _ = Describe("QUIC Bit Greasing", func() {
 			Expect(err).ToNot(HaveOccurred())
 		}()
 
-		conn, err := quic.DialAddr(fmt.Sprintf("localhost:%d", proxyPort), tlsClientConfig, clientConf)
+		conn, err := quic.DialAddr(context.Background(), fmt.Sprintf("localhost:%d", proxyPort), tlsClientConfig, clientConf)
 		Expect(err).ToNot(HaveOccurred())
 		str, err := conn.OpenStream()
 		Expect(err).ToNot(HaveOccurred())
@@ -86,7 +86,7 @@ var _ = Describe("QUIC Bit Greasing", func() {
 				c, proxy := runProxy(fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port))
 				defer proxy.Close()
 				runTransfer(
-					ln,
+					*ln,
 					getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{version}, DisableQUICBitGreasing: true}),
 					proxy.LocalPort(),
 				)
@@ -112,7 +112,7 @@ var _ = Describe("QUIC Bit Greasing", func() {
 				// If we hit one of those cases, just rerun the transfer.
 				for i := 0; i < 10; i++ {
 					runTransfer(
-						ln,
+						*ln,
 						getQuicConfig(&quic.Config{
 							DisableQUICBitGreasing: true,
 							Versions:               []protocol.VersionNumber{version},
@@ -143,7 +143,7 @@ var _ = Describe("QUIC Bit Greasing", func() {
 				// When greasing is enabled by the quic.Config, we occasionally disable it to grease the greasing mechanism.
 				// If we hit one of those cases, just rerun the transfer.
 				for i := 0; i < 10; i++ {
-					runTransfer(ln, getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{version}}), proxy.LocalPort())
+					runTransfer(*ln, getQuicConfig(&quic.Config{Versions: []protocol.VersionNumber{version}}), proxy.LocalPort())
 					if atomic.LoadUint32(&c.outgoingQUICBitNotSet) > 0 {
 						break
 					}

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -104,7 +104,7 @@ var _ = Describe("MITM test", func() {
 				defer ticker.Stop()
 
 				if wire.IsLongHeaderPacket(raw[0]) {
-					hdr, _, _, err := wire.ParsePacket(raw)
+					hdr, _, _, err := wire.ParsePacket(raw, true)
 					Expect(err).ToNot(HaveOccurred())
 					replyHdr := &wire.ExtendedHeader{
 						Header: wire.Header{
@@ -120,7 +120,7 @@ var _ = Describe("MITM test", func() {
 					for i := 0; i < numPackets; i++ {
 						payloadLen := rand.Int31n(100)
 						replyHdr.Length = protocol.ByteCount(rand.Int31n(payloadLen + 1))
-						b, err := replyHdr.Append(nil, hdr.Version)
+						b, err := replyHdr.Append(nil, true, hdr.Version)
 						Expect(err).ToNot(HaveOccurred())
 						r := make([]byte, payloadLen)
 						rand.Read(r)
@@ -133,12 +133,12 @@ var _ = Describe("MITM test", func() {
 				} else {
 					connID, err := wire.ParseConnectionID(raw, connIDLen)
 					Expect(err).ToNot(HaveOccurred())
-					_, pn, pnLen, _, err := wire.ParseShortHeader(raw, connIDLen)
+					_, pn, pnLen, _, err := wire.ParseShortHeader(raw, true, connIDLen)
 					if err != nil { // normally, ParseShortHeader is called after decrypting the header
 						Expect(err).To(MatchError(wire.ErrInvalidReservedBits))
 					}
 					for i := 0; i < numPackets; i++ {
-						b, err := wire.AppendShortHeader(nil, connID, pn, pnLen, protocol.KeyPhaseBit(rand.Intn(2)))
+						b, err := wire.AppendShortHeader(nil, true, connID, pn, pnLen, protocol.KeyPhaseBit(rand.Intn(2)))
 						Expect(err).ToNot(HaveOccurred())
 						payloadLen := rand.Int31n(100)
 						r := make([]byte, payloadLen)
@@ -330,7 +330,7 @@ var _ = Describe("MITM test", func() {
 				if dir == quicproxy.DirectionIncoming {
 					defer GinkgoRecover()
 
-					hdr, _, _, err := wire.ParsePacket(raw)
+					hdr, _, _, err := wire.ParsePacket(raw, true)
 					Expect(err).ToNot(HaveOccurred())
 
 					if hdr.Type != protocol.PacketTypeInitial {
@@ -372,7 +372,7 @@ var _ = Describe("MITM test", func() {
 					defer GinkgoRecover()
 					defer close(done)
 
-					hdr, _, _, err := wire.ParsePacket(raw)
+					hdr, _, _, err := wire.ParsePacket(raw, true)
 					Expect(err).ToNot(HaveOccurred())
 
 					if hdr.Type != protocol.PacketTypeInitial {
@@ -405,7 +405,7 @@ var _ = Describe("MITM test", func() {
 				if dir == quicproxy.DirectionIncoming {
 					defer GinkgoRecover()
 
-					hdr, _, _, err := wire.ParsePacket(raw)
+					hdr, _, _, err := wire.ParsePacket(raw, true)
 					Expect(err).ToNot(HaveOccurred())
 					if hdr.Type != protocol.PacketTypeInitial || injected {
 						return 0
@@ -433,7 +433,7 @@ var _ = Describe("MITM test", func() {
 				if dir == quicproxy.DirectionIncoming {
 					defer GinkgoRecover()
 
-					hdr, _, _, err := wire.ParsePacket(raw)
+					hdr, _, _, err := wire.ParsePacket(raw, true)
 					Expect(err).ToNot(HaveOccurred())
 					if hdr.Type != protocol.PacketTypeInitial || injected {
 						return 0

--- a/integrationtests/self/zero_rtt_oldgo_test.go
+++ b/integrationtests/self/zero_rtt_oldgo_test.go
@@ -35,7 +35,7 @@ var _ = Describe("0-RTT", func() {
 					if !wire.IsLongHeaderPacket(data[0]) {
 						break
 					}
-					hdr, _, rest, err := wire.ParsePacket(data)
+					hdr, _, rest, err := wire.ParsePacket(data, true)
 					Expect(err).ToNot(HaveOccurred())
 					if hdr.Type == protocol.PacketType0RTT {
 						num0RTTPackets.Add(1)
@@ -368,7 +368,7 @@ var _ = Describe("0-RTT", func() {
 			RemoteAddr: fmt.Sprintf("localhost:%d", ln.Addr().(*net.UDPAddr).Port),
 			DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
 				if wire.IsLongHeaderPacket(data[0]) {
-					hdr, _, _, err := wire.ParsePacket(data)
+					hdr, _, _, err := wire.ParsePacket(data, true)
 					Expect(err).ToNot(HaveOccurred())
 					if hdr.Type == protocol.PacketType0RTT {
 						num0RTTPackets.Add(1)
@@ -380,7 +380,7 @@ var _ = Describe("0-RTT", func() {
 				if !wire.IsLongHeaderPacket(data[0]) {
 					return false
 				}
-				hdr, _, _, err := wire.ParsePacket(data)
+				hdr, _, _, err := wire.ParsePacket(data, true)
 				Expect(err).ToNot(HaveOccurred())
 				if hdr.Type == protocol.PacketType0RTT {
 					// drop 25% of the 0-RTT packets
@@ -415,7 +415,7 @@ var _ = Describe("0-RTT", func() {
 
 		countZeroRTTBytes := func(data []byte) (n protocol.ByteCount) {
 			for len(data) > 0 {
-				hdr, _, rest, err := wire.ParsePacket(data)
+				hdr, _, rest, err := wire.ParsePacket(data, true)
 				if err != nil {
 					return
 				}

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -40,14 +40,14 @@ var _ = Describe("QUIC Proxy", func() {
 			PacketNumber:    p,
 			PacketNumberLen: protocol.PacketNumberLen4,
 		}
-		b, err := hdr.Append(nil, protocol.Version1)
+		b, err := hdr.Append(nil, true, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		b = append(b, payload...)
 		return b
 	}
 
 	readPacketNumber := func(b []byte) protocol.PacketNumber {
-		hdr, data, _, err := wire.ParsePacket(b)
+		hdr, data, _, err := wire.ParsePacket(b, false)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		Expect(hdr.Type).To(Equal(protocol.PacketTypeInitial))
 		extHdr, err := hdr.ParseExtended(bytes.NewReader(data), protocol.Version1)

--- a/interface.go
+++ b/interface.go
@@ -324,7 +324,10 @@ type Config struct {
 	Allow0RTT bool
 	// Enable QUIC datagram support (RFC 9221).
 	EnableDatagrams bool
-	Tracer          func(context.Context, logging.Perspective, ConnectionID) *logging.ConnectionTracer
+	// DisableQUICBitGreasing disables greasing of the QUIC bit.
+	// By default, greasing is enabled according to RFC 9287.
+	DisableQUICBitGreasing bool
+	Tracer                 func(context.Context, logging.Perspective, ConnectionID) *logging.ConnectionTracer
 }
 
 type ClientHelloInfo struct {

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -13,7 +13,7 @@ import (
 
 // writePacket returns a new raw packet with the specified header and payload
 func writePacket(hdr *wire.ExtendedHeader, data []byte) []byte {
-	b, err := hdr.Append(nil, hdr.Version)
+	b, err := hdr.Append(nil, true, hdr.Version)
 	if err != nil {
 		panic(fmt.Sprintf("failed to write header: %s", err))
 	}

--- a/internal/wire/extended_header.go
+++ b/internal/wire/extended_header.go
@@ -95,7 +95,7 @@ func (h *ExtendedHeader) readPacketNumber(b *bytes.Reader) error {
 }
 
 // Append appends the Header.
-func (h *ExtendedHeader) Append(b []byte, v protocol.VersionNumber) ([]byte, error) {
+func (h *ExtendedHeader) Append(b []byte, quicBit bool, v protocol.VersionNumber) ([]byte, error) {
 	if h.DestConnectionID.Len() > protocol.MaxConnIDLen {
 		return nil, fmt.Errorf("invalid connection ID length: %d bytes", h.DestConnectionID.Len())
 	}
@@ -130,6 +130,9 @@ func (h *ExtendedHeader) Append(b []byte, v protocol.VersionNumber) ([]byte, err
 		}
 	}
 	firstByte := 0xc0 | packetType<<4
+	if !quicBit { // unset the quic bit
+		firstByte ^= 0x40
+	}
 	if h.Type != protocol.PacketTypeRetry {
 		// Retry packets don't have a packet number
 		firstByte |= uint8(h.PacketNumberLen - 1)

--- a/internal/wire/header_test.go
+++ b/internal/wire/header_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Header Parsing", func() {
 					Version:          protocol.Version1,
 				},
 				PacketNumberLen: 2,
-			}).Append(nil, protocol.Version1)
+			}).Append(nil, true, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 			connID, err := ParseConnectionID(b, 8)
 			Expect(err).ToNot(HaveOccurred())
@@ -42,7 +42,7 @@ var _ = Describe("Header Parsing", func() {
 					Version:          protocol.Version1,
 				},
 				PacketNumberLen: 2,
-			}).Append(nil, protocol.Version1)
+			}).Append(nil, true, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 			data := b[:len(b)-2] // cut the packet number
 			_, err = ParseConnectionID(data, 8)
@@ -187,7 +187,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, []byte("foobar")...)
 			Expect(IsVersionNegotiationPacket(data)).To(BeFalse())
 
-			hdr, pdata, rest, err := ParsePacket(data)
+			hdr, pdata, rest, err := ParsePacket(data, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pdata).To(Equal(data))
 			Expect(hdr.DestConnectionID).To(Equal(destConnID))
@@ -207,15 +207,28 @@ var _ = Describe("Header Parsing", func() {
 			Expect(extHdr.ParsedLen()).To(Equal(hdr.ParsedLen() + 4))
 		})
 
-		It("errors if 0x40 is not set", func() {
+		It("errors if the QUIC bit is not set", func() {
 			data := []byte{
 				0x80 | 0x2<<4,
-				0x11,                   // connection ID lengths
+				0x4,                    // connection ID lengths
 				0xde, 0xca, 0xfb, 0xad, // dest conn ID
+				0x4,
 				0xde, 0xad, 0xbe, 0xef, // src conn ID
 			}
-			_, _, _, err := ParsePacket(data)
+			_, _, _, err := ParsePacket(data, false)
 			Expect(err).To(MatchError("not a QUIC packet"))
+		})
+
+		It("doesn't error if the QUIC bit is not set, if we're ignoring the QUIC bit", func() {
+			data := []byte{0x80 | 0x2<<4}
+			data = appendVersion(data, protocol.Version1)
+			data = append(data, 0x4)
+			data = append(data, []byte{0xde, 0xca, 0xfb, 0xad}...) // dest conn ID
+			data = append(data, 0x0)                               // src conn ID len
+			data = append(data, 0x0)                               // length
+			data = append(data, []byte("foobar")...)               // unspecified bytes
+			_, _, _, err := ParsePacket(data, true)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("stops parsing when encountering an unsupported version", func() {
@@ -228,7 +241,7 @@ var _ = Describe("Header Parsing", func() {
 				0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0x1, // src conn ID
 				'f', 'o', 'o', 'b', 'a', 'r', // unspecified bytes
 			}
-			hdr, _, rest, err := ParsePacket(data)
+			hdr, _, rest, err := ParsePacket(data, false)
 			Expect(err).To(MatchError(ErrUnsupportedVersion))
 			Expect(hdr.Version).To(Equal(protocol.VersionNumber(0xdeadbeef)))
 			Expect(hdr.DestConnectionID).To(Equal(protocol.ParseConnectionID([]byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8})))
@@ -244,7 +257,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, []byte{0xde, 0xad, 0xbe, 0xef}...) // source connection ID
 			data = append(data, encodeVarInt(0)...)                // length
 			data = append(data, []byte{0xde, 0xca, 0xfb, 0xad}...)
-			hdr, _, _, err := ParsePacket(data)
+			hdr, _, _, err := ParsePacket(data, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.Type).To(Equal(protocol.PacketType0RTT))
 			Expect(hdr.SrcConnectionID).To(Equal(protocol.ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef})))
@@ -259,7 +272,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, 0)                                        // src conn ID len
 			data = append(data, encodeVarInt(0)...)                       // length
 			data = append(data, []byte{0xde, 0xca, 0xfb, 0xad}...)
-			hdr, _, _, err := ParsePacket(data)
+			hdr, _, _, err := ParsePacket(data, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.SrcConnectionID).To(BeZero())
 			Expect(hdr.DestConnectionID).To(Equal(protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})))
@@ -273,7 +286,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, 0x0)                                                                                  // src conn ID len
 			data = append(data, encodeVarInt(0)...)                                                                   // length
 			data = append(data, []byte{0xde, 0xca, 0xfb, 0xad}...)
-			_, _, _, err := ParsePacket(data)
+			_, _, _, err := ParsePacket(data, false)
 			Expect(err).To(MatchError(protocol.ErrInvalidConnectionIDLen))
 		})
 
@@ -285,7 +298,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, encodeVarInt(0)...)       // length
 			data = append(data, []byte{0x1, 0x23}...)
 
-			hdr, _, _, err := ParsePacket(data)
+			hdr, _, _, err := ParsePacket(data, false)
 			Expect(err).ToNot(HaveOccurred())
 			b := bytes.NewReader(data)
 			extHdr, err := hdr.ParseExtended(b, protocol.Version1)
@@ -304,7 +317,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}...) // source connection ID
 			data = append(data, []byte{'f', 'o', 'o', 'b', 'a', 'r'}...)  // token
 			data = append(data, []byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}...)
-			hdr, pdata, rest, err := ParsePacket(data)
+			hdr, pdata, rest, err := ParsePacket(data, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.Type).To(Equal(protocol.PacketTypeRetry))
 			Expect(hdr.Version).To(Equal(protocol.Version1))
@@ -324,7 +337,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}...) // source connection ID
 			data = append(data, []byte{'f', 'o', 'o', 'b', 'a', 'r'}...)  // token
 			data = append(data, []byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}...)
-			hdr, pdata, rest, err := ParsePacket(data)
+			hdr, pdata, rest, err := ParsePacket(data, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.Type).To(Equal(protocol.PacketTypeRetry))
 			Expect(hdr.Version).To(Equal(protocol.Version2))
@@ -342,7 +355,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, []byte{'f', 'o', 'o', 'b', 'a', 'r'}...) // token
 			data = append(data, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}...)
 			// this results in a token length of 0
-			_, _, _, err := ParsePacket(data)
+			_, _, _, err := ParsePacket(data, false)
 			Expect(err).To(MatchError(io.EOF))
 		})
 
@@ -354,7 +367,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, encodeVarInt(0x42)...) // length, 1 byte
 			data = append(data, []byte{0x12, 0x34}...) // packet number
 
-			_, _, _, err := ParsePacket(data)
+			_, _, _, err := ParsePacket(data, false)
 			Expect(err).To(MatchError(io.EOF))
 		})
 
@@ -364,7 +377,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, []byte{0x0, 0x0}...)   // connection ID lengths
 			data = append(data, encodeVarInt(2)...)    // length
 			data = append(data, []byte{0x12, 0x34}...) // packet number
-			hdr, _, _, err := ParsePacket(data)
+			hdr, _, _, err := ParsePacket(data, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hdr.Type).To(Equal(protocol.PacketTypeHandshake))
 			extHdr, err := hdr.ParseExtended(bytes.NewReader(data), protocol.Version1)
@@ -381,7 +394,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, 0x8)                                                       // src conn ID len
 			data = append(data, []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0x13, 0x37}...) // src conn ID
 			for i := 1; i < len(data); i++ {
-				_, _, _, err := ParsePacket(data[:i])
+				_, _, _, err := ParsePacket(data[:i], false)
 				Expect(err).To(Equal(io.EOF))
 			}
 		})
@@ -395,7 +408,7 @@ var _ = Describe("Header Parsing", func() {
 			data = append(data, []byte{0xde, 0xad, 0xbe, 0xef}...) // packet number
 			for i := hdrLen; i < len(data); i++ {
 				data = data[:i]
-				hdr, _, _, err := ParsePacket(data)
+				hdr, _, _, err := ParsePacket(data, false)
 				Expect(err).ToNot(HaveOccurred())
 				b := bytes.NewReader(data)
 				_, err = hdr.ParseExtended(b, protocol.Version1)
@@ -412,7 +425,7 @@ var _ = Describe("Header Parsing", func() {
 			hdrLen := len(data)
 			for i := hdrLen; i < len(data); i++ {
 				data = data[:i]
-				hdr, _, _, err := ParsePacket(data)
+				hdr, _, _, err := ParsePacket(data, false)
 				Expect(err).ToNot(HaveOccurred())
 				b := bytes.NewReader(data)
 				_, err = hdr.ParseExtended(b, protocol.Version1)
@@ -432,12 +445,12 @@ var _ = Describe("Header Parsing", func() {
 					Header:          hdr,
 					PacketNumber:    0x1337,
 					PacketNumberLen: 2,
-				}).Append(nil, protocol.Version1)
+				}).Append(nil, true, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				hdrRaw := append([]byte{}, b...)
 				b = append(b, []byte("foobar")...) // payload of the first packet
 				b = append(b, []byte("raboof")...) // second packet
-				parsedHdr, data, rest, err := ParsePacket(b)
+				parsedHdr, data, rest, err := ParsePacket(b, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(parsedHdr.Type).To(Equal(hdr.Type))
 				Expect(parsedHdr.DestConnectionID).To(Equal(hdr.DestConnectionID))
@@ -455,9 +468,9 @@ var _ = Describe("Header Parsing", func() {
 					},
 					PacketNumber:    0x1337,
 					PacketNumberLen: 2,
-				}).Append(nil, protocol.Version1)
+				}).Append(nil, true, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
-				_, _, _, err = ParsePacket(b)
+				_, _, _, err = ParsePacket(b, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("packet length (2 bytes) is smaller than the expected length (3 bytes)"))
 			})
@@ -472,10 +485,10 @@ var _ = Describe("Header Parsing", func() {
 					},
 					PacketNumber:    0x1337,
 					PacketNumberLen: 2,
-				}).Append(nil, protocol.Version1)
+				}).Append(nil, true, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				b = append(b, make([]byte, 500-2 /* for packet number length */)...)
-				_, _, _, err = ParsePacket(b)
+				_, _, _, err = ParsePacket(b, false)
 				Expect(err).To(MatchError("packet length (500 bytes) is smaller than the expected length (1000 bytes)"))
 			})
 		})

--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -422,8 +422,8 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 		b = p.marshalVarintParam(b, maxDatagramFrameSizeParameterID, uint64(p.MaxDatagramFrameSize))
 	}
 	if p.GreaseQuicBit {
-		quicvarint.Append(b, uint64(greaseQuicBitParameterID))
-		quicvarint.Append(b, 0)
+		b = quicvarint.Append(b, uint64(greaseQuicBitParameterID))
+		b = quicvarint.Append(b, 0)
 	}
 
 	if pers == protocol.PerspectiveClient && len(AdditionalTransportParametersClient) > 0 {

--- a/mock_packer_test.go
+++ b/mock_packer_test.go
@@ -14,6 +14,7 @@ import (
 	ackhandler "github.com/quic-go/quic-go/internal/ackhandler"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	qerr "github.com/quic-go/quic-go/internal/qerr"
+	wire "github.com/quic-go/quic-go/internal/wire"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -75,6 +76,42 @@ func (c *PackerAppendPacketCall) Do(f func(*packetBuffer, protocol.ByteCount, pr
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *PackerAppendPacketCall) DoAndReturn(f func(*packetBuffer, protocol.ByteCount, protocol.VersionNumber) (shortHeaderPacket, error)) *PackerAppendPacketCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// HandleTransportParameters mocks base method.
+func (m *MockPacker) HandleTransportParameters(arg0 *wire.TransportParameters) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "HandleTransportParameters", arg0)
+}
+
+// HandleTransportParameters indicates an expected call of HandleTransportParameters.
+func (mr *MockPackerMockRecorder) HandleTransportParameters(arg0 any) *PackerHandleTransportParametersCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleTransportParameters", reflect.TypeOf((*MockPacker)(nil).HandleTransportParameters), arg0)
+	return &PackerHandleTransportParametersCall{Call: call}
+}
+
+// PackerHandleTransportParametersCall wrap *gomock.Call
+type PackerHandleTransportParametersCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *PackerHandleTransportParametersCall) Return() *PackerHandleTransportParametersCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *PackerHandleTransportParametersCall) Do(f func(*wire.TransportParameters)) *PackerHandleTransportParametersCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *PackerHandleTransportParametersCall) DoAndReturn(f func(*wire.TransportParameters)) *PackerHandleTransportParametersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Packet packer", func() {
 			if !wire.IsLongHeaderPacket(data[0]) {
 				break
 			}
-			hdr, _, more, err := wire.ParsePacket(data)
+			hdr, _, more, err := wire.ParsePacket(data, false)
 			Expect(err).ToNot(HaveOccurred())
 			r := bytes.NewReader(data)
 			extHdr, err := hdr.ParseExtended(r, version)
@@ -59,7 +59,7 @@ var _ = Describe("Packet packer", func() {
 	}
 
 	parseShortHeaderPacket := func(data []byte) {
-		l, _, pnLen, _, err := wire.ParseShortHeader(data, connID.Len())
+		l, _, pnLen, _, err := wire.ParseShortHeader(data, false, connID.Len())
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		ExpectWithOffset(1, len(data)-l+int(pnLen)).To(BeNumerically(">=", 4))
 	}
@@ -689,7 +689,7 @@ var _ = Describe("Packet packer", func() {
 				Expect(packet.IsOnlyShortHeaderPacket()).To(BeFalse())
 				// cut off the tag that the mock sealer added
 				// packet.buffer.Data = packet.buffer.Data[:packet.buffer.Len()-protocol.ByteCount(sealer.Overhead())]
-				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data)
+				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, false)
 				Expect(err).ToNot(HaveOccurred())
 				data := packet.buffer.Data
 				r := bytes.NewReader(data)
@@ -732,7 +732,7 @@ var _ = Describe("Packet packer", func() {
 				// cut off the tag that the mock sealer added
 				buffer.Data = buffer.Data[:buffer.Len()-protocol.ByteCount(sealer.Overhead())]
 				data := buffer.Data
-				l, _, pnLen, _, err := wire.ParseShortHeader(data, connID.Len())
+				l, _, pnLen, _, err := wire.ParseShortHeader(data, false, connID.Len())
 				Expect(err).ToNot(HaveOccurred())
 				r := bytes.NewReader(data[l:])
 				Expect(pnLen).To(Equal(protocol.PacketNumberLen1))
@@ -1211,7 +1211,7 @@ var _ = Describe("Packet packer", func() {
 				Expect(packet.shortHdrPacket).To(BeNil())
 				// cut off the tag that the mock sealer added
 				// packet.buffer.Data = packet.buffer.Data[:packet.buffer.Len()-protocol.ByteCount(sealer.Overhead())]
-				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data)
+				hdr, _, _, err := wire.ParsePacket(packet.buffer.Data, false)
 				Expect(err).ToNot(HaveOccurred())
 				data := packet.buffer.Data
 				r := bytes.NewReader(data)

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -174,8 +174,10 @@ func (u *packetUnpacker) unpackShortHeader(hd headerDecryptor, data []byte) (int
 		&data[0],
 		data[hdrLen:hdrLen+4],
 	)
-	// 3. parse the header (and learn the actual length of the packet number)
-	l, pn, pnLen, kp, parseErr := wire.ParseShortHeader(data, u.shortHdrConnIDLen)
+	// 3. parse the header (and learn the actual length of the packet number) .
+	// An endpoint that advertises the grease_quic_bit transport parameter MUST accept packets with the QUIC Bit set to a value of 0.
+	// nTODO: should be !s.config.DisableQUICBitGreasing, but pending further investigation.
+	l, pn, pnLen, kp, parseErr := wire.ParseShortHeader(data, false, u.shortHdrConnIDLen)
 	if parseErr != nil && parseErr != wire.ErrInvalidReservedBits {
 		return l, pn, pnLen, kp, parseErr
 	}

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -24,20 +24,20 @@ var _ = Describe("Packet Unpacker", func() {
 	)
 
 	getLongHeader := func(extHdr *wire.ExtendedHeader) (*wire.Header, []byte) {
-		b, err := extHdr.Append(nil, protocol.Version1)
+		b, err := extHdr.Append(nil, true, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		hdrLen := len(b)
 		if extHdr.Length > protocol.ByteCount(extHdr.PacketNumberLen) {
 			b = append(b, make([]byte, int(extHdr.Length)-int(extHdr.PacketNumberLen))...)
 		}
-		hdr, _, _, err := wire.ParsePacket(b)
+		hdr, _, _, err := wire.ParsePacket(b, false)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return hdr, b[:hdrLen]
 	}
 
 	getShortHeader := func(connID protocol.ConnectionID, pn protocol.PacketNumber, pnLen protocol.PacketNumberLen, kp protocol.KeyPhaseBit) []byte {
-		b, err := wire.AppendShortHeader(nil, connID, pn, pnLen, kp)
+		b, err := wire.AppendShortHeader(nil, true, connID, pn, pnLen, kp)
 		Expect(err).ToNot(HaveOccurred())
 		return b
 	}
@@ -69,7 +69,7 @@ var _ = Describe("Packet Unpacker", func() {
 	})
 
 	It("errors when the packet is too small to obtain the header decryption sample, for short headers", func() {
-		b, err := wire.AppendShortHeader(nil, connID, 1337, protocol.PacketNumberLen2, protocol.KeyPhaseOne)
+		b, err := wire.AppendShortHeader(nil, true, connID, 1337, protocol.PacketNumberLen2, protocol.KeyPhaseOne)
 		Expect(err).ToNot(HaveOccurred())
 		data := append(b, make([]byte, 2 /* fill up packet number */ +15 /* need 16 bytes */)...)
 		opener := mocks.NewMockShortHeaderOpener(mockCtrl)

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Packet Unpacker", func() {
 
 	BeforeEach(func() {
 		cs = mocks.NewMockCryptoSetup(mockCtrl)
-		unpacker = newPacketUnpacker(cs, 4)
+		unpacker = newPacketUnpacker(cs, 4, false)
 	})
 
 	It("errors when the packet is too small to obtain the header decryption sample, for long headers", func() {

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -408,6 +408,7 @@ type eventTransportParameters struct {
 	PreferredAddress *preferredAddress
 
 	MaxDatagramFrameSize protocol.ByteCount
+	GreaseQuicBit        bool
 }
 
 func (e eventTransportParameters) Category() category { return categoryTransport }
@@ -452,6 +453,9 @@ func (e eventTransportParameters) MarshalJSONObject(enc *gojay.Encoder) {
 	}
 	if e.MaxDatagramFrameSize != protocol.InvalidByteCount {
 		enc.Int64Key("max_datagram_frame_size", int64(e.MaxDatagramFrameSize))
+	}
+	if e.GreaseQuicBit {
+		enc.BoolKey("grease_quic_bit", true)
 	}
 }
 

--- a/qlog/qlog.go
+++ b/qlog/qlog.go
@@ -325,6 +325,7 @@ func (t *connectionTracer) toTransportParameters(tp *wire.TransportParameters) *
 		InitialMaxStreamsUni:            int64(tp.MaxUniStreamNum),
 		PreferredAddress:                pa,
 		MaxDatagramFrameSize:            tp.MaxDatagramFrameSize,
+		GreaseQuicBit:                   tp.GreaseQuicBit,
 	}
 }
 

--- a/qlog/qlog_test.go
+++ b/qlog/qlog_test.go
@@ -309,6 +309,7 @@ var _ = Describe("Tracing", func() {
 				Expect(ev).To(HaveKeyWithValue("initial_max_streams_uni", float64(20)))
 				Expect(ev).ToNot(HaveKey("preferred_address"))
 				Expect(ev).ToNot(HaveKey("max_datagram_frame_size"))
+				Expect(ev).ToNot(HaveKey("quic_grease_bit"))
 			})
 
 			It("records the server's transport parameters, without a stateless reset token", func() {
@@ -370,6 +371,17 @@ var _ = Describe("Tracing", func() {
 				Expect(entry.Name).To(Equal("transport:parameters_set"))
 				ev := entry.Event
 				Expect(ev).To(HaveKeyWithValue("max_datagram_frame_size", float64(1337)))
+			})
+
+			It("records transport parameters that enable the Grease QUIC bit extension", func() {
+				tracer.SentTransportParameters(&logging.TransportParameters{
+					GreaseQuicBit: true,
+				})
+				entry := exportAndParseSingle()
+				Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+				Expect(entry.Name).To(Equal("transport:parameters_set"))
+				ev := entry.Event
+				Expect(ev).To(HaveKeyWithValue("grease_quic_bit", true))
 			})
 
 			It("records received transport parameters", func() {

--- a/server.go
+++ b/server.go
@@ -415,7 +415,7 @@ func (s *baseServer) handlePacketImpl(p receivedPacket) bool /* is the buffer st
 
 	// If we're creating a new connection, the packet will be passed to the connection.
 	// The header will then be parsed again.
-	hdr, _, _, err := wire.ParsePacket(p.data)
+	hdr, _, _, err := wire.ParsePacket(p.data, !s.config.DisableQUICBitGreasing)
 	if err != nil {
 		if s.tracer != nil && s.tracer.DroppedPacket != nil {
 			s.tracer.DroppedPacket(p.remoteAddr, logging.PacketTypeNotDetermined, p.Size(), logging.PacketDropHeaderParseError)
@@ -756,7 +756,7 @@ func (s *baseServer) sendRetryPacket(p rejectedPacket) error {
 
 	buf := getPacketBuffer()
 	defer buf.Release()
-	buf.Data, err = replyHdr.Append(buf.Data, hdr.Version)
+	buf.Data, err = replyHdr.Append(buf.Data, true, hdr.Version)
 	if err != nil {
 		return err
 	}
@@ -825,7 +825,7 @@ func (s *baseServer) sendError(remoteAddr net.Addr, hdr *wire.Header, sealer han
 	replyHdr.PacketNumberLen = protocol.PacketNumberLen4
 	replyHdr.Length = 4 /* packet number len */ + ccf.Length(hdr.Version) + protocol.ByteCount(sealer.Overhead())
 	var err error
-	b.Data, err = replyHdr.Append(b.Data, hdr.Version)
+	b.Data, err = replyHdr.Append(b.Data, true, hdr.Version)
 	if err != nil {
 		return err
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Server", func() {
 			Header:          *hdr,
 			PacketNumber:    0x42,
 			PacketNumberLen: protocol.PacketNumberLen4,
-		}).Append(buf.Data, protocol.Version1)
+		}).Append(buf.Data, true, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		n := len(buf.Data)
 		buf.Data = append(buf.Data, p...)
@@ -78,7 +78,7 @@ var _ = Describe("Server", func() {
 	}
 
 	parseHeader := func(data []byte) *wire.Header {
-		hdr, _, _, err := wire.ParsePacket(data)
+		hdr, _, _, err := wire.ParsePacket(data, false)
 		Expect(err).ToNot(HaveOccurred())
 		return hdr
 	}
@@ -683,7 +683,7 @@ var _ = Describe("Server", func() {
 				}
 				wg.Wait()
 				p := getInitialWithRandomDestConnID()
-				hdr, _, _, err := wire.ParsePacket(p.data)
+				hdr, _, _, err := wire.ParsePacket(p.data, false)
 				Expect(err).ToNot(HaveOccurred())
 				tracer.EXPECT().SentPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				done := make(chan struct{})

--- a/transport_test.go
+++ b/transport_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Transport", func() {
 				Version:          protocol.Version1,
 			},
 			PacketNumberLen: protocol.PacketNumberLen2,
-		}).Append(nil, protocol.Version1)
+		}).Append(nil, true, protocol.Version1)
 		Expect(err).ToNot(HaveOccurred())
 		return b
 	}
@@ -199,7 +199,7 @@ var _ = Describe("Transport", func() {
 		rand.Read(token[:])
 
 		var b []byte
-		b, err := wire.AppendShortHeader(b, connID, 1337, 2, protocol.KeyPhaseOne)
+		b, err := wire.AppendShortHeader(b, true, connID, 1337, 2, protocol.KeyPhaseOne)
 		Expect(err).ToNot(HaveOccurred())
 		b = append(b, token[:]...)
 		conn := NewMockPacketHandler(mockCtrl)
@@ -232,7 +232,7 @@ var _ = Describe("Transport", func() {
 		rand.Read(token[:])
 
 		var b []byte
-		b, err := wire.AppendShortHeader(b, connID, 1337, 2, protocol.KeyPhaseOne)
+		b, err := wire.AppendShortHeader(b, true, connID, 1337, 2, protocol.KeyPhaseOne)
 		Expect(err).ToNot(HaveOccurred())
 		b = append(b, token[:]...)
 		conn := NewMockPacketHandler(mockCtrl)
@@ -268,7 +268,7 @@ var _ = Describe("Transport", func() {
 		tr.handlerMap = phm
 
 		var b []byte
-		b, err := wire.AppendShortHeader(b, connID, 1337, 2, protocol.KeyPhaseOne)
+		b, err := wire.AppendShortHeader(b, true, connID, 1337, 2, protocol.KeyPhaseOne)
 		Expect(err).ToNot(HaveOccurred())
 		b = append(b, make([]byte, protocol.MinStatelessResetSize-len(b)+1)...)
 


### PR DESCRIPTION
Hello!

I wanted the greasing QUIC bit feature in quic-go. Hence I copied the implementation from #3521  on the current master which has highly refactored header handling (writing & parsing).
While the greasing and handling seems to work for long header packets. It is not working for short headers when the corresponding peer sends a short header with QUIC bit 0. Due to this the integration test for grease_quic_bit is also failing.

While I have been working on debugging further. I am sharing the draft PR to get some help
* Get feedback on what I might be missing, Since this was already done and folks here are well aware of the refactoring changes. 
* To keep up the #3521 effort from being lost due to refactoring

Any help is appreciated. 

Thanks. 