### PR TITLE
handshake: optimize AEAD handling for long header sealers and openers

### DIFF
--- a/internal/handshake/aead.go
+++ b/internal/handshake/aead.go
@@ -1,13 +1,12 @@
 package handshake
 
 import (
-	"crypto/cipher"
 	"encoding/binary"
 
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
-func createAEAD(suite *cipherSuite, trafficSecret []byte, v protocol.Version) cipher.AEAD {
+func createAEAD(suite *cipherSuite, trafficSecret []byte, v protocol.Version) *xorNonceAEAD {
 	keyLabel := hkdfLabelKeyV1
 	ivLabel := hkdfLabelIVV1
 	if v == protocol.Version2 {
@@ -20,28 +19,26 @@ func createAEAD(suite *cipherSuite, trafficSecret []byte, v protocol.Version) ci
 }
 
 type longHeaderSealer struct {
-	aead            cipher.AEAD
+	aead            *xorNonceAEAD
 	headerProtector headerProtector
-
-	// use a single slice to avoid allocations
-	nonceBuf []byte
+	nonceBuf        [8]byte
 }
 
 var _ LongHeaderSealer = &longHeaderSealer{}
 
-func newLongHeaderSealer(aead cipher.AEAD, headerProtector headerProtector) LongHeaderSealer {
+func newLongHeaderSealer(aead *xorNonceAEAD, headerProtector headerProtector) LongHeaderSealer {
+	if aead.NonceSize() != 8 {
+		panic("unexpected nonce size")
+	}
 	return &longHeaderSealer{
 		aead:            aead,
 		headerProtector: headerProtector,
-		nonceBuf:        make([]byte, aead.NonceSize()),
 	}
 }
 
 func (s *longHeaderSealer) Seal(dst, src []byte, pn protocol.PacketNumber, ad []byte) []byte {
-	binary.BigEndian.PutUint64(s.nonceBuf[len(s.nonceBuf)-8:], uint64(pn))
-	// The AEAD we're using here will be the qtls.aeadAESGCM13.
-	// It uses the nonce provided here and XOR it with the IV.
-	return s.aead.Seal(dst, s.nonceBuf, src, ad)
+	binary.BigEndian.PutUint64(s.nonceBuf[:], uint64(pn))
+	return s.aead.Seal(dst, s.nonceBuf[:], src, ad)
 }
 
 func (s *longHeaderSealer) EncryptHeader(sample []byte, firstByte *byte, pnBytes []byte) {
@@ -53,21 +50,23 @@ func (s *longHeaderSealer) Overhead() int {
 }
 
 type longHeaderOpener struct {
-	aead            cipher.AEAD
+	aead            *xorNonceAEAD
 	headerProtector headerProtector
 	highestRcvdPN   protocol.PacketNumber // highest packet number received (which could be successfully unprotected)
 
-	// use a single slice to avoid allocations
-	nonceBuf []byte
+	// use a single array to avoid allocations
+	nonceBuf [8]byte
 }
 
 var _ LongHeaderOpener = &longHeaderOpener{}
 
-func newLongHeaderOpener(aead cipher.AEAD, headerProtector headerProtector) LongHeaderOpener {
+func newLongHeaderOpener(aead *xorNonceAEAD, headerProtector headerProtector) LongHeaderOpener {
+	if aead.NonceSize() != 8 {
+		panic("unexpected nonce size")
+	}
 	return &longHeaderOpener{
 		aead:            aead,
 		headerProtector: headerProtector,
-		nonceBuf:        make([]byte, aead.NonceSize()),
 	}
 }
 
@@ -76,10 +75,8 @@ func (o *longHeaderOpener) DecodePacketNumber(wirePN protocol.PacketNumber, wire
 }
 
 func (o *longHeaderOpener) Open(dst, src []byte, pn protocol.PacketNumber, ad []byte) ([]byte, error) {
-	binary.BigEndian.PutUint64(o.nonceBuf[len(o.nonceBuf)-8:], uint64(pn))
-	// The AEAD we're using here will be the qtls.aeadAESGCM13.
-	// It uses the nonce provided here and XOR it with the IV.
-	dec, err := o.aead.Open(dst, o.nonceBuf, src, ad)
+	binary.BigEndian.PutUint64(o.nonceBuf[:], uint64(pn))
+	dec, err := o.aead.Open(dst, o.nonceBuf[:], src, ad)
 	if err == nil {
 		o.highestRcvdPN = max(o.highestRcvdPN, pn)
 	} else {

--- a/internal/handshake/aead_test.go
+++ b/internal/handshake/aead_test.go
@@ -33,8 +33,8 @@ var _ = Describe("Long Header AEAD", func() {
 						aead, err := cipher.NewGCM(block)
 						Expect(err).ToNot(HaveOccurred())
 
-						return newLongHeaderSealer(aead, newHeaderProtector(cs, hpKey, true, v)),
-							newLongHeaderOpener(aead, newHeaderProtector(cs, hpKey, true, v))
+						return newLongHeaderSealer(&xorNonceAEAD{aead: aead}, newHeaderProtector(cs, hpKey, true, v)),
+							newLongHeaderOpener(&xorNonceAEAD{aead: aead}, newHeaderProtector(cs, hpKey, true, v))
 					}
 
 					Context("message encryption", func() {

--- a/internal/handshake/cipher_suite.go
+++ b/internal/handshake/cipher_suite.go
@@ -18,7 +18,7 @@ type cipherSuite struct {
 	ID     uint16
 	Hash   crypto.Hash
 	KeyLen int
-	AEAD   func(key, nonceMask []byte) cipher.AEAD
+	AEAD   func(key, nonceMask []byte) *xorNonceAEAD
 }
 
 func (s cipherSuite) IVLen() int { return aeadNonceLength }
@@ -36,7 +36,7 @@ func getCipherSuite(id uint16) *cipherSuite {
 	}
 }
 
-func aeadAESGCMTLS13(key, nonceMask []byte) cipher.AEAD {
+func aeadAESGCMTLS13(key, nonceMask []byte) *xorNonceAEAD {
 	if len(nonceMask) != aeadNonceLength {
 		panic("tls: internal error: wrong nonce length")
 	}
@@ -54,7 +54,7 @@ func aeadAESGCMTLS13(key, nonceMask []byte) cipher.AEAD {
 	return ret
 }
 
-func aeadChaCha20Poly1305(key, nonceMask []byte) cipher.AEAD {
+func aeadChaCha20Poly1305(key, nonceMask []byte) *xorNonceAEAD {
 	if len(nonceMask) != aeadNonceLength {
 		panic("tls: internal error: wrong nonce length")
 	}


### PR DESCRIPTION
Not a huge improvement, only slightly fewer allocs.

Part of #3663.

```
name                               old time/op    new time/op    delta
InitialAEADCreate-16                 4.78µs ± 5%    4.79µs ± 5%    ~     (p=0.927 n=10+10)
InitialAEAD/opening_100_bytes-16      116ns ± 2%     118ns ± 3%    ~     (p=0.116 n=8+10)
InitialAEAD/opening_1200_bytes-16     207ns ± 1%     208ns ± 3%    ~     (p=0.616 n=10+10)
InitialAEAD/sealing_100_bytes-16      111ns ± 3%     111ns ± 3%    ~     (p=0.764 n=9+10)
InitialAEAD/sealing_1200_bytes-16     206ns ± 2%     207ns ± 3%    ~     (p=0.424 n=10+10)

name                               old alloc/op   new alloc/op   delta
InitialAEADCreate-16                 10.5kB ± 0%    10.4kB ± 0%  -0.72%  (p=0.000 n=10+10)
InitialAEAD/opening_100_bytes-16      0.00B          0.00B         ~     (all equal)
InitialAEAD/opening_1200_bytes-16     0.00B          0.00B         ~     (all equal)
InitialAEAD/sealing_100_bytes-16      0.00B          0.00B         ~     (all equal)
InitialAEAD/sealing_1200_bytes-16     0.00B          0.00B         ~     (all equal)

name                               old allocs/op  new allocs/op  delta
InitialAEADCreate-16                    131 ± 0%       129 ± 0%  -1.53%  (p=0.000 n=10+10)
InitialAEAD/opening_100_bytes-16       0.00           0.00         ~     (all equal)
InitialAEAD/opening_1200_bytes-16      0.00           0.00         ~     (all equal)
InitialAEAD/sealing_100_bytes-16       0.00           0.00         ~     (all equal)
InitialAEAD/sealing_1200_bytes-16      0.00           0.00         ~     (all equal)
