### PR TITLE
ci: remove unused depguard check for qtls

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,16 +2,6 @@ run:
   skip-files:
     - internal/handshake/cipher_suite.go
 linters-settings:
-  depguard:
-    rules:
-      qtls:
-        list-mode: lax
-        files:
-          - "!internal/qtls/**"
-          - "$all"
-        deny:
-          - pkg: github.com/quic-go/qtls-go1-20
-            desc: "importing qtls only allowed in internal/qtls"
   misspell:
     ignore-words:
       - ect
@@ -20,7 +10,6 @@ linters:
   disable-all: true
   enable:
     - asciicheck
-    - depguard
     - exhaustive
     - exportloopref
     - goimports


### PR DESCRIPTION
Fortunately, qtls is a thing of the past.