### PR TITLE
docs: improve API documentation for OpenStreamSync

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -164,7 +164,8 @@ type Connection interface {
 	// OpenStreamSync opens a new bidirectional QUIC stream.
 	// It blocks until a new stream can be opened.
 	// There is no signaling to the peer about new streams:
-	// The peer can only accept the stream after data has been sent on the stream.
+	// The peer can only accept the stream after data has been sent on the stream,
+	// or the stream has been reset or closed.
 	// If the error is non-nil, it satisfies the net.Error interface.
 	// If the connection was closed due to a timeout, Timeout() will be true.
 	OpenStreamSync(context.Context) (Stream, error)

--- a/interface.go
+++ b/interface.go
@@ -163,6 +163,8 @@ type Connection interface {
 	OpenStream() (Stream, error)
 	// OpenStreamSync opens a new bidirectional QUIC stream.
 	// It blocks until a new stream can be opened.
+	// There is no signaling to the peer about new streams:
+	// The peer can only accept the stream after data has been sent on the stream.
 	// If the error is non-nil, it satisfies the net.Error interface.
 	// If the connection was closed due to a timeout, Timeout() will be true.
 	OpenStreamSync(context.Context) (Stream, error)


### PR DESCRIPTION
Both `OpenStream` and `OpenStreamSync` themselves only create steam objects locally, but `OpenStreamSync` does not add document descriptions, which will cause ambiguity.