### PR TITLE
unmap IPv4-mapped IPv6 addresses

### DIFF
--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -221,7 +221,7 @@ func (c *oobConn) ReadPacket() (receivedPacket, error) {
 				// 	unsigned int    ipi6_ifindex; /* send/recv interface index */
 				// };
 				if len(body) == 20 {
-					p.info.addr = netip.AddrFrom16(*(*[16]byte)(body[:16]))
+					p.info.addr = netip.AddrFrom16(*(*[16]byte)(body[:16])).Unmap()
 					p.info.ifIndex = binary.LittleEndian.Uint32(body[16:])
 				} else {
 					invalidCmsgOnceV6.Do(func() {

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -235,7 +235,7 @@ var _ = Describe("OOB Conn Test", func() {
 			Eventually(packetChan).Should(Receive(&p))
 			Expect(utils.IsIPv4(p.remoteAddr.(*net.UDPAddr).IP)).To(BeTrue())
 			Expect(p.info).To(Not(BeNil()))
-			Expect(p.info.addr.Is4In6() || p.info.addr.Is4()).To(BeTrue())
+			Expect(p.info.addr.Is4()).To(BeTrue())
 			ip := p.info.addr.As4()
 			Expect(net.IP(ip[:])).To(Equal(ip4.To4()))
 


### PR DESCRIPTION
Closes #4308.

As an alternative or addition to https://github.com/quic-go/quic-go/pull/4308 (issues #4304 and #4105). Perhaps this can better be dealt with at the boundary.