### PR TITLE
http3: add a RoundTripOpt to check the server's SETTINGS frame

### DIFF
--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -17,6 +17,30 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
+// Settings are HTTP/3 settings that apply to the underlying connection.
+type Settings struct {
+	// Support for HTTP/3 datagrams (RFC 9297)
+	EnableDatagram bool
+	// Extended CONNECT, RFC 9220
+	EnableExtendedConnect bool
+	// Other settings, defined by the application
+	Other map[uint64]uint64
+}
+
+// RoundTripOpt are options for the Transport.RoundTripOpt method.
+type RoundTripOpt struct {
+	// OnlyCachedConn controls whether the RoundTripper may create a new QUIC connection.
+	// If set true and no cached connection is available, RoundTripOpt will return ErrNoCachedConn.
+	OnlyCachedConn bool
+	// DontCloseRequestStream controls whether the request stream is closed after sending the request.
+	// If set, context cancellations have no effect after the response headers are received.
+	DontCloseRequestStream bool
+	// CheckSettings is run before the request is sent to the server.
+	// If not yet received, it blocks until the server's SETTINGS frame is received.
+	// If an error is returned, the request won't be sent to the server, and the error is returned.
+	CheckSettings func(Settings) error
+}
+
 type roundTripCloser interface {
 	RoundTripOpt(*http.Request, RoundTripOpt) (*http.Response, error)
 	HandshakeComplete() bool
@@ -86,16 +110,6 @@ type RoundTripper struct {
 	newClient func(hostname string, tlsConf *tls.Config, opts *roundTripperOpts, conf *quic.Config, dialer dialFunc) (roundTripCloser, error) // so we can mock it in tests
 	clients   map[string]*roundTripCloserWithCount
 	transport *quic.Transport
-}
-
-// RoundTripOpt are options for the Transport.RoundTripOpt method.
-type RoundTripOpt struct {
-	// OnlyCachedConn controls whether the RoundTripper may create a new QUIC connection.
-	// If set true and no cached connection is available, RoundTripOpt will return ErrNoCachedConn.
-	OnlyCachedConn bool
-	// DontCloseRequestStream controls whether the request stream is closed after sending the request.
-	// If set, context cancellations have no effect after the response headers are received.
-	DontCloseRequestStream bool
 }
 
 var (

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -559,4 +559,17 @@ var _ = Describe("HTTP tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(200))
 	})
+
+	It("checks the server's settings", func() {
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/hello", port), nil)
+		Expect(err).ToNot(HaveOccurred())
+		testErr := errors.New("test error")
+		_, err = rt.RoundTripOpt(req, http3.RoundTripOpt{CheckSettings: func(settings http3.Settings) error {
+			Expect(settings.EnableExtendedConnect).To(BeTrue())
+			Expect(settings.EnableDatagram).To(BeFalse())
+			Expect(settings.Other).To(BeEmpty())
+			return testErr
+		}})
+		Expect(err).To(MatchError(err))
+	})
 })


### PR DESCRIPTION
Fixes #4160. Needed for #3522 and https://github.com/quic-go/webtransport-go/issues/106.

For some requests, the client is required to check the server's HTTP/3 SETTINGS. For example, a client is only allowed to send HTTP/3 datagrams if the server explicitly enabled support.

SETTINGS are sent asynchronously on a control stream (usually the first unidirectional stream). This means that the SETTINGS might not be available at the beginning of the connection. This is not expected to be the common case, since the server can send the SETTINGS in 0.5-RTT data, but we have to be able to deal with arbitrary delays.

For WebTransport, there are even more SETTINGS values that the client needs to check. By making CheckSettings a callback on the RoundTripOpt, this entire validation logic can live at the WebTransport layer.