### PR TITLE
qlog: add a logger for events outside of established connections

### DIFF
--- a/internal/mocks/logging/internal/tracer.go
+++ b/internal/mocks/logging/internal/tracer.go
@@ -41,6 +41,42 @@ func (m *MockTracer) EXPECT() *MockTracerMockRecorder {
 	return m.recorder
 }
 
+// Debug mocks base method.
+func (m *MockTracer) Debug(arg0, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Debug", arg0, arg1)
+}
+
+// Debug indicates an expected call of Debug.
+func (mr *MockTracerMockRecorder) Debug(arg0, arg1 any) *TracerDebugCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Debug", reflect.TypeOf((*MockTracer)(nil).Debug), arg0, arg1)
+	return &TracerDebugCall{Call: call}
+}
+
+// TracerDebugCall wrap *gomock.Call
+type TracerDebugCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *TracerDebugCall) Return() *TracerDebugCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *TracerDebugCall) Do(f func(string, string)) *TracerDebugCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *TracerDebugCall) DoAndReturn(f func(string, string)) *TracerDebugCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // DroppedPacket mocks base method.
 func (m *MockTracer) DroppedPacket(arg0 net.Addr, arg1 logging.PacketType, arg2 protocol.ByteCount, arg3 logging.PacketDropReason) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/logging/internal/tracer.go
+++ b/internal/mocks/logging/internal/tracer.go
@@ -41,6 +41,42 @@ func (m *MockTracer) EXPECT() *MockTracerMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockTracer) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockTracerMockRecorder) Close() *TracerCloseCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockTracer)(nil).Close))
+	return &TracerCloseCall{Call: call}
+}
+
+// TracerCloseCall wrap *gomock.Call
+type TracerCloseCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *TracerCloseCall) Return() *TracerCloseCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *TracerCloseCall) Do(f func()) *TracerCloseCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *TracerCloseCall) DoAndReturn(f func()) *TracerCloseCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Debug mocks base method.
 func (m *MockTracer) Debug(arg0, arg1 string) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/logging/mockgen.go
+++ b/internal/mocks/logging/mockgen.go
@@ -14,6 +14,7 @@ type Tracer interface {
 	SentPacket(net.Addr, *logging.Header, logging.ByteCount, []logging.Frame)
 	SentVersionNegotiationPacket(_ net.Addr, dest, src logging.ArbitraryLenConnectionID, _ []logging.VersionNumber)
 	DroppedPacket(net.Addr, logging.PacketType, logging.ByteCount, logging.PacketDropReason)
+	Debug(name, msg string)
 }
 
 //go:generate sh -c "go run go.uber.org/mock/mockgen -typed -build_flags=\"-tags=gomock\" -package internal -destination internal/connection_tracer.go github.com/quic-go/quic-go/internal/mocks/logging ConnectionTracer"

--- a/internal/mocks/logging/mockgen.go
+++ b/internal/mocks/logging/mockgen.go
@@ -15,6 +15,7 @@ type Tracer interface {
 	SentVersionNegotiationPacket(_ net.Addr, dest, src logging.ArbitraryLenConnectionID, _ []logging.VersionNumber)
 	DroppedPacket(net.Addr, logging.PacketType, logging.ByteCount, logging.PacketDropReason)
 	Debug(name, msg string)
+	Close()
 }
 
 //go:generate sh -c "go run go.uber.org/mock/mockgen -typed -build_flags=\"-tags=gomock\" -package internal -destination internal/connection_tracer.go github.com/quic-go/quic-go/internal/mocks/logging ConnectionTracer"

--- a/internal/mocks/logging/tracer.go
+++ b/internal/mocks/logging/tracer.go
@@ -28,5 +28,8 @@ func NewMockTracer(ctrl *gomock.Controller) (*logging.Tracer, *MockTracer) {
 		Debug: func(name, msg string) {
 			t.Debug(name, msg)
 		},
+		Close: func() {
+			t.Close()
+		},
 	}, t
 }

