### PR TITLE
handshake: embed the mask as an array into the aesHeaderProtector

### DIFF
--- a/internal/handshake/header_protector.go
+++ b/internal/handshake/header_protector.go
@@ -37,7 +37,7 @@ func newHeaderProtector(suite *cipherSuite, trafficSecret []byte, isLongHeader b
 }
 
 type aesHeaderProtector struct {
-	mask         []byte
+	mask         [16]byte // AES always has a 16 byte block size
 	block        cipher.Block
 	isLongHeader bool
 }
@@ -52,7 +52,6 @@ func newAESHeaderProtector(suite *cipherSuite, trafficSecret []byte, isLongHeade
 	}
 	return &aesHeaderProtector{
 		block:        block,
-		mask:         make([]byte, block.BlockSize()),
 		isLongHeader: isLongHeader,
 	}
 }
@@ -69,7 +68,7 @@ func (p *aesHeaderProtector) apply(sample []byte, firstByte *byte, hdrBytes []by
 	if len(sample) != len(p.mask) {
 		panic("invalid sample size")
 	}
-	p.block.Encrypt(p.mask, sample)
+	p.block.Encrypt(p.mask[:], sample)
 	if p.isLongHeader {
 		*firstByte ^= p.mask[0] & 0xf
 	} else {


### PR DESCRIPTION
Part of #3663.
```
InitialAEADCreate-16                 4.78µs ± 5%    4.75µs ± 4%    ~     (p=0.631 n=10+10)
InitialAEAD/opening_100_bytes-16      116ns ± 2%     116ns ± 2%    ~     (p=0.846 n=8+10)
InitialAEAD/opening_1200_bytes-16     207ns ± 1%     209ns ± 2%    ~     (p=0.137 n=10+10)
InitialAEAD/sealing_100_bytes-16      111ns ± 3%     113ns ± 4%  +2.05%  (p=0.037 n=9+10)
InitialAEAD/sealing_1200_bytes-16     206ns ± 2%     206ns ± 3%    ~     (p=0.739 n=10+10)

name                               old alloc/op   new alloc/op   delta
InitialAEADCreate-16                 10.5kB ± 0%    10.4kB ± 0%  -0.31%  (p=0.000 n=10+10)
InitialAEAD/opening_100_bytes-16      0.00B          0.00B         ~     (all equal)
InitialAEAD/opening_1200_bytes-16     0.00B          0.00B         ~     (all equal)
InitialAEAD/sealing_100_bytes-16      0.00B          0.00B         ~     (all equal)
InitialAEAD/sealing_1200_bytes-16     0.00B          0.00B         ~     (all equal)

name                               old allocs/op  new allocs/op  delta
InitialAEADCreate-16                    131 ± 0%       129 ± 0%  -1.53%  (p=0.000 n=10+10)
InitialAEAD/opening_100_bytes-16       0.00           0.00         ~     (all equal)
InitialAEAD/opening_1200_bytes-16      0.00           0.00         ~     (all equal)
InitialAEAD/sealing_100_bytes-16       0.00           0.00         ~     (all equal)
InitialAEAD/sealing_1200_bytes-16      0.00           0.00         ~     (all equal)
