### PR TITLE
don't preallocate the slice for STREAM frames when composing a packet

### DIFF
--- a/packet_packer.go
+++ b/packet_packer.go
@@ -589,12 +589,11 @@ func (p *packetPacker) composeNextPacket(maxFrameSize protocol.ByteCount, onlyAc
 		return payload{}
 	}
 
-	pl := payload{streamFrames: make([]ackhandler.StreamFrame, 0, 1)}
-
 	hasData := p.framer.HasData()
 	hasRetransmission := p.retransmissionQueue.HasAppData()
 
 	var hasAck bool
+	var pl payload
 	if ackAllowed {
 		if ack := p.acks.GetAckFrame(protocol.Encryption1RTT, !hasRetransmission && !hasData); ack != nil {
 			pl.ack = ack


### PR DESCRIPTION
The slice will be allocated when STREAM frames are appended. By not preallocating it is made sure that the slice is only created in cases where STREAM frames are actually sent in this packet.

Part of #3526.