### PR TITLE
http3: don't automatically set RoundTripper.QuicConfig.EnableDatagrams

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -73,6 +73,10 @@ var _ roundTripCloser = &client{}
 func newClient(hostname string, tlsConf *tls.Config, opts *roundTripperOpts, conf *quic.Config, dialer dialFunc) (roundTripCloser, error) {
 	if conf == nil {
 		conf = defaultQuicConfig.Clone()
+		conf.EnableDatagrams = opts.EnableDatagram
+	}
+	if opts.EnableDatagram && !conf.EnableDatagrams {
+		return nil, errors.New("HTTP Datagrams enabled, but QUIC Datagrams disabled")
 	}
 	if len(conf.Versions) == 0 {
 		conf = conf.Clone()
@@ -84,7 +88,6 @@ func newClient(hostname string, tlsConf *tls.Config, opts *roundTripperOpts, con
 	if conf.MaxIncomingStreams == 0 {
 		conf.MaxIncomingStreams = -1 // don't allow any bidirectional streams
 	}
-	conf.EnableDatagrams = opts.EnableDatagram
 	logger := utils.DefaultLogger.WithPrefix("h3 client")
 
 	if tlsConf == nil {

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -50,9 +50,8 @@ type RoundTripper struct {
 	// If nil, reasonable default values will be used.
 	QuicConfig *quic.Config
 
-	// Enable support for HTTP/3 datagrams.
-	// If set to true, QuicConfig.EnableDatagram will be set.
-	// See https://datatracker.ietf.org/doc/html/rfc9297.
+	// Enable support for HTTP/3 datagrams (RFC 9297).
+	// If a QuicConfig is set, datagram support also needs to be enabled on the QUIC layer by setting EnableDatagrams.
 	EnableDatagrams bool
 
 	// Additional HTTP/3 settings.


### PR DESCRIPTION
If the user provides a quic.Config, we shouldn't modify it. Instead, we should return an error if the user enables HTTP Datagrams but fails to enable datagrams on the QUIC layer.

This isn't required by RFC 9297. If the QUIC layer disables datagrams, one could - in principe - use the Capsule protocol. However, that's probably never (?) intended by the user.