--- a/internal/mocks/logging/tracer.go
+++ b/internal/mocks/logging/tracer.go
@@ -25,5 +25,8 @@ func NewMockTracer(ctrl *gomock.Controller) (*logging.Tracer, *MockTracer) {
 		DroppedPacket: func(remote net.Addr, typ logging.PacketType, size logging.ByteCount, reason logging.PacketDropReason) {
 			t.DroppedPacket(remote, typ, size, reason)
 		},
+		Debug: func(name, msg string) {
+			t.Debug(name, msg)
+		},
 	}, t
 }

--- a/logging/multiplex_test.go
+++ b/logging/multiplex_test.go
@@ -64,6 +64,12 @@ var _ = Describe("Tracing", func() {
 				tr2.EXPECT().DroppedPacket(remote, PacketTypeRetry, ByteCount(1024), PacketDropDuplicate)
 				tracer.DroppedPacket(remote, PacketTypeRetry, 1024, PacketDropDuplicate)
 			})
+
+			It("traces the Debug event", func() {
+				tr1.EXPECT().Debug("foo", "bar")
+				tr2.EXPECT().Debug("foo", "bar")
+				tracer.Debug("foo", "bar")
+			})
 		})
 	})
 

--- a/logging/multiplex_test.go
+++ b/logging/multiplex_test.go
@@ -70,6 +70,12 @@ var _ = Describe("Tracing", func() {
 				tr2.EXPECT().Debug("foo", "bar")
 				tracer.Debug("foo", "bar")
 			})
+
+			It("traces the Close event", func() {
+				tr1.EXPECT().Close()
+				tr2.EXPECT().Close()
+				tracer.Close()
+			})
 		})
 	})
 

--- a/logging/tracer.go
+++ b/logging/tracer.go
@@ -7,6 +7,7 @@ type Tracer struct {
 	SentPacket                   func(net.Addr, *Header, ByteCount, []Frame)
 	SentVersionNegotiationPacket func(_ net.Addr, dest, src ArbitraryLenConnectionID, _ []VersionNumber)
 	DroppedPacket                func(net.Addr, PacketType, ByteCount, PacketDropReason)
+	Debug                        func(name, msg string)
 }
 
 // NewMultiplexedTracer creates a new tracer that multiplexes events to multiple tracers.
@@ -36,6 +37,13 @@ func NewMultiplexedTracer(tracers ...*Tracer) *Tracer {
 			for _, t := range tracers {
 				if t.DroppedPacket != nil {
 					t.DroppedPacket(remote, typ, size, reason)
+				}
+			}
+		},
+		Debug: func(name, msg string) {
+			for _, t := range tracers {
+				if t.Debug != nil {
+					t.Debug(name, msg)
 				}
 			}
 		},

--- a/logging/tracer.go
+++ b/logging/tracer.go
@@ -8,6 +8,7 @@ type Tracer struct {
 	SentVersionNegotiationPacket func(_ net.Addr, dest, src ArbitraryLenConnectionID, _ []VersionNumber)
 	DroppedPacket                func(net.Addr, PacketType, ByteCount, PacketDropReason)
 	Debug                        func(name, msg string)
+	Close                        func()
 }
 
 // NewMultiplexedTracer creates a new tracer that multiplexes events to multiple tracers.
@@ -44,6 +45,13 @@ func NewMultiplexedTracer(tracers ...*Tracer) *Tracer {
 			for _, t := range tracers {
 				if t.Debug != nil {
 					t.Debug(name, msg)
+				}
+			}
+		},
+		Close: func() {
+			for _, t := range tracers {
+				if t.Close != nil {
+					t.Close()
 				}
 			}
 		},

