### PR TITLE
qlog/event.go: import the error structs from quic-go/qerr

### DIFF
--- a/qlog/event.go
+++ b/qlog/event.go
@@ -7,10 +7,10 @@ import (
 	"net/netip"
 	"time"
 
-	"github.com/quic-go/quic-go"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/logging"
+	"github.com/quic-go/quic-go/qerr"
 
 	"github.com/francoispqt/gojay"
 )
@@ -114,12 +114,12 @@ func (e eventConnectionClosed) IsNil() bool        { return false }
 
 func (e eventConnectionClosed) MarshalJSONObject(enc *gojay.Encoder) {
 	var (
-		statelessResetErr     *quic.StatelessResetError
-		handshakeTimeoutErr   *quic.HandshakeTimeoutError
-		idleTimeoutErr        *quic.IdleTimeoutError
-		applicationErr        *quic.ApplicationError
-		transportErr          *quic.TransportError
-		versionNegotiationErr *quic.VersionNegotiationError
+		statelessResetErr     *qerr.StatelessResetError
+		handshakeTimeoutErr   *qerr.HandshakeTimeoutError
+		idleTimeoutErr        *qerr.IdleTimeoutError
+		applicationErr        *qerr.ApplicationError
+		transportErr          *qerr.TransportError
+		versionNegotiationErr *qerr.VersionNegotiationError
 	)
 	switch {
 	case errors.As(e.e, &statelessResetErr):


### PR DESCRIPTION
Instead of importing the error structs from the quic-go package, we can be more specific and import them from the qerr package.
If you tried to import the quic-go/qlog package you got an cyclic import error.
This fixes the problem.

