### PR TITLE
quicvarint: use int instead of internal protocol.ByteCount type

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,11 +5,21 @@ linters-settings:
   misspell:
     ignore-words:
       - ect
+  depguard:
+    rules:
+      quicvarint:
+        list-mode: strict
+        files:
+          - "**/github.com/quic-go/quic-go/quicvarint/*"
+          - "!$test"
+        allow:
+          - $gostd
 
 linters:
   disable-all: true
   enable:
     - asciicheck
+    - depguard
     - exhaustive
     - exportloopref
     - goimports

--- a/framer.go
+++ b/framer.go
@@ -137,7 +137,7 @@ func (f *framerI) AppendStreamFrames(frames []ackhandler.StreamFrame, maxLen pro
 		// For the last STREAM frame, we'll remove the DataLen field later.
 		// Therefore, we can pretend to have more bytes available when popping
 		// the STREAM frame (which will always have the DataLen set).
-		remainingLen += quicvarint.Len(uint64(remainingLen))
+		remainingLen += protocol.ByteCount(quicvarint.Len(uint64(remainingLen)))
 		frame, ok, hasMoreData := str.popStreamFrame(remainingLen, v)
 		if hasMoreData { // put the stream back in the queue (at the end)
 			f.streamQueue.PushBack(id)

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
 )
 
@@ -160,7 +159,7 @@ func parseSettingsFrame(r io.Reader, l uint64) (*settingsFrame, error) {
 
 func (f *settingsFrame) Append(b []byte) []byte {
 	b = quicvarint.Append(b, 0x4)
-	var l protocol.ByteCount
+	var l int
 	for id, val := range f.Other {
 		l += quicvarint.Len(id) + quicvarint.Len(val)
 	}

--- a/internal/wire/ack_frame.go
+++ b/internal/wire/ack_frame.go
@@ -163,7 +163,7 @@ func (f *AckFrame) Length(_ protocol.Version) protocol.ByteCount {
 		length += quicvarint.Len(f.ECT1)
 		length += quicvarint.Len(f.ECNCE)
 	}
-	return length
+	return protocol.ByteCount(length)
 }
 
 // gets the number of ACK ranges that can be encoded
@@ -174,7 +174,7 @@ func (f *AckFrame) numEncodableAckRanges() int {
 	for i := 1; i < len(f.AckRanges); i++ {
 		gap, len := f.encodeAckRange(i)
 		rangeLen := quicvarint.Len(gap) + quicvarint.Len(len)
-		if length+rangeLen > protocol.MaxAckFrameSize {
+		if protocol.ByteCount(length+rangeLen) > protocol.MaxAckFrameSize {
 			// Writing range i would exceed the MaxAckFrameSize.
 			// So encode one range less than that.
 			return i - 1

--- a/internal/wire/connection_close_frame.go
+++ b/internal/wire/connection_close_frame.go
@@ -54,9 +54,9 @@ func parseConnectionCloseFrame(r *bytes.Reader, typ uint64, _ protocol.Version) 
 
 // Length of a written frame
 func (f *ConnectionCloseFrame) Length(protocol.Version) protocol.ByteCount {
-	length := 1 + quicvarint.Len(f.ErrorCode) + quicvarint.Len(uint64(len(f.ReasonPhrase))) + protocol.ByteCount(len(f.ReasonPhrase))
+	length := 1 + protocol.ByteCount(quicvarint.Len(f.ErrorCode)+quicvarint.Len(uint64(len(f.ReasonPhrase)))) + protocol.ByteCount(len(f.ReasonPhrase))
 	if !f.IsApplicationError {
-		length += quicvarint.Len(f.FrameType) // for the frame type
+		length += protocol.ByteCount(quicvarint.Len(f.FrameType)) // for the frame type
 	}
 	return length
 }

--- a/internal/wire/crypto_frame.go
+++ b/internal/wire/crypto_frame.go
@@ -48,14 +48,14 @@ func (f *CryptoFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {
 
 // Length of a written frame
 func (f *CryptoFrame) Length(_ protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(uint64(f.Offset)) + quicvarint.Len(uint64(len(f.Data))) + protocol.ByteCount(len(f.Data))
+	return protocol.ByteCount(1 + quicvarint.Len(uint64(f.Offset)) + quicvarint.Len(uint64(len(f.Data))) + len(f.Data))
 }
 
 // MaxDataLen returns the maximum data length
 func (f *CryptoFrame) MaxDataLen(maxSize protocol.ByteCount) protocol.ByteCount {
 	// pretend that the data size will be 1 bytes
 	// if it turns out that varint encoding the length will consume 2 bytes, we need to adjust the data length afterwards
-	headerLen := 1 + quicvarint.Len(uint64(f.Offset)) + 1
+	headerLen := protocol.ByteCount(1 + quicvarint.Len(uint64(f.Offset)) + 1)
 	if headerLen > maxSize {
 		return 0
 	}

--- a/internal/wire/crypto_frame_test.go
+++ b/internal/wire/crypto_frame_test.go
@@ -97,7 +97,7 @@ var _ = Describe("CRYPTO frame", func() {
 				Offset: 0x1337,
 				Data:   []byte("foobar"),
 			}
-			Expect(f.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(0x1337) + quicvarint.Len(6) + 6))
+			Expect(f.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(0x1337) + quicvarint.Len(6) + 6))
 		})
 	})
 

--- a/internal/wire/data_blocked_frame.go
+++ b/internal/wire/data_blocked_frame.go
@@ -27,5 +27,5 @@ func (f *DataBlockedFrame) Append(b []byte, version protocol.Version) ([]byte, e
 
 // Length of a written frame
 func (f *DataBlockedFrame) Length(version protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(uint64(f.MaximumData))
+	return 1 + protocol.ByteCount(quicvarint.Len(uint64(f.MaximumData)))
 }

--- a/internal/wire/data_blocked_frame_test.go
+++ b/internal/wire/data_blocked_frame_test.go
@@ -45,7 +45,7 @@ var _ = Describe("DATA_BLOCKED frame", func() {
 
 		It("has the correct min length", func() {
 			frame := DataBlockedFrame{MaximumData: 0x12345}
-			Expect(frame.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(0x12345)))
+			Expect(frame.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(0x12345)))
 		})
 	})
 })

--- a/internal/wire/datagram_frame.go
+++ b/internal/wire/datagram_frame.go
@@ -80,7 +80,7 @@ func (f *DatagramFrame) MaxDataLen(maxSize protocol.ByteCount, version protocol.
 func (f *DatagramFrame) Length(_ protocol.Version) protocol.ByteCount {
 	length := 1 + protocol.ByteCount(len(f.Data))
 	if f.DataLenPresent {
-		length += quicvarint.Len(uint64(len(f.Data)))
+		length += protocol.ByteCount(quicvarint.Len(uint64(len(f.Data))))
 	}
 	return length
 }

--- a/internal/wire/datagram_frame_test.go
+++ b/internal/wire/datagram_frame_test.go
@@ -85,7 +85,7 @@ var _ = Describe("STREAM frame", func() {
 				DataLenPresent: true,
 				Data:           []byte("foobar"),
 			}
-			Expect(f.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(6) + 6))
+			Expect(f.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(6) + 6))
 		})
 
 		It("has the right length for a frame without length", func() {

--- a/internal/wire/extended_header.go
+++ b/internal/wire/extended_header.go
@@ -165,7 +165,7 @@ func (h *ExtendedHeader) ParsedLen() protocol.ByteCount {
 func (h *ExtendedHeader) GetLength(_ protocol.Version) protocol.ByteCount {
 	length := 1 /* type byte */ + 4 /* version */ + 1 /* dest conn ID len */ + protocol.ByteCount(h.DestConnectionID.Len()) + 1 /* src conn ID len */ + protocol.ByteCount(h.SrcConnectionID.Len()) + protocol.ByteCount(h.PacketNumberLen) + 2 /* length */
 	if h.Type == protocol.PacketTypeInitial {
-		length += quicvarint.Len(uint64(len(h.Token))) + protocol.ByteCount(len(h.Token))
+		length += protocol.ByteCount(quicvarint.Len(uint64(len(h.Token))) + len(h.Token))
 	}
 	return length
 }

--- a/internal/wire/max_data_frame.go
+++ b/internal/wire/max_data_frame.go
@@ -31,5 +31,5 @@ func (f *MaxDataFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {
 
 // Length of a written frame
 func (f *MaxDataFrame) Length(_ protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(uint64(f.MaximumData))
+	return 1 + protocol.ByteCount(quicvarint.Len(uint64(f.MaximumData)))
 }

--- a/internal/wire/max_data_frame_test.go
+++ b/internal/wire/max_data_frame_test.go
@@ -38,7 +38,7 @@ var _ = Describe("MAX_DATA frame", func() {
 			f := &MaxDataFrame{
 				MaximumData: 0xdeadbeef,
 			}
-			Expect(f.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(0xdeadbeef)))
+			Expect(f.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(0xdeadbeef)))
 		})
 
 		It("writes a MAX_DATA frame", func() {

--- a/internal/wire/max_stream_data_frame.go
+++ b/internal/wire/max_stream_data_frame.go
@@ -29,7 +29,7 @@ func parseMaxStreamDataFrame(r *bytes.Reader, _ protocol.Version) (*MaxStreamDat
 	}, nil
 }
 
-func (f *MaxStreamDataFrame) Append(b []byte, version protocol.Version) ([]byte, error) {
+func (f *MaxStreamDataFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {
 	b = append(b, maxStreamDataFrameType)
 	b = quicvarint.Append(b, uint64(f.StreamID))
 	b = quicvarint.Append(b, uint64(f.MaximumStreamData))
@@ -37,6 +37,6 @@ func (f *MaxStreamDataFrame) Append(b []byte, version protocol.Version) ([]byte,
 }
 
 // Length of a written frame
-func (f *MaxStreamDataFrame) Length(version protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.MaximumStreamData))
+func (f *MaxStreamDataFrame) Length(protocol.Version) protocol.ByteCount {
+	return 1 + protocol.ByteCount(quicvarint.Len(uint64(f.StreamID))+quicvarint.Len(uint64(f.MaximumStreamData)))
 }

--- a/internal/wire/max_stream_data_frame_test.go
+++ b/internal/wire/max_stream_data_frame_test.go
@@ -43,7 +43,7 @@ var _ = Describe("MAX_STREAM_DATA frame", func() {
 				StreamID:          0x1337,
 				MaximumStreamData: 0xdeadbeef,
 			}
-			Expect(f.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.MaximumStreamData))))
+			Expect(f.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.MaximumStreamData))))
 		})
 
 		It("writes a sample frame", func() {

--- a/internal/wire/max_streams_frame.go
+++ b/internal/wire/max_streams_frame.go
@@ -46,5 +46,5 @@ func (f *MaxStreamsFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {
 
 // Length of a written frame
 func (f *MaxStreamsFrame) Length(protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(uint64(f.MaxStreamNum))
+	return 1 + protocol.ByteCount(quicvarint.Len(uint64(f.MaxStreamNum)))
 }

--- a/internal/wire/max_streams_frame_test.go
+++ b/internal/wire/max_streams_frame_test.go
@@ -106,7 +106,7 @@ var _ = Describe("MAX_STREAMS frame", func() {
 
 		It("has the correct length", func() {
 			frame := MaxStreamsFrame{MaxStreamNum: 0x1337}
-			Expect(frame.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(0x1337)))
+			Expect(frame.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(0x1337)))
 		})
 	})
 })

