### PR TITLE
remove unneeded nil check for new connections in the server

### DIFF
--- a/server.go
+++ b/server.go
@@ -718,10 +718,6 @@ func (s *baseServer) handleInitialImpl(p receivedPacket, hdr *wire.Header) error
 			conn.closeWithTransportError(ConnectionRefused)
 		}
 	}()
-	if conn == nil {
-		p.buffer.Release()
-		return nil
-	}
 	return nil
 }
 


### PR DESCRIPTION
I don't believe it's needed. `AddWithConnID` will return `false` if there's no connection.
Furthermore, `conn.run` would have panicked with a nil pointer dereference anyway before we even hit this `nil` check.