### PR TITLE
Prevent using IPv4-mapped IPv6 address as source in OOB

### DIFF
--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -274,7 +274,7 @@ func (info *packetInfo) OOB() []byte {
 	if info == nil {
 		return nil
 	}
-	if info.addr.Is4() {
+	if info.addr.Is4() || info.addr.Is4In6() {
 		ip := info.addr.As4()
 		// struct in_pktinfo {
 		// 	unsigned int   ipi_ifindex;  /* Interface index */

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -5,6 +5,7 @@ package quic
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"time"
 
 	"golang.org/x/net/ipv4"
@@ -307,6 +308,16 @@ var _ = Describe("OOB Conn Test", func() {
 			Expect(oobMsg).To(HaveCap(cap(oob))) // check that it appended to oob
 			expected := appendIPv4ECNMsg([]byte{}, protocol.ECNCE)
 			Expect(oobMsg).To(Equal(expected))
+		})
+	})
+
+	Context("serializing packet info", func() {
+		It("treats IPv4-mapped IPv6 addresses as IPv4", func() {
+			addr4in6 := netip.MustParseAddr("::ffff:127.0.0.1")
+			info4in6 := packetInfo{addr: addr4in6, ifIndex: 0}
+			addr4 := netip.MustParseAddr("127.0.0.1")
+			info4 := packetInfo{addr: addr4, ifIndex: 0}
+			Expect(info4in6.OOB()).To(Equal(info4.OOB()))
 		})
 	})
 


### PR DESCRIPTION
Fixes https://github.com/quic-go/quic-go/issues/4304 and https://github.com/quic-go/quic-go/issues/4105. Thanks to @peterjeremy for identifying the issue.