--- a/internal/wire/new_connection_id_frame.go
+++ b/internal/wire/new_connection_id_frame.go
@@ -73,5 +73,5 @@ func (f *NewConnectionIDFrame) Append(b []byte, _ protocol.Version) ([]byte, err
 
 // Length of a written frame
 func (f *NewConnectionIDFrame) Length(protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(f.SequenceNumber) + quicvarint.Len(f.RetirePriorTo) + 1 /* connection ID length */ + protocol.ByteCount(f.ConnectionID.Len()) + 16
+	return 1 + protocol.ByteCount(quicvarint.Len(f.SequenceNumber)+quicvarint.Len(f.RetirePriorTo)+1 /* connection ID length */ +f.ConnectionID.Len()) + 16
 }

--- a/internal/wire/new_token_frame.go
+++ b/internal/wire/new_token_frame.go
@@ -41,5 +41,5 @@ func (f *NewTokenFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {
 
 // Length of a written frame
 func (f *NewTokenFrame) Length(protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(uint64(len(f.Token))) + protocol.ByteCount(len(f.Token))
+	return 1 + protocol.ByteCount(quicvarint.Len(uint64(len(f.Token)))+len(f.Token))
 }

--- a/internal/wire/new_token_frame_test.go
+++ b/internal/wire/new_token_frame_test.go
@@ -59,7 +59,7 @@ var _ = Describe("NEW_TOKEN frame", func() {
 
 		It("has the correct min length", func() {
 			frame := &NewTokenFrame{Token: []byte("foobar")}
-			Expect(frame.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(6) + 6))
+			Expect(frame.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(6) + 6))
 		})
 	})
 })

