### PR TITLE
qtls: protect the tls.ClientSessionCache implementation with a mutex

### DIFF
--- a/internal/qtls/client_session_cache.go
+++ b/internal/qtls/client_session_cache.go
@@ -2,9 +2,11 @@ package qtls
 
 import (
 	"crypto/tls"
+	"sync"
 )
 
 type clientSessionCache struct {
+	mx      sync.Mutex
 	getData func(earlyData bool) []byte
 	setData func(data []byte, earlyData bool) (allowEarlyData bool)
 	wrapped tls.ClientSessionCache
@@ -12,7 +14,10 @@ type clientSessionCache struct {
 
 var _ tls.ClientSessionCache = &clientSessionCache{}
 
-func (c clientSessionCache) Put(key string, cs *tls.ClientSessionState) {
+func (c *clientSessionCache) Put(key string, cs *tls.ClientSessionState) {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+
 	if cs == nil {
 		c.wrapped.Put(key, nil)
 		return
@@ -32,7 +37,10 @@ func (c clientSessionCache) Put(key string, cs *tls.ClientSessionState) {
 	c.wrapped.Put(key, newCS)
 }
 
-func (c clientSessionCache) Get(key string) (*tls.ClientSessionState, bool) {
+func (c *clientSessionCache) Get(key string) (*tls.ClientSessionState, bool) {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+
 	cs, ok := c.wrapped.Get(key)
 	if !ok || cs == nil {
 		return cs, ok


### PR DESCRIPTION
This prevents a race condition when the underlying ClientSessionCache provided by the application returns the same session ticket for multiple connections. Reusing session tickets is explicitly recommended against by both RFC 8446 and RFC 9001, but it's not forbidden. This fix only benefits applications that compromise their users' privacy by reusing session tickets.

@ainar-g Could you give this PR a try? As a permanent fix, I'd recommend not reusing session tickets though.