### PR TITLE
utils: use time.Duration.Abs

### DIFF
--- a/internal/utils/minmax.go
+++ b/internal/utils/minmax.go
@@ -35,14 +35,6 @@ func MinNonZeroDuration(a, b time.Duration) time.Duration {
 	return Min(a, b)
 }
 
-// AbsDuration returns the absolute value of a time duration
-func AbsDuration(d time.Duration) time.Duration {
-	if d >= 0 {
-		return d
-	}
-	return -d
-}
-
 // MinTime returns the earlier time
 func MinTime(a, b time.Time) time.Time {
 	if a.After(b) {

--- a/internal/utils/minmax_test.go
+++ b/internal/utils/minmax_test.go
@@ -50,9 +50,4 @@ var _ = Describe("Min / Max", func() {
 		Expect(MinNonZeroTime(b, b.Add(time.Second))).To(Equal(b))
 		Expect(MinNonZeroTime(b.Add(time.Second), b)).To(Equal(b))
 	})
-
-	It("returns the abs time", func() {
-		Expect(AbsDuration(time.Microsecond)).To(Equal(time.Microsecond))
-		Expect(AbsDuration(-time.Microsecond)).To(Equal(time.Microsecond))
-	})
 })

--- a/internal/utils/rtt_stats.go
+++ b/internal/utils/rtt_stats.go
@@ -90,7 +90,7 @@ func (r *RTTStats) UpdateRTT(sendDelta, ackDelay time.Duration, now time.Time) {
 		r.smoothedRTT = sample
 		r.meanDeviation = sample / 2
 	} else {
-		r.meanDeviation = time.Duration(oneMinusBeta*float32(r.meanDeviation/time.Microsecond)+rttBeta*float32(AbsDuration(r.smoothedRTT-sample)/time.Microsecond)) * time.Microsecond
+		r.meanDeviation = time.Duration(oneMinusBeta*float32(r.meanDeviation/time.Microsecond)+rttBeta*float32((r.smoothedRTT-sample).Abs()/time.Microsecond)) * time.Microsecond
 		r.smoothedRTT = time.Duration((float32(r.smoothedRTT/time.Microsecond)*oneMinusAlpha)+(float32(sample/time.Microsecond)*rttAlpha)) * time.Microsecond
 	}
 }
@@ -126,6 +126,6 @@ func (r *RTTStats) OnConnectionMigration() {
 // is larger. The mean deviation is increased to the most recent deviation if
 // it's larger.
 func (r *RTTStats) ExpireSmoothedMetrics() {
-	r.meanDeviation = Max(r.meanDeviation, AbsDuration(r.smoothedRTT-r.latestRTT))
+	r.meanDeviation = Max(r.meanDeviation, (r.smoothedRTT - r.latestRTT).Abs())
 	r.smoothedRTT = Max(r.smoothedRTT, r.latestRTT)
 }


### PR DESCRIPTION
This function was added in Go 1.19, and covers some corner cases that our custom implementation didn't.