--- a/internal/wire/reset_stream_frame.go
+++ b/internal/wire/reset_stream_frame.go
@@ -49,6 +49,6 @@ func (f *ResetStreamFrame) Append(b []byte, _ protocol.Version) ([]byte, error) 
 }
 
 // Length of a written frame
-func (f *ResetStreamFrame) Length(version protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.ErrorCode)) + quicvarint.Len(uint64(f.FinalSize))
+func (f *ResetStreamFrame) Length(protocol.Version) protocol.ByteCount {
+	return 1 + protocol.ByteCount(quicvarint.Len(uint64(f.StreamID))+quicvarint.Len(uint64(f.ErrorCode))+quicvarint.Len(uint64(f.FinalSize)))
 }

--- a/internal/wire/reset_stream_frame_test.go
+++ b/internal/wire/reset_stream_frame_test.go
@@ -61,7 +61,7 @@ var _ = Describe("RESET_STREAM frame", func() {
 				ErrorCode: 0xde,
 			}
 			expectedLen := 1 + quicvarint.Len(0x1337) + quicvarint.Len(0x1234567) + 2
-			Expect(rst.Length(protocol.Version1)).To(Equal(expectedLen))
+			Expect(rst.Length(protocol.Version1)).To(BeEquivalentTo(expectedLen))
 		})
 	})
 })

