### PR TITLE
close connection when an abnormally large number of frames are queued

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -521,6 +521,9 @@ func (s *connection) run() error {
 
 runLoop:
 	for {
+		if s.framer.QueuedTooManyControlFrames() {
+			s.closeLocal(&qerr.TransportError{ErrorCode: InternalError})
+		}
 		// Close immediately if requested
 		select {
 		case closeErr = <-s.closeChan:


### PR DESCRIPTION
Under normal circumstances, we should be able to send out control frames right away, so we don't expect any queue to build up. To defend against resource exhaustion attacks, we limit the control frame queue to 16k elements.