### PR TITLE
http3: add ConnContext to the server

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -618,7 +618,7 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 	if s.ConnContext != nil {
 		ctx = s.ConnContext(ctx, conn)
 		if ctx == nil {
-			panic("ConnContext returned nil")
+			panic("http3: ConnContext returned nil")
 		}
 	}
 	req = req.WithContext(ctx)

--- a/http3/server.go
+++ b/http3/server.go
@@ -211,6 +211,11 @@ type Server struct {
 	// In that case, the stream type will not be set.
 	UniStreamHijacker func(StreamType, quic.Connection, quic.ReceiveStream, error) (hijacked bool)
 
+	// ConnContext optionally specifies a function that modifies
+	// the context used for a new connection c. The provided ctx
+	// has a ServerContextKey value.
+	ConnContext func(ctx context.Context, c quic.Connection) context.Context
+
 	mutex     sync.RWMutex
 	listeners map[*QUICEarlyListener]listenerInfo
 
@@ -610,6 +615,9 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 	ctx = context.WithValue(ctx, ServerContextKey, s)
 	ctx = context.WithValue(ctx, http.LocalAddrContextKey, conn.LocalAddr())
 	ctx = context.WithValue(ctx, RemoteAddrContextKey, conn.RemoteAddr())
+	if s.ConnContext != nil {
+		ctx = s.ConnContext(ctx, conn)
+	}
 	req = req.WithContext(ctx)
 	r := newResponseWriter(str, conn, s.logger)
 	if req.Method == http.MethodHead {

--- a/http3/server.go
+++ b/http3/server.go
@@ -617,6 +617,9 @@ func (s *Server) handleRequest(conn quic.Connection, str quic.Stream, decoder *q
 	ctx = context.WithValue(ctx, RemoteAddrContextKey, conn.RemoteAddr())
 	if s.ConnContext != nil {
 		ctx = s.ConnContext(ctx, conn)
+		if ctx == nil {
+			panic("ConnContext returned nil")
+		}
 	}
 	req = req.WithContext(ctx)
 	r := newResponseWriter(str, conn, s.logger)

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -72,6 +72,9 @@ var _ = Describe("Server", func() {
 		s = &Server{
 			TLSConfig: testdata.GetTLSConfig(),
 			logger:    utils.DefaultLogger,
+			ConnContext: func(ctx context.Context, c quic.Connection) context.Context {
+				return context.WithValue(ctx, "test-conn-context-key", c)
+			},
 		}
 		origQuicListenAddr = quicListenAddr
 	})
@@ -163,6 +166,7 @@ var _ = Describe("Server", func() {
 			Expect(req.Host).To(Equal("www.example.com"))
 			Expect(req.RemoteAddr).To(Equal("127.0.0.1:1337"))
 			Expect(req.Context().Value(ServerContextKey)).To(Equal(s))
+			Expect(req.Context().Value("test-conn-context-key")).ToNot(Equal(nil))
 		})
 
 		It("returns 200 with an empty handler", func() {

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -67,13 +67,14 @@ var _ = Describe("Server", func() {
 		s                  *Server
 		origQuicListenAddr = quicListenAddr
 	)
+	type testConnContextKey string
 
 	BeforeEach(func() {
 		s = &Server{
 			TLSConfig: testdata.GetTLSConfig(),
 			logger:    utils.DefaultLogger,
 			ConnContext: func(ctx context.Context, c quic.Connection) context.Context {
-				return context.WithValue(ctx, "test-conn-context-key", c)
+				return context.WithValue(ctx, testConnContextKey("test"), c)
 			},
 		}
 		origQuicListenAddr = quicListenAddr
@@ -166,7 +167,7 @@ var _ = Describe("Server", func() {
 			Expect(req.Host).To(Equal("www.example.com"))
 			Expect(req.RemoteAddr).To(Equal("127.0.0.1:1337"))
 			Expect(req.Context().Value(ServerContextKey)).To(Equal(s))
-			Expect(req.Context().Value("test-conn-context-key")).ToNot(Equal(nil))
+			Expect(req.Context().Value(testConnContextKey("test"))).ToNot(Equal(nil))
 		})
 
 		It("returns 200 with an empty handler", func() {

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -528,4 +528,30 @@ var _ = Describe("HTTP tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(200))
 	})
+
+	It("sets conn context", func() {
+		type ctxKey int
+		server.ConnContext = func(ctx context.Context, c quic.Connection) context.Context {
+			ctx = context.WithValue(ctx, ctxKey(0), "Hello")
+			ctx = context.WithValue(ctx, ctxKey(1), c)
+			return ctx
+		}
+		mux.HandleFunc("/conn-context", func(w http.ResponseWriter, r *http.Request) {
+			defer GinkgoRecover()
+			v, ok := r.Context().Value(ctxKey(0)).(string)
+			Expect(ok).To(BeTrue())
+			Expect(v).To(Equal("Hello"))
+
+			_, ok = r.Context().Value(ctxKey(1)).(quic.Connection)
+			Expect(ok).ToNot(Equal(nil))
+
+			serv, ok := r.Context().Value(http3.ServerContextKey).(*http3.Server)
+			Expect(ok).To(BeTrue())
+			Expect(serv).To(Equal(server))
+		})
+
+		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/conn-context", port))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(200))
+	})
 })

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -546,8 +546,9 @@ var _ = Describe("HTTP tests", func() {
 			Expect(ok).To(BeTrue())
 			Expect(v).To(Equal("Hello"))
 
-			_, ok = r.Context().Value(ctxKey(1)).(quic.Connection)
-			Expect(ok).ToNot(Equal(nil))
+			c, ok := r.Context().Value(ctxKey(1)).(quic.Connection)
+			Expect(ok).To(BeTrue())
+			Expect(c).ToNot(BeNil())
 
 			serv, ok := r.Context().Value(http3.ServerContextKey).(*http3.Server)
 			Expect(ok).To(BeTrue())

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -532,6 +532,10 @@ var _ = Describe("HTTP tests", func() {
 	It("sets conn context", func() {
 		type ctxKey int
 		server.ConnContext = func(ctx context.Context, c quic.Connection) context.Context {
+			serv, ok := ctx.Value(http3.ServerContextKey).(*http3.Server)
+			Expect(ok).To(BeTrue())
+			Expect(serv).To(Equal(server))
+
 			ctx = context.WithValue(ctx, ctxKey(0), "Hello")
 			ctx = context.WithValue(ctx, ctxKey(1), c)
 			return ctx


### PR DESCRIPTION
ConnContext can be used to modify the context used by a new http Request. This is equivalent to `ConnContext` in `http.Server`, but with a `quic.Connection` instead of a `net.Conn`.

```
// ConnContext optionally specifies a function that modifies
// the context used for a new connection c. The provided ctx
// has a ServerContextKey value.
ConnContext func(ctx context.Context, c quic.Connection) context.Context
```