--- a/internal/wire/retire_connection_id_frame.go
+++ b/internal/wire/retire_connection_id_frame.go
@@ -28,5 +28,5 @@ func (f *RetireConnectionIDFrame) Append(b []byte, _ protocol.Version) ([]byte, 
 
 // Length of a written frame
 func (f *RetireConnectionIDFrame) Length(protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(f.SequenceNumber)
+	return 1 + protocol.ByteCount(quicvarint.Len(f.SequenceNumber))
 }

--- a/internal/wire/stop_sending_frame.go
+++ b/internal/wire/stop_sending_frame.go
@@ -33,7 +33,7 @@ func parseStopSendingFrame(r *bytes.Reader, _ protocol.Version) (*StopSendingFra
 
 // Length of a written frame
 func (f *StopSendingFrame) Length(_ protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.ErrorCode))
+	return 1 + protocol.ByteCount(quicvarint.Len(uint64(f.StreamID))+quicvarint.Len(uint64(f.ErrorCode)))
 }
 
 func (f *StopSendingFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/stop_sending_frame_test.go
+++ b/internal/wire/stop_sending_frame_test.go
@@ -57,7 +57,7 @@ var _ = Describe("STOP_SENDING frame", func() {
 				StreamID:  0xdeadbeef,
 				ErrorCode: 0x1234567,
 			}
-			Expect(frame.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(0xdeadbeef) + quicvarint.Len(0x1234567)))
+			Expect(frame.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(0xdeadbeef) + quicvarint.Len(0x1234567)))
 		})
 	})
 })

