### PR TITLE
wire: optimize generation of Version Negotiation packets

### DIFF
--- a/internal/wire/version_negotiation.go
+++ b/internal/wire/version_negotiation.go
@@ -1,13 +1,11 @@
 package wire
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
 
 	"github.com/quic-go/quic-go/internal/protocol"
-	"github.com/quic-go/quic-go/internal/utils"
 )
 
 // ParseVersionNegotiationPacket parses a Version Negotiation packet.
@@ -37,20 +35,19 @@ func ParseVersionNegotiationPacket(b []byte) (dest, src protocol.ArbitraryLenCon
 func ComposeVersionNegotiation(destConnID, srcConnID protocol.ArbitraryLenConnectionID, versions []protocol.Version) []byte {
 	greasedVersions := protocol.GetGreasedVersions(versions)
 	expectedLen := 1 /* type byte */ + 4 /* version field */ + 1 /* dest connection ID length field */ + destConnID.Len() + 1 /* src connection ID length field */ + srcConnID.Len() + len(greasedVersions)*4
-	buf := bytes.NewBuffer(make([]byte, 0, expectedLen))
-	r := make([]byte, 1)
-	_, _ = rand.Read(r) // ignore the error here. It is not critical to have perfect random here.
+	buf := make([]byte, 1+4 /* type byte and version field */, expectedLen)
+	_, _ = rand.Read(buf[:1]) // ignore the error here. It is not critical to have perfect random here.
 	// Setting the "QUIC bit" (0x40) is not required by the RFC,
 	// but it allows clients to demultiplex QUIC with a long list of other protocols.
 	// See RFC 9443 and https://mailarchive.ietf.org/arch/msg/quic/oR4kxGKY6mjtPC1CZegY1ED4beg/ for details.
-	buf.WriteByte(r[0] | 0xc0)
-	utils.BigEndian.WriteUint32(buf, 0) // version 0
-	buf.WriteByte(uint8(destConnID.Len()))
-	buf.Write(destConnID.Bytes())
-	buf.WriteByte(uint8(srcConnID.Len()))
-	buf.Write(srcConnID.Bytes())
+	buf[0] |= 0xc0
+	// The next 4 bytes are left at 0 (version number).
+	buf = append(buf, uint8(destConnID.Len()))
+	buf = append(buf, destConnID.Bytes()...)
+	buf = append(buf, uint8(srcConnID.Len()))
+	buf = append(buf, srcConnID.Bytes()...)
 	for _, v := range greasedVersions {
-		utils.BigEndian.WriteUint32(buf, uint32(v))
+		buf = binary.BigEndian.AppendUint32(buf, uint32(v))
 	}
-	return buf.Bytes()
+	return buf
 }

--- a/internal/wire/version_negotiation_test.go
+++ b/internal/wire/version_negotiation_test.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"encoding/binary"
+	"testing"
 
 	"golang.org/x/exp/rand"
 
@@ -91,3 +92,13 @@ var _ = Describe("Version Negotiation Packets", func() {
 		Expect(reservedVersion&0x0f0f0f0f == 0x0a0a0a0a).To(BeTrue()) // check that it's a greased version number
 	})
 })
+
+func BenchmarkComposeVersionNegotiationPacket(b *testing.B) {
+	b.ReportAllocs()
+	supportedVersions := []protocol.Version{protocol.Version2, protocol.Version1, 0x1337}
+	destConnID := protocol.ArbitraryLenConnectionID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0xa, 0xb, 0xc, 0xd}
+	srcConnID := protocol.ArbitraryLenConnectionID{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+	for i := 0; i < b.N; i++ {
+		ComposeVersionNegotiation(destConnID, srcConnID, supportedVersions)
+	}
+}


### PR DESCRIPTION
```
name                                old time/op    new time/op    delta
ComposeVersionNegotiationPacket-16     900ns ± 2%     317ns ± 3%  -64.74%  (p=0.000 n=10+10)

name                                old alloc/op   new alloc/op   delta
ComposeVersionNegotiationPacket-16      120B ± 0%       64B ± 0%  -46.67%  (p=0.000 n=10+10)

name                                old allocs/op  new allocs/op  delta
ComposeVersionNegotiationPacket-16      6.00 ± 0%      2.00 ± 0%  -66.67%  (p=0.000 n=10+10)
