### PR TITLE
add a qlog tracer for events outside of QUIC connections

### DIFF
--- a/integrationtests/self/conn_id_test.go
+++ b/integrationtests/self/conn_id_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Connection ID lengths tests", func() {
 			ConnectionIDLength:    connIDLen,
 			ConnectionIDGenerator: connIDGenerator,
 		}
+		addTracer(tr)
 		ln, err := tr.Listen(getTLSConfig(), getQuicConfig(nil))
 		Expect(err).ToNot(HaveOccurred())
 		go func() {
@@ -92,6 +93,7 @@ var _ = Describe("Connection ID lengths tests", func() {
 			ConnectionIDLength:    connIDLen,
 			ConnectionIDGenerator: connIDGenerator,
 		}
+		addTracer(tr)
 		defer tr.Close()
 		cl, err := tr.Dial(
 			context.Background(),

--- a/integrationtests/self/handshake_rtt_test.go
+++ b/integrationtests/self/handshake_rtt_test.go
@@ -64,6 +64,7 @@ var _ = Describe("Handshake RTT tests", func() {
 			Conn:                     udpConn,
 			MaxUnvalidatedHandshakes: -1,
 		}
+		addTracer(tr)
 		defer tr.Close()
 		ln, err := tr.Listen(serverTLSConfig, serverConfig)
 		Expect(err).ToNot(HaveOccurred())

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -328,7 +328,10 @@ var _ = Describe("Handshake tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			pconn, err = net.ListenUDP("udp", laddr)
 			Expect(err).ToNot(HaveOccurred())
-			dialer = &quic.Transport{Conn: pconn, ConnectionIDLength: 4}
+			dialer = &quic.Transport{
+				Conn:               pconn,
+				ConnectionIDLength: 4,
+			}
 		})
 
 		AfterEach(func() {
@@ -431,9 +434,8 @@ var _ = Describe("Handshake tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			udpConn, err := net.ListenUDP("udp", laddr)
 			Expect(err).ToNot(HaveOccurred())
-			tr := quic.Transport{
-				Conn: udpConn,
-			}
+			tr := &quic.Transport{Conn: udpConn}
+			addTracer(tr)
 			defer tr.Close()
 			tlsConf := &tls.Config{}
 			done := make(chan struct{})
@@ -476,10 +478,11 @@ var _ = Describe("Handshake tests", func() {
 
 		It("sends a Retry when the number of handshakes reaches MaxUnvalidatedHandshakes", func() {
 			const limit = 3
-			tr := quic.Transport{
+			tr := &quic.Transport{
 				Conn:                     conn,
 				MaxUnvalidatedHandshakes: limit,
 			}
+			addTracer(tr)
 			defer tr.Close()
 
 			// Block all handshakes.
@@ -541,10 +544,11 @@ var _ = Describe("Handshake tests", func() {
 
 		It("rejects connections when the number of handshakes reaches MaxHandshakes", func() {
 			const limit = 3
-			tr := quic.Transport{
+			tr := &quic.Transport{
 				Conn:          conn,
 				MaxHandshakes: limit,
 			}
+			addTracer(tr)
 			defer tr.Close()
 
 			// Block all handshakes.
@@ -717,6 +721,7 @@ var _ = Describe("Handshake tests", func() {
 				Conn:                     udpConn,
 				MaxUnvalidatedHandshakes: -1,
 			}
+			addTracer(tr)
 			defer tr.Close()
 			server, err := tr.Listen(getTLSConfig(), serverConfig)
 			Expect(err).ToNot(HaveOccurred())

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -41,6 +41,7 @@ var _ = Describe("MITM test", func() {
 			Conn:               c,
 			ConnectionIDLength: connIDLen,
 		}
+		addTracer(serverTransport)
 		if forceAddressValidation {
 			serverTransport.MaxUnvalidatedHandshakes = -1
 		}
@@ -86,6 +87,7 @@ var _ = Describe("MITM test", func() {
 			Conn:               clientUDPConn,
 			ConnectionIDLength: connIDLen,
 		}
+		addTracer(clientTransport)
 	})
 
 	Context("unsuccessful attacks", func() {

--- a/integrationtests/self/multiplex_test.go
+++ b/integrationtests/self/multiplex_test.go
@@ -74,6 +74,7 @@ var _ = Describe("Multiplexing", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer conn.Close()
 			tr := &quic.Transport{Conn: conn}
+			addTracer(tr)
 
 			done1 := make(chan struct{})
 			done2 := make(chan struct{})
@@ -109,6 +110,7 @@ var _ = Describe("Multiplexing", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer conn.Close()
 			tr := &quic.Transport{Conn: conn}
+			addTracer(tr)
 
 			done1 := make(chan struct{})
 			done2 := make(chan struct{})
@@ -139,6 +141,7 @@ var _ = Describe("Multiplexing", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer conn.Close()
 			tr := &quic.Transport{Conn: conn}
+			addTracer(tr)
 			server, err := tr.Listen(
 				getTLSConfig(),
 				getQuicConfig(nil),
@@ -167,6 +170,7 @@ var _ = Describe("Multiplexing", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer conn1.Close()
 				tr1 := &quic.Transport{Conn: conn1}
+				addTracer(tr1)
 
 				addr2, err := net.ResolveUDPAddr("udp", "localhost:0")
 				Expect(err).ToNot(HaveOccurred())
@@ -174,6 +178,7 @@ var _ = Describe("Multiplexing", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer conn2.Close()
 				tr2 := &quic.Transport{Conn: conn2}
+				addTracer(tr2)
 
 				server1, err := tr1.Listen(
 					getTLSConfig(),
@@ -220,6 +225,7 @@ var _ = Describe("Multiplexing", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer conn1.Close()
 		tr1 := &quic.Transport{Conn: conn1}
+		addTracer(tr1)
 
 		addr2, err := net.ResolveUDPAddr("udp", "localhost:0")
 		Expect(err).ToNot(HaveOccurred())
@@ -227,6 +233,7 @@ var _ = Describe("Multiplexing", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer conn2.Close()
 		tr2 := &quic.Transport{Conn: conn2}
+		addTracer(tr2)
 
 		server, err := tr1.Listen(getTLSConfig(), getQuicConfig(nil))
 		Expect(err).ToNot(HaveOccurred())

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -175,6 +175,7 @@ var _ = Describe("0-RTT", func() {
 				Conn:               udpConn,
 				ConnectionIDLength: connIDLen,
 			}
+			addTracer(tr)
 			defer tr.Close()
 			conn, err = tr.DialEarly(
 				context.Background(),
@@ -463,6 +464,7 @@ var _ = Describe("0-RTT", func() {
 			Conn:                     udpConn,
 			MaxUnvalidatedHandshakes: -1,
 		}
+		addTracer(tr)
 		defer tr.Close()
 		ln, err := tr.ListenEarly(
 			tlsConf,

--- a/integrationtests/tools/qlog.go
+++ b/integrationtests/tools/qlog.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"time"
 
 	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/internal/utils"
@@ -14,13 +15,21 @@ import (
 	"github.com/quic-go/quic-go/qlog"
 )
 
-func NewQlogger(logger io.Writer) func(context.Context, logging.Perspective, quic.ConnectionID) *logging.ConnectionTracer {
+func QlogTracer(logger io.Writer) *logging.Tracer {
+	filename := fmt.Sprintf("log_%s_transport.qlog", time.Now().Format("2006-01-02T15:04:05"))
+	fmt.Fprintf(logger, "Creating %s.\n", filename)
+	f, err := os.Create(filename)
+	if err != nil {
+		log.Fatalf("failed to create qlog file: %s", err)
+		return nil
+	}
+	bw := bufio.NewWriter(f)
+	return qlog.NewTracer(utils.NewBufferedWriteCloser(bw, f))
+}
+
+func NewQlogConnectionTracer(logger io.Writer) func(context.Context, logging.Perspective, quic.ConnectionID) *logging.ConnectionTracer {
 	return func(_ context.Context, p logging.Perspective, connID quic.ConnectionID) *logging.ConnectionTracer {
-		role := "server"
-		if p == logging.PerspectiveClient {
-			role = "client"
-		}
-		filename := fmt.Sprintf("log_%s_%s.qlog", connID, role)
+		filename := fmt.Sprintf("log_%s_%s.qlog", connID, p.String())
 		fmt.Fprintf(logger, "Creating %s.\n", filename)
 		f, err := os.Create(filename)
 		if err != nil {

--- a/integrationtests/versionnegotiation/versionnegotiation_suite_test.go
+++ b/integrationtests/versionnegotiation/versionnegotiation_suite_test.go
@@ -65,7 +65,7 @@ func maybeAddQLOGTracer(c *quic.Config) *quic.Config {
 	if !enableQlog {
 		return c
 	}
-	qlogger := tools.NewQlogger(GinkgoWriter)
+	qlogger := tools.NewQlogConnectionTracer(GinkgoWriter)
 	if c.Tracer == nil {
 		c.Tracer = qlogger
 	} else if qlogger != nil {

--- a/qlog/connection_tracer.go
+++ b/qlog/connection_tracer.go
@@ -23,10 +23,10 @@ type connectionTracer struct {
 // NewConnectionTracer creates a new tracer to record a qlog for a connection.
 func NewConnectionTracer(w io.WriteCloser, p logging.Perspective, odcid protocol.ConnectionID) *logging.ConnectionTracer {
 	tr := &trace{
-		VantagePoint: vantagePoint{Type: p},
+		VantagePoint: vantagePoint{Type: p.String()},
 		CommonFields: commonFields{
-			ODCID:         odcid,
-			GroupID:       odcid,
+			ODCID:         &odcid,
+			GroupID:       &odcid,
 			ReferenceTime: time.Now(),
 		},
 	}

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -233,6 +233,20 @@ func (e eventVersionNegotiationReceived) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.ArrayKey("supported_versions", versions(e.SupportedVersions))
 }
 
+type eventVersionNegotiationSent struct {
+	Header            packetHeaderVersionNegotiation
+	SupportedVersions []versionNumber
+}
+
+func (e eventVersionNegotiationSent) Category() category { return categoryTransport }
+func (e eventVersionNegotiationSent) Name() string       { return "packet_sent" }
+func (e eventVersionNegotiationSent) IsNil() bool        { return false }
+
+func (e eventVersionNegotiationSent) MarshalJSONObject(enc *gojay.Encoder) {
+	enc.ObjectKey("header", e.Header)
+	enc.ArrayKey("supported_versions", versions(e.SupportedVersions))
+}
+
 type eventPacketBuffered struct {
 	PacketType logging.PacketType
 	PacketSize protocol.ByteCount

--- a/qlog/trace.go
+++ b/qlog/trace.go
@@ -4,7 +4,6 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/logging"
 
 	"github.com/francoispqt/gojay"
@@ -62,30 +61,27 @@ func (c configuration) MarshalJSONObject(enc *gojay.Encoder) {
 
 type vantagePoint struct {
 	Name string
-	Type protocol.Perspective
+	Type string
 }
 
 func (p vantagePoint) IsNil() bool { return false }
 func (p vantagePoint) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKeyOmitEmpty("name", p.Name)
-	switch p.Type {
-	case protocol.PerspectiveClient:
-		enc.StringKey("type", "client")
-	case protocol.PerspectiveServer:
-		enc.StringKey("type", "server")
-	}
+	enc.StringKeyOmitEmpty("type", p.Type)
 }
 
 type commonFields struct {
-	ODCID         logging.ConnectionID
-	GroupID       logging.ConnectionID
+	ODCID         *logging.ConnectionID
+	GroupID       *logging.ConnectionID
 	ProtocolType  string
 	ReferenceTime time.Time
 }
 
 func (f commonFields) MarshalJSONObject(enc *gojay.Encoder) {
-	enc.StringKey("ODCID", f.ODCID.String())
-	enc.StringKey("group_id", f.ODCID.String())
+	if f.ODCID != nil {
+		enc.StringKey("ODCID", f.ODCID.String())
+		enc.StringKey("group_id", f.ODCID.String())
+	}
 	enc.StringKeyOmitEmpty("protocol_type", f.ProtocolType)
 	enc.Float64Key("reference_time", float64(f.ReferenceTime.UnixNano())/1e6)
 	enc.StringKey("time_format", "relative")

--- a/qlog/tracer.go
+++ b/qlog/tracer.go
@@ -1,0 +1,29 @@
+package qlog
+
+import (
+	"io"
+	"time"
+
+	"github.com/quic-go/quic-go/logging"
+)
+
+func NewTracer(w io.WriteCloser) *logging.Tracer {
+	tr := &trace{
+		VantagePoint: vantagePoint{Type: "transport"},
+		CommonFields: commonFields{ReferenceTime: time.Now()},
+	}
+	wr := *newWriter(w, tr)
+	go wr.Run()
+	return &logging.Tracer{
+		SentPacket:                   nil,
+		SentVersionNegotiationPacket: nil,
+		DroppedPacket:                nil,
+		Debug: func(name, msg string) {
+			wr.RecordEvent(time.Now(), &eventGeneric{
+				name: name,
+				msg:  msg,
+			})
+		},
+		Close: func() { wr.Close() },
+	}
+}

--- a/qlog/tracer_test.go
+++ b/qlog/tracer_test.go
@@ -1,0 +1,59 @@
+package qlog
+
+import (
+	"bytes"
+	"encoding/json"
+	"time"
+
+	"github.com/quic-go/quic-go/logging"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Tracing", func() {
+	var (
+		tracer *logging.Tracer
+		buf    *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		buf = &bytes.Buffer{}
+		tracer = NewTracer(nopWriteCloser(buf))
+	})
+
+	It("exports a trace that has the right metadata", func() {
+		tracer.Close()
+
+		m := make(map[string]interface{})
+		Expect(json.Unmarshal(buf.Bytes(), &m)).To(Succeed())
+		Expect(m).To(HaveKeyWithValue("qlog_version", "draft-02"))
+		Expect(m).To(HaveKey("title"))
+		Expect(m).To(HaveKey("trace"))
+		trace := m["trace"].(map[string]interface{})
+		Expect(trace).To(HaveKey(("common_fields")))
+		commonFields := trace["common_fields"].(map[string]interface{})
+		Expect(commonFields).ToNot(HaveKey("ODCID"))
+		Expect(commonFields).ToNot(HaveKey("group_id"))
+		Expect(commonFields).To(HaveKey("reference_time"))
+		referenceTime := time.Unix(0, int64(commonFields["reference_time"].(float64)*1e6))
+		Expect(referenceTime).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+		Expect(commonFields).To(HaveKeyWithValue("time_format", "relative"))
+		Expect(trace).To(HaveKey("vantage_point"))
+		vantagePoint := trace["vantage_point"].(map[string]interface{})
+		Expect(vantagePoint).To(HaveKeyWithValue("type", "transport"))
+	})
+
+	Context("Events", func() {
+		It("records a generic event", func() {
+			tracer.Debug("foo", "bar")
+			tracer.Close()
+			entry := exportAndParseSingle(buf)
+			Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+			Expect(entry.Name).To(Equal("transport:foo"))
+			ev := entry.Event
+			Expect(ev).To(HaveLen(1))
+			Expect(ev).To(HaveKeyWithValue("details", "bar"))
+		})
+	})
+})

--- a/qlog/tracer_test.go
+++ b/qlog/tracer_test.go
@@ -47,6 +47,41 @@ var _ = Describe("Tracing", func() {
 	})
 
 	Context("Events", func() {
+		It("records a sent long header packet, without an ACK", func() {
+			tracer.SentPacket(
+				nil,
+				&logging.Header{
+					Type:             protocol.PacketTypeHandshake,
+					DestConnectionID: protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+					SrcConnectionID:  protocol.ParseConnectionID([]byte{4, 3, 2, 1}),
+					Length:           1337,
+					Version:          protocol.Version1,
+				},
+				1234,
+				[]logging.Frame{
+					&logging.MaxStreamDataFrame{StreamID: 42, MaximumStreamData: 987},
+					&logging.StreamFrame{StreamID: 123, Offset: 1234, Length: 6, Fin: true},
+				},
+			)
+			tracer.Close()
+			entry := exportAndParseSingle(buf)
+			Expect(entry.Time).To(BeTemporally("~", time.Now(), scaleDuration(10*time.Millisecond)))
+			Expect(entry.Name).To(Equal("transport:packet_sent"))
+			ev := entry.Event
+			Expect(ev).To(HaveKey("raw"))
+			raw := ev["raw"].(map[string]interface{})
+			Expect(raw).To(HaveKeyWithValue("length", float64(1234)))
+			Expect(ev).To(HaveKey("header"))
+			hdr := ev["header"].(map[string]interface{})
+			Expect(hdr).To(HaveKeyWithValue("packet_type", "handshake"))
+			Expect(hdr).To(HaveKeyWithValue("scid", "04030201"))
+			Expect(ev).To(HaveKey("frames"))
+			frames := ev["frames"].([]interface{})
+			Expect(frames).To(HaveLen(2))
+			Expect(frames[0].(map[string]interface{})).To(HaveKeyWithValue("frame_type", "max_stream_data"))
+			Expect(frames[1].(map[string]interface{})).To(HaveKeyWithValue("frame_type", "stream"))
+		})
+
 		It("records sending of a Version Negotiation packet", func() {
 			tracer.SentVersionNegotiationPacket(
 				nil,


### PR DESCRIPTION
By attaching a qlog tracer to the `Transport`, it's now possible to log QUIC events that don't belong to any particular connection. For example, this could be Version Negotiation and Retry packets that we send, packets that we can't associate with any connection, etc.

It also allows using the `Debug` function on the `logging.Tracer` to dig deeper into unexpected behavior happening in a server.