### PR TITLE
remove shutdown method on the Connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -232,7 +232,7 @@ func (c *client) dial(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
-		c.conn.shutdown()
+		c.conn.destroy(nil)
 		return context.Cause(ctx)
 	case err := <-errorChan:
 		return err

--- a/client_test.go
+++ b/client_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Client", func() {
 
 	AfterEach(func() {
 		if s, ok := cl.conn.(*connection); ok {
-			s.shutdown()
+			s.destroy(nil)
 		}
 		Eventually(areConnsRunning).Should(BeFalse())
 	})

--- a/closed_conn.go
+++ b/closed_conn.go
@@ -41,7 +41,6 @@ func (c *closedLocalConn) handlePacket(p receivedPacket) {
 	c.sendPacket(p.remoteAddr, p.info)
 }
 
-func (c *closedLocalConn) shutdown()                            {}
 func (c *closedLocalConn) destroy(error)                        {}
 func (c *closedLocalConn) getPerspective() protocol.Perspective { return c.perspective }
 
@@ -59,6 +58,5 @@ func newClosedRemoteConn(pers protocol.Perspective) packetHandler {
 }
 
 func (s *closedRemoteConn) handlePacket(receivedPacket)          {}
-func (s *closedRemoteConn) shutdown()                            {}
 func (s *closedRemoteConn) destroy(error)                        {}
 func (s *closedRemoteConn) getPerspective() protocol.Perspective { return s.perspective }

--- a/closed_conn_test.go
+++ b/closed_conn_test.go
@@ -14,8 +14,6 @@ var _ = Describe("Closed local connection", func() {
 	It("tells its perspective", func() {
 		conn := newClosedLocalConn(nil, protocol.PerspectiveClient, utils.DefaultLogger)
 		Expect(conn.getPerspective()).To(Equal(protocol.PerspectiveClient))
-		// stop the connection
-		conn.shutdown()
 	})
 
 	It("repeats the packet containing the CONNECTION_CLOSE frame", func() {

--- a/connection.go
+++ b/connection.go
@@ -1572,13 +1572,6 @@ func (s *connection) closeRemote(e error) {
 	})
 }
 
-// Close the connection. It sends a NO_ERROR application error.
-// It waits until the run loop has stopped before returning
-func (s *connection) shutdown() {
-	s.closeLocal(nil)
-	<-s.ctx.Done()
-}
-
 func (s *connection) CloseWithError(code ApplicationErrorCode, desc string) error {
 	s.closeLocal(&qerr.ApplicationError{
 		ErrorCode:    code,

--- a/mock_packet_handler_test.go
+++ b/mock_packet_handler_test.go
@@ -147,39 +147,3 @@ func (c *PacketHandlerhandlePacketCall) DoAndReturn(f func(receivedPacket)) *Pac
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
-
-// shutdown mocks base method.
-func (m *MockPacketHandler) shutdown() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "shutdown")
-}
-
-// shutdown indicates an expected call of shutdown.
-func (mr *MockPacketHandlerMockRecorder) shutdown() *PacketHandlershutdownCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "shutdown", reflect.TypeOf((*MockPacketHandler)(nil).shutdown))
-	return &PacketHandlershutdownCall{Call: call}
-}
-
-// PacketHandlershutdownCall wrap *gomock.Call
-type PacketHandlershutdownCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *PacketHandlershutdownCall) Return() *PacketHandlershutdownCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *PacketHandlershutdownCall) Do(f func()) *PacketHandlershutdownCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *PacketHandlershutdownCall) DoAndReturn(f func()) *PacketHandlershutdownCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}

--- a/mock_quic_conn_test.go
+++ b/mock_quic_conn_test.go
@@ -841,39 +841,3 @@ func (c *QUICConnrunCall) DoAndReturn(f func() error) *QUICConnrunCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
-
-// shutdown mocks base method.
-func (m *MockQUICConn) shutdown() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "shutdown")
-}
-
-// shutdown indicates an expected call of shutdown.
-func (mr *MockQUICConnMockRecorder) shutdown() *QUICConnshutdownCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "shutdown", reflect.TypeOf((*MockQUICConn)(nil).shutdown))
-	return &QUICConnshutdownCall{Call: call}
-}
-
-// QUICConnshutdownCall wrap *gomock.Call
-type QUICConnshutdownCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *QUICConnshutdownCall) Return() *QUICConnshutdownCall {
-	c.Call = c.Call.Return()
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *QUICConnshutdownCall) Do(f func()) *QUICConnshutdownCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *QUICConnshutdownCall) DoAndReturn(f func()) *QUICConnshutdownCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -191,7 +191,6 @@ func (h *packetHandlerMap) ReplaceWithClosed(ids []protocol.ConnectionID, pers p
 
 	time.AfterFunc(h.deleteRetiredConnsAfter, func() {
 		h.mutex.Lock()
-		handler.shutdown()
 		for _, id := range ids {
 			delete(h.handlers, id)
 		}

--- a/server.go
+++ b/server.go
@@ -24,7 +24,6 @@ var ErrServerClosed = errors.New("quic: server closed")
 // packetHandler handles packets
 type packetHandler interface {
 	handlePacket(receivedPacket)
-	shutdown()
 	destroy(error)
 	getPerspective() protocol.Perspective
 }
@@ -45,7 +44,6 @@ type quicConn interface {
 	getPerspective() protocol.Perspective
 	run() error
 	destroy(error)
-	shutdown()
 }
 
 type zeroRTTQueue struct {


### PR DESCRIPTION
There's no need to have a dedicated shutdown method, as the use case (shutting down an outgoing connection attempt on context cancellation) can be achieved by using Connection.destroy.