### PR TITLE
http3: only use :protocol pseudo-header for Extended CONNECT

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -140,15 +140,13 @@ func requestFromHeaders(headerFields []qpack.HeaderField) (*http.Request, error)
 			if err != nil {
 				return nil, err
 			}
+			protocol = hdr.Protocol
 		} else {
 			u.Path = hdr.Path
 		}
 		u.Scheme = hdr.Scheme
 		u.Host = hdr.Authority
 		requestURI = hdr.Authority
-		if hdr.Protocol != "" {
-			protocol = hdr.Protocol
-		}
 	} else {
 		u, err = url.ParseRequestURI(hdr.Path)
 		if err != nil {

--- a/http3/headers.go
+++ b/http3/headers.go
@@ -128,7 +128,8 @@ func requestFromHeaders(headerFields []qpack.HeaderField) (*http.Request, error)
 
 	var u *url.URL
 	var requestURI string
-	var protocol string
+
+	protocol := "HTTP/3.0"
 
 	if isConnect {
 		u = &url.URL{}
@@ -143,9 +144,10 @@ func requestFromHeaders(headerFields []qpack.HeaderField) (*http.Request, error)
 		u.Scheme = hdr.Scheme
 		u.Host = hdr.Authority
 		requestURI = hdr.Authority
-		protocol = hdr.Protocol
+		if hdr.Protocol != "" {
+			protocol = hdr.Protocol
+		}
 	} else {
-		protocol = "HTTP/3.0"
 		u, err = url.ParseRequestURI(hdr.Path)
 		if err != nil {
 			return nil, fmt.Errorf("invalid content length: %w", err)

--- a/http3/headers.go
+++ b/http3/headers.go
@@ -124,6 +124,8 @@ func requestFromHeaders(headerFields []qpack.HeaderField) (*http.Request, error)
 		}
 	} else if len(hdr.Path) == 0 || len(hdr.Authority) == 0 || len(hdr.Method) == 0 {
 		return nil, errors.New(":path, :authority and :method must not be empty")
+	} else if len(hdr.Protocol) > 0 {
+		return nil, errors.New(":protocol must be empty")
 	}
 
 	var u *url.URL

--- a/http3/headers.go
+++ b/http3/headers.go
@@ -124,7 +124,9 @@ func requestFromHeaders(headerFields []qpack.HeaderField) (*http.Request, error)
 		}
 	} else if len(hdr.Path) == 0 || len(hdr.Authority) == 0 || len(hdr.Method) == 0 {
 		return nil, errors.New(":path, :authority and :method must not be empty")
-	} else if len(hdr.Protocol) > 0 {
+	}
+
+	if !isExtendedConnected && len(hdr.Protocol) > 0 {
 		return nil, errors.New(":protocol must be empty")
 	}
 

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -212,6 +212,17 @@ var _ = Describe("Request", func() {
 		Expect(err).To(MatchError(":path, :authority and :method must not be empty"))
 	})
 
+	It("errors with invalid protocol", func() {
+		headers := []qpack.HeaderField{
+			{Name: ":path", Value: "/foo"},
+			{Name: ":authority", Value: "quic.clemente.io"},
+			{Name: ":method", Value: "GET"},
+			{Name: ":protocol", Value: "connect-udp"},
+		}
+		_, err := requestFromHeaders(headers)
+		Expect(err).To(MatchError(":protocol must be empty"))
+	})
+
 	Context("regular HTTP CONNECT", func() {
 		It("handles CONNECT method", func() {
 			headers := []qpack.HeaderField{

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -221,6 +221,7 @@ var _ = Describe("Request", func() {
 			req, err := requestFromHeaders(headers)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(req.Method).To(Equal(http.MethodConnect))
+			Expect(req.Proto).To(Equal("HTTP/3.0"))
 			Expect(req.RequestURI).To(Equal("quic.clemente.io"))
 		})
 


### PR DESCRIPTION
The default value should be "HTTP/3.0".