### PR TITLE
send the CONNECTION_REFUSED error when refusing a connection

### DIFF
--- a/closed_conn.go
+++ b/closed_conn.go
@@ -41,8 +41,9 @@ func (c *closedLocalConn) handlePacket(p receivedPacket) {
 	c.sendPacket(p.remoteAddr, p.info)
 }
 
-func (c *closedLocalConn) destroy(error)                        {}
-func (c *closedLocalConn) getPerspective() protocol.Perspective { return c.perspective }
+func (c *closedLocalConn) destroy(error)                              {}
+func (c *closedLocalConn) closeWithTransportError(TransportErrorCode) {}
+func (c *closedLocalConn) getPerspective() protocol.Perspective       { return c.perspective }
 
 // A closedRemoteConn is a connection that was closed remotely.
 // For such a connection, we might receive reordered packets that were sent before the CONNECTION_CLOSE.
@@ -57,6 +58,7 @@ func newClosedRemoteConn(pers protocol.Perspective) packetHandler {
 	return &closedRemoteConn{perspective: pers}
 }
 
-func (s *closedRemoteConn) handlePacket(receivedPacket)          {}
-func (s *closedRemoteConn) destroy(error)                        {}
-func (s *closedRemoteConn) getPerspective() protocol.Perspective { return s.perspective }
+func (c *closedRemoteConn) handlePacket(receivedPacket)                {}
+func (c *closedRemoteConn) destroy(error)                              {}
+func (c *closedRemoteConn) closeWithTransportError(TransportErrorCode) {}
+func (c *closedRemoteConn) getPerspective() protocol.Perspective       { return c.perspective }

--- a/connection.go
+++ b/connection.go
@@ -1581,6 +1581,11 @@ func (s *connection) CloseWithError(code ApplicationErrorCode, desc string) erro
 	return nil
 }
 
+func (s *connection) closeWithTransportError(code TransportErrorCode) {
+	s.closeLocal(&qerr.TransportError{ErrorCode: code})
+	<-s.ctx.Done()
+}
+
 func (s *connection) handleCloseError(closeErr *closeError) {
 	e := closeErr.err
 	if e == nil {

--- a/mock_packet_handler_test.go
+++ b/mock_packet_handler_test.go
@@ -12,6 +12,7 @@ import (
 	reflect "reflect"
 
 	protocol "github.com/quic-go/quic-go/internal/protocol"
+	qerr "github.com/quic-go/quic-go/internal/qerr"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -36,6 +37,42 @@ func NewMockPacketHandler(ctrl *gomock.Controller) *MockPacketHandler {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPacketHandler) EXPECT() *MockPacketHandlerMockRecorder {
 	return m.recorder
+}
+
+// closeWithTransportError mocks base method.
+func (m *MockPacketHandler) closeWithTransportError(arg0 qerr.TransportErrorCode) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "closeWithTransportError", arg0)
+}
+
+// closeWithTransportError indicates an expected call of closeWithTransportError.
+func (mr *MockPacketHandlerMockRecorder) closeWithTransportError(arg0 any) *PacketHandlercloseWithTransportErrorCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "closeWithTransportError", reflect.TypeOf((*MockPacketHandler)(nil).closeWithTransportError), arg0)
+	return &PacketHandlercloseWithTransportErrorCall{Call: call}
+}
+
+// PacketHandlercloseWithTransportErrorCall wrap *gomock.Call
+type PacketHandlercloseWithTransportErrorCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *PacketHandlercloseWithTransportErrorCall) Return() *PacketHandlercloseWithTransportErrorCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *PacketHandlercloseWithTransportErrorCall) Do(f func(qerr.TransportErrorCode)) *PacketHandlercloseWithTransportErrorCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *PacketHandlercloseWithTransportErrorCall) DoAndReturn(f func(qerr.TransportErrorCode)) *PacketHandlercloseWithTransportErrorCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // destroy mocks base method.

--- a/mock_quic_conn_test.go
+++ b/mock_quic_conn_test.go
@@ -656,6 +656,42 @@ func (c *QUICConnSendDatagramCall) DoAndReturn(f func([]byte) error) *QUICConnSe
 	return c
 }
 
+// closeWithTransportError mocks base method.
+func (m *MockQUICConn) closeWithTransportError(arg0 qerr.TransportErrorCode) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "closeWithTransportError", arg0)
+}
+
+// closeWithTransportError indicates an expected call of closeWithTransportError.
+func (mr *MockQUICConnMockRecorder) closeWithTransportError(arg0 any) *QUICConncloseWithTransportErrorCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "closeWithTransportError", reflect.TypeOf((*MockQUICConn)(nil).closeWithTransportError), arg0)
+	return &QUICConncloseWithTransportErrorCall{Call: call}
+}
+
+// QUICConncloseWithTransportErrorCall wrap *gomock.Call
+type QUICConncloseWithTransportErrorCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *QUICConncloseWithTransportErrorCall) Return() *QUICConncloseWithTransportErrorCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *QUICConncloseWithTransportErrorCall) Do(f func(qerr.TransportErrorCode)) *QUICConncloseWithTransportErrorCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *QUICConncloseWithTransportErrorCall) DoAndReturn(f func(qerr.TransportErrorCode)) *QUICConncloseWithTransportErrorCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // destroy mocks base method.
 func (m *MockQUICConn) destroy(arg0 error) {
 	m.ctrl.T.Helper()

--- a/server_test.go
+++ b/server_test.go
@@ -327,7 +327,7 @@ var _ = Describe("Server", func() {
 				Eventually(run).Should(BeClosed())
 				Eventually(done).Should(BeClosed())
 				// shutdown
-				conn.EXPECT().destroy(gomock.Any())
+				conn.EXPECT().closeWithTransportError(gomock.Any())
 			})
 
 			It("sends a Version Negotiation Packet for unsupported versions", func() {
@@ -530,7 +530,7 @@ var _ = Describe("Server", func() {
 				Eventually(run).Should(BeClosed())
 				Eventually(done).Should(BeClosed())
 				// shutdown
-				conn.EXPECT().destroy(gomock.Any()).MaxTimes(1)
+				conn.EXPECT().closeWithTransportError(gomock.Any()).MaxTimes(1)
 			})
 
 			It("drops packets if the receive queue is full", func() {
@@ -570,7 +570,7 @@ var _ = Describe("Server", func() {
 					conn.EXPECT().Context().Return(context.Background()).MaxTimes(1)
 					conn.EXPECT().HandshakeComplete().Return(make(chan struct{})).MaxTimes(1)
 					// shutdown
-					conn.EXPECT().destroy(gomock.Any()).MaxTimes(1)
+					conn.EXPECT().closeWithTransportError(gomock.Any()).MaxTimes(1)
 					return conn
 				}
 
@@ -1008,7 +1008,7 @@ var _ = Describe("Server", func() {
 				) quicConn {
 					conn := NewMockQUICConn(mockCtrl)
 					conn.EXPECT().handlePacket(gomock.Any())
-					conn.EXPECT().destroy(&qerr.TransportError{ErrorCode: ConnectionRefused}).Do(func(error) { close(destroyed) })
+					conn.EXPECT().closeWithTransportError(ConnectionRefused).Do(func(TransportErrorCode) { close(destroyed) })
 					conn.EXPECT().HandshakeComplete().Return(make(chan struct{}))
 					conn.EXPECT().run().MaxTimes(1)
 					conn.EXPECT().Context().Return(context.Background())
@@ -1468,7 +1468,7 @@ var _ = Describe("Server", func() {
 				conn.EXPECT().Context().Return(context.Background())
 				close(called)
 				// shutdown
-				conn.EXPECT().destroy(gomock.Any())
+				conn.EXPECT().closeWithTransportError(gomock.Any())
 				return conn
 			}
 


### PR DESCRIPTION
So far, we used `Connection.destroy`, which destroys a connection without sending out a CONNECTION_CLOSE frame. This is useful (for example) when receiving a stateless reset, but it's not what we want when the server refuses an incoming connection. In this case, we want to send out a packet with a CONNECTION_CLOSE frame to inform the client that the connection attempt is being rejected.

This PR also adds an integration test. Once again this confirms the rule: If there's no test, it will break, rather sooner than later.