--- a/qlog/connection_tracer.go
+++ b/qlog/connection_tracer.go
@@ -23,10 +23,10 @@ type connectionTracer struct {
 // NewConnectionTracer creates a new tracer to record a qlog for a connection.
 func NewConnectionTracer(w io.WriteCloser, p logging.Perspective, odcid protocol.ConnectionID) *logging.ConnectionTracer {
 	tr := &trace{
-		VantagePoint: vantagePoint{Type: p},
+		VantagePoint: vantagePoint{Type: p.String()},
 		CommonFields: commonFields{
-			ODCID:         odcid,
-			GroupID:       odcid,
+			ODCID:         &odcid,
+			GroupID:       &odcid,
 			ReferenceTime: time.Now(),
 		},
 	}

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -233,6 +233,20 @@ func (e eventVersionNegotiationReceived) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.ArrayKey("supported_versions", versions(e.SupportedVersions))
 }
 
+type eventVersionNegotiationSent struct {
+	Header            packetHeaderVersionNegotiation
+	SupportedVersions []versionNumber
+}
+
+func (e eventVersionNegotiationSent) Category() category { return categoryTransport }
+func (e eventVersionNegotiationSent) Name() string       { return "packet_sent" }
+func (e eventVersionNegotiationSent) IsNil() bool        { return false }
+
+func (e eventVersionNegotiationSent) MarshalJSONObject(enc *gojay.Encoder) {
+	enc.ObjectKey("header", e.Header)
+	enc.ArrayKey("supported_versions", versions(e.SupportedVersions))
+}
+
 type eventPacketBuffered struct {
 	PacketType logging.PacketType
 	PacketSize protocol.ByteCount

--- a/qlog/trace.go
+++ b/qlog/trace.go
@@ -4,7 +4,6 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/logging"
 
 	"github.com/francoispqt/gojay"
@@ -62,30 +61,27 @@ func (c configuration) MarshalJSONObject(enc *gojay.Encoder) {
 
 type vantagePoint struct {
 	Name string
-	Type protocol.Perspective
+	Type string
 }
 
 func (p vantagePoint) IsNil() bool { return false }
 func (p vantagePoint) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKeyOmitEmpty("name", p.Name)
-	switch p.Type {
-	case protocol.PerspectiveClient:
-		enc.StringKey("type", "client")
-	case protocol.PerspectiveServer:
-		enc.StringKey("type", "server")
-	}
+	enc.StringKeyOmitEmpty("type", p.Type)
 }
 
 type commonFields struct {
-	ODCID         logging.ConnectionID
-	GroupID       logging.ConnectionID
+	ODCID         *logging.ConnectionID
+	GroupID       *logging.ConnectionID
 	ProtocolType  string
 	ReferenceTime time.Time
 }
 
 func (f commonFields) MarshalJSONObject(enc *gojay.Encoder) {
-	enc.StringKey("ODCID", f.ODCID.String())
-	enc.StringKey("group_id", f.ODCID.String())
+	if f.ODCID != nil {
+		enc.StringKey("ODCID", f.ODCID.String())
+		enc.StringKey("group_id", f.ODCID.String())
+	}
 	enc.StringKeyOmitEmpty("protocol_type", f.ProtocolType)
 	enc.Float64Key("reference_time", float64(f.ReferenceTime.UnixNano())/1e6)
 	enc.StringKey("time_format", "relative")

--- a/qlog/tracer.go
+++ b/qlog/tracer.go
@@ -1,0 +1,29 @@
+package qlog
+
+import (
+	"io"
+	"time"
+
+	"github.com/quic-go/quic-go/logging"
+)
+
+func NewTracer(w io.WriteCloser) *logging.Tracer {
+	tr := &trace{
+		VantagePoint: vantagePoint{Type: "transport"},
+		CommonFields: commonFields{ReferenceTime: time.Now()},
+	}
+	wr := *newWriter(w, tr)
+	go wr.Run()
+	return &logging.Tracer{
+		SentPacket:                   nil,
+		SentVersionNegotiationPacket: nil,
+		DroppedPacket:                nil,
+		Debug: func(name, msg string) {
+			wr.RecordEvent(time.Now(), &eventGeneric{
+				name: name,
+				msg:  msg,
+			})
+		},
+		Close: func() { wr.Close() },
+	}
+}

--- a/qlog/tracer_test.go
+++ b/qlog/tracer_test.go
@@ -1,0 +1,59 @@
+package qlog
+
+import (
+	"bytes"
+	"encoding/json"
+	"time"
+
+	"github.com/quic-go/quic-go/logging"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Tracing", func() {
+	var (
+		tracer *logging.Tracer
+		buf    *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		buf = &bytes.Buffer{}
+		tracer = NewTracer(nopWriteCloser(buf))
+	})
+
+	It("exports a trace that has the right metadata", func() {
+		tracer.Close()
+
+		m := make(map[string]interface{})
+		Expect(json.Unmarshal(buf.Bytes(), &m)).To(Succeed())
+		Expect(m).To(HaveKeyWithValue("qlog_version", "draft-02"))
+		Expect(m).To(HaveKey("title"))
+		Expect(m).To(HaveKey("trace"))
+		trace := m["trace"].(map[string]interface{})
+		Expect(trace).To(HaveKey(("common_fields")))
+		commonFields := trace["common_fields"].(map[string]interface{})
+		Expect(commonFields).ToNot(HaveKey("ODCID"))
+		Expect(commonFields).ToNot(HaveKey("group_id"))
+		Expect(commonFields).To(HaveKey("reference_time"))
+		referenceTime := time.Unix(0, int64(commonFields["reference_time"].(float64)*1e6))
+		Expect(referenceTime).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+		Expect(commonFields).To(HaveKeyWithValue("time_format", "relative"))
+		Expect(trace).To(HaveKey("vantage_point"))
+		vantagePoint := trace["vantage_point"].(map[string]interface{})
+		Expect(vantagePoint).To(HaveKeyWithValue("type", "transport"))
+	})
+
+	Context("Events", func() {
+		It("records a generic event", func() {
+			tracer.Debug("foo", "bar")
+			tracer.Close()
+			entry := exportAndParseSingle(buf)
+			Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+			Expect(entry.Name).To(Equal("transport:foo"))
+			ev := entry.Event
+			Expect(ev).To(HaveLen(1))
+			Expect(ev).To(HaveKeyWithValue("details", "bar"))
+		})
+	})
+})

--- a/qlog/tracer_test.go
+++ b/qlog/tracer_test.go
@@ -47,6 +47,41 @@ var _ = Describe("Tracing", func() {
 	})
 
 	Context("Events", func() {
+		It("records a sent long header packet, without an ACK", func() {
+			tracer.SentPacket(
+				nil,
+				&logging.Header{
+					Type:             protocol.PacketTypeHandshake,
+					DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+					SrcConnectionID:  protocol.ParseConnectionID([]byte{4, 3, 2, 1}),
+					Length:           1337,
+					Version:          protocol.Version1,
+				},
+				1234,
+				[]logging.Frame{
+					&logging.MaxStreamDataFrame{StreamID: 42, MaximumStreamData: 987},
+					&logging.StreamFrame{StreamID: 123, Offset: 1234, Length: 6, Fin: true},
+				},
+			)
+			tracer.Close()
+			entry := exportAndParseSingle(buf)
+			Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+			Expect(entry.Name).To(Equal("transport:packet_sent"))
+			ev := entry.Event
+			Expect(ev).To(HaveKey("raw"))
+			raw := ev["raw"].(map[string]interface{})
+			Expect(raw).To(HaveKeyWithValue("length", float64(1234)))
+			Expect(ev).To(HaveKey("header"))
+			hdr := ev["header"].(map[string]interface{})
+			Expect(hdr).To(HaveKeyWithValue("packet_type", "handshake"))
+			Expect(hdr).To(HaveKeyWithValue("scid", "04030201"))
+			Expect(ev).To(HaveKey("frames"))
+			frames := ev["frames"].([]interface{})
+			Expect(frames).To(HaveLen(2))
+			Expect(frames[0].(map[string]interface{})).To(HaveKeyWithValue("frame_type", "max_stream_data"))
+			Expect(frames[1].(map[string]interface{})).To(HaveKeyWithValue("frame_type", "stream"))
+		})
+
 		It("records sending of a Version Negotiation packet", func() {
 			tracer.SentVersionNegotiationPacket(
 				nil,


### PR DESCRIPTION
Depends on #4298.

This qlogger will log events that happen outside of established connections: dropped packets that can't be associated with any connection, sent Retry and Version Negotiation packets, etc.