### PR TITLE
http3: don't modify any fields of the http.Request when doing 0-RTT

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -305,8 +305,14 @@ func (c *client) roundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Respon
 	// Immediately send out this request, if this is a 0-RTT request.
 	switch req.Method {
 	case MethodGet0RTT:
+		// don't modify the original request
+		reqCopy := *req
+		req = &reqCopy
 		req.Method = http.MethodGet
 	case MethodHead0RTT:
+		// don't modify the original request
+		reqCopy := *req
+		req = &reqCopy
 		req.Method = http.MethodHead
 	default:
 		// wait for the handshake to complete

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -824,6 +824,8 @@ var _ = Describe("Client", func() {
 				_, err := cl.RoundTripOpt(req, RoundTripOpt{})
 				Expect(err).To(MatchError(testErr))
 				Expect(decodeHeader(buf)).To(HaveKeyWithValue(":method", serialized))
+				// make sure the request wasn't modified
+				Expect(req.Method).To(Equal(method))
 			},
 			Entry("GET", MethodGet0RTT, http.MethodGet),
 			Entry("HEAD", MethodHead0RTT, http.MethodHead),


### PR DESCRIPTION
Depends on #4378.