### PR TITLE
testutils: make the package public

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -21,10 +21,10 @@ import (
 	mocklogging "github.com/quic-go/quic-go/internal/mocks/logging"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
-	"github.com/quic-go/quic-go/internal/testutils"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/internal/wire"
 	"github.com/quic-go/quic-go/logging"
+	"github.com/quic-go/quic-go/testutils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/quic-go/quic-go"
 	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
 	"github.com/quic-go/quic-go/internal/protocol"
-	"github.com/quic-go/quic-go/internal/testutils"
 	"github.com/quic-go/quic-go/internal/wire"
+	"github.com/quic-go/quic-go/testutils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -1,3 +1,6 @@
+// Package testutils contains utilities for simulating packet injection and man-in-the-middle (MITM) attacker tests.
+// It is not supposed to be used for non-testing purposes.
+// The API is not guaranteed to be stable.
 package testutils
 
 import (
@@ -7,9 +10,6 @@ import (
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/wire"
 )
-
-// Utilities for simulating packet injection and man-in-the-middle (MITM) attacker tests.
-// Do not use for non-testing purposes.
 
 // writePacket returns a new raw packet with the specified header and payload
 func writePacket(hdr *wire.ExtendedHeader, data []byte) []byte {


### PR DESCRIPTION
This package can be useful outside of quic-go. We're not making any API guarantees at this point.