--- a/internal/wire/stream_data_blocked_frame.go
+++ b/internal/wire/stream_data_blocked_frame.go
@@ -37,6 +37,6 @@ func (f *StreamDataBlockedFrame) Append(b []byte, _ protocol.Version) ([]byte, e
 }
 
 // Length of a written frame
-func (f *StreamDataBlockedFrame) Length(version protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(uint64(f.StreamID)) + quicvarint.Len(uint64(f.MaximumStreamData))
+func (f *StreamDataBlockedFrame) Length(protocol.Version) protocol.ByteCount {
+	return 1 + protocol.ByteCount(quicvarint.Len(uint64(f.StreamID))+quicvarint.Len(uint64(f.MaximumStreamData)))
 }

--- a/internal/wire/stream_data_blocked_frame_test.go
+++ b/internal/wire/stream_data_blocked_frame_test.go
@@ -42,7 +42,7 @@ var _ = Describe("STREAM_DATA_BLOCKED frame", func() {
 				StreamID:          0x1337,
 				MaximumStreamData: 0xdeadbeef,
 			}
-			Expect(f.Length(0)).To(Equal(1 + quicvarint.Len(0x1337) + quicvarint.Len(0xdeadbeef)))
+			Expect(f.Length(0)).To(BeEquivalentTo(1 + quicvarint.Len(0x1337) + quicvarint.Len(0xdeadbeef)))
 		})
 
 		It("writes a sample frame", func() {

--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -108,7 +108,7 @@ func (f *StreamFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {
 }
 
 // Length returns the total length of the STREAM frame
-func (f *StreamFrame) Length(version protocol.Version) protocol.ByteCount {
+func (f *StreamFrame) Length(protocol.Version) protocol.ByteCount {
 	length := 1 + quicvarint.Len(uint64(f.StreamID))
 	if f.Offset != 0 {
 		length += quicvarint.Len(uint64(f.Offset))
@@ -116,7 +116,7 @@ func (f *StreamFrame) Length(version protocol.Version) protocol.ByteCount {
 	if f.DataLenPresent {
 		length += quicvarint.Len(uint64(f.DataLen()))
 	}
-	return length + f.DataLen()
+	return protocol.ByteCount(length) + f.DataLen()
 }
 
 // DataLen gives the length of data in bytes
@@ -126,14 +126,14 @@ func (f *StreamFrame) DataLen() protocol.ByteCount {
 
 // MaxDataLen returns the maximum data length
 // If 0 is returned, writing will fail (a STREAM frame must contain at least 1 byte of data).
-func (f *StreamFrame) MaxDataLen(maxSize protocol.ByteCount, version protocol.Version) protocol.ByteCount {
-	headerLen := 1 + quicvarint.Len(uint64(f.StreamID))
+func (f *StreamFrame) MaxDataLen(maxSize protocol.ByteCount, _ protocol.Version) protocol.ByteCount {
+	headerLen := 1 + protocol.ByteCount(quicvarint.Len(uint64(f.StreamID)))
 	if f.Offset != 0 {
-		headerLen += quicvarint.Len(uint64(f.Offset))
+		headerLen += protocol.ByteCount(quicvarint.Len(uint64(f.Offset)))
 	}
 	if f.DataLenPresent {
-		// pretend that the data size will be 1 bytes
-		// if it turns out that varint encoding the length will consume 2 bytes, we need to adjust the data length afterwards
+		// Pretend that the data size will be 1 byte.
+		// If it turns out that varint encoding the length will consume 2 bytes, we need to adjust the data length afterward
 		headerLen++
 	}
 	if headerLen > maxSize {

--- a/internal/wire/stream_frame_test.go
+++ b/internal/wire/stream_frame_test.go
@@ -222,7 +222,7 @@ var _ = Describe("STREAM frame", func() {
 				StreamID: 0x1337,
 				Data:     []byte("foobar"),
 			}
-			Expect(f.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(0x1337) + 6))
+			Expect(f.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(0x1337) + 6))
 		})
 
 		It("has the right length for a frame with offset", func() {
@@ -231,7 +231,7 @@ var _ = Describe("STREAM frame", func() {
 				Offset:   0x42,
 				Data:     []byte("foobar"),
 			}
-			Expect(f.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(0x1337) + quicvarint.Len(0x42) + 6))
+			Expect(f.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(0x1337) + quicvarint.Len(0x42) + 6))
 		})
 
 		It("has the right length for a frame with data length", func() {
@@ -241,7 +241,7 @@ var _ = Describe("STREAM frame", func() {
 				DataLenPresent: true,
 				Data:           []byte("foobar"),
 			}
-			Expect(f.Length(protocol.Version1)).To(Equal(1 + quicvarint.Len(0x1337) + quicvarint.Len(0x1234567) + quicvarint.Len(6) + 6))
+			Expect(f.Length(protocol.Version1)).To(BeEquivalentTo(1 + quicvarint.Len(0x1337) + quicvarint.Len(0x1234567) + quicvarint.Len(6) + 6))
 		})
 	})
 

--- a/internal/wire/streams_blocked_frame.go
+++ b/internal/wire/streams_blocked_frame.go
@@ -46,5 +46,5 @@ func (f *StreamsBlockedFrame) Append(b []byte, _ protocol.Version) ([]byte, erro
 
 // Length of a written frame
 func (f *StreamsBlockedFrame) Length(_ protocol.Version) protocol.ByteCount {
-	return 1 + quicvarint.Len(uint64(f.StreamLimit))
+	return 1 + protocol.ByteCount(quicvarint.Len(uint64(f.StreamLimit)))
 }

--- a/internal/wire/streams_blocked_frame_test.go
+++ b/internal/wire/streams_blocked_frame_test.go
@@ -106,7 +106,7 @@ var _ = Describe("STREAMS_BLOCKED frame", func() {
 
 		It("has the correct min length", func() {
 			frame := StreamsBlockedFrame{StreamLimit: 0x123456}
-			Expect(frame.Length(0)).To(Equal(protocol.ByteCount(1) + quicvarint.Len(0x123456)))
+			Expect(frame.Length(0)).To(Equal(1 + protocol.ByteCount(quicvarint.Len(0x123456))))
 		})
 	})
 })

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -3,8 +3,6 @@ package quicvarint
 import (
 	"fmt"
 	"io"
-
-	"github.com/quic-go/quic-go/internal/protocol"
 )
 
 // taken from the QUIC draft
@@ -91,7 +89,7 @@ func Append(b []byte, i uint64) []byte {
 }
 
 // AppendWithLen append i in the QUIC varint format with the desired length.
-func AppendWithLen(b []byte, i uint64, length protocol.ByteCount) []byte {
+func AppendWithLen(b []byte, i uint64, length int) []byte {
 	if length != 1 && length != 2 && length != 4 && length != 8 {
 		panic("invalid varint length")
 	}
@@ -109,17 +107,17 @@ func AppendWithLen(b []byte, i uint64, length protocol.ByteCount) []byte {
 	} else if length == 8 {
 		b = append(b, 0b11000000)
 	}
-	for j := protocol.ByteCount(1); j < length-l; j++ {
+	for j := 1; j < length-l; j++ {
 		b = append(b, 0)
 	}
-	for j := protocol.ByteCount(0); j < l; j++ {
+	for j := 0; j < l; j++ {
 		b = append(b, uint8(i>>(8*(l-1-j))))
 	}
 	return b
 }
 
 // Len determines the number of bytes that will be needed to write the number i.
-func Len(i uint64) protocol.ByteCount {
+func Len(i uint64) int {
 	if i <= maxVarInt1 {
 		return 1
 	}


### PR DESCRIPTION
Not sure if `int` or `uint64` would be better here.