### PR TITLE
example: remove -v flag and custom logger configuration

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -23,22 +23,12 @@ import (
 )
 
 func main() {
-	verbose := flag.Bool("v", false, "verbose")
 	quiet := flag.Bool("q", false, "don't print the data")
 	keyLogFile := flag.String("keylog", "", "key log file")
 	insecure := flag.Bool("insecure", false, "skip certificate verification")
 	enableQlog := flag.Bool("qlog", false, "output a qlog (in the same directory)")
 	flag.Parse()
 	urls := flag.Args()
-
-	logger := utils.DefaultLogger
-
-	if *verbose {
-		logger.SetLogLevel(utils.LogLevelDebug)
-	} else {
-		logger.SetLogLevel(utils.LogLevelInfo)
-	}
-	logger.SetLogTimeFormat("")
 
 	var keyLog io.Writer
 	if len(*keyLogFile) > 0 {
@@ -84,13 +74,13 @@ func main() {
 	var wg sync.WaitGroup
 	wg.Add(len(urls))
 	for _, addr := range urls {
-		logger.Infof("GET %s", addr)
+		log.Printf("GET %s", addr)
 		go func(addr string) {
 			rsp, err := hclient.Get(addr)
 			if err != nil {
 				log.Fatal(err)
 			}
-			logger.Infof("Got response for %s: %#v", addr, rsp)
+			log.Printf("Got response for %s: %#v", addr, rsp)
 
 			body := &bytes.Buffer{}
 			_, err = io.Copy(body, rsp.Body)
@@ -98,10 +88,9 @@ func main() {
 				log.Fatal(err)
 			}
 			if *quiet {
-				logger.Infof("Response Body: %d bytes", body.Len())
+				log.Printf("Response Body: %d bytes", body.Len())
 			} else {
-				logger.Infof("Response Body:")
-				logger.Infof("%s", body.Bytes())
+				log.Printf("Response Body (%d bytes):\n%s", body.Len(), body.Bytes())
 			}
 			wg.Done()
 		}(addr)

--- a/example/main.go
+++ b/example/main.go
@@ -121,7 +121,7 @@ func setupHandler(www string) http.Handler {
 					err = errors.New("couldn't get uploaded file size")
 				}
 			}
-			utils.DefaultLogger.Infof("Error receiving upload: %#v", err)
+			log.Printf("Error receiving upload: %#v", err)
 		}
 		io.WriteString(w, `<html><body><form action="/demo/upload" method="post" enctype="multipart/form-data">
 				<input type="file" name="uploadfile"><br>
@@ -139,7 +139,6 @@ func main() {
 	}()
 	// runtime.SetBlockProfileRate(1)
 
-	verbose := flag.Bool("v", false, "verbose")
 	bs := binds{}
 	flag.Var(&bs, "bind", "bind to")
 	www := flag.String("www", "", "www data")
@@ -148,15 +147,6 @@ func main() {
 	cert := flag.String("cert", "", "TLS certificate (requires -key option)")
 	enableQlog := flag.Bool("qlog", false, "output a qlog (in the same directory)")
 	flag.Parse()
-
-	logger := utils.DefaultLogger
-
-	if *verbose {
-		logger.SetLogLevel(utils.LogLevelDebug)
-	} else {
-		logger.SetLogLevel(utils.LogLevelInfo)
-	}
-	logger.SetLogTimeFormat("")
 
 	if len(bs) == 0 {
 		bs = binds{"localhost:6121"}


### PR DESCRIPTION
Users can adjust the log level using the QUIC_GO_LOG_LEVEL environment variable. This is more representative of how quic-go would actually be used, since the logger is part of an internal package.