### PR TITLE
http3: rename Server.QuicConfig to Server.QUICConfig

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -168,7 +168,7 @@ func main() {
 				server := http3.Server{
 					Handler: handler,
 					Addr:    bCap,
-					QuicConfig: &quic.Config{
+					QUICConfig: &quic.Config{
 						Tracer: qlog.DefaultTracer,
 					},
 				}

--- a/http3/server.go
+++ b/http3/server.go
@@ -172,19 +172,18 @@ type Server struct {
 	// set for ListenAndServe and Serve methods.
 	TLSConfig *tls.Config
 
-	// QuicConfig provides the parameters for QUIC connection created with
-	// Serve. If nil, it uses reasonable default values.
+	// QUICConfig provides the parameters for QUIC connection created with Serve.
+	// If nil, it uses reasonable default values.
 	//
-	// Configured versions are also used in Alt-Svc response header set with
-	// SetQUICHeaders.
-	QuicConfig *quic.Config
+	// Configured versions are also used in Alt-Svc response header set with SetQUICHeaders.
+	QUICConfig *quic.Config
 
 	// Handler is the HTTP request handler to use. If not set, defaults to
 	// http.NotFound.
 	Handler http.Handler
 
 	// EnableDatagrams enables support for HTTP/3 datagrams.
-	// If set to true, QuicConfig.EnableDatagram will be set.
+	// If set to true, QUICConfig.EnableDatagram will be set.
 	// See https://datatracker.ietf.org/doc/html/rfc9297.
 	EnableDatagrams bool
 
@@ -311,11 +310,11 @@ func (s *Server) serveConn(tlsConf *tls.Config, conn net.PacketConn) error {
 	}
 
 	baseConf := ConfigureTLSConfig(tlsConf)
-	quicConf := s.QuicConfig
+	quicConf := s.QUICConfig
 	if quicConf == nil {
 		quicConf = &quic.Config{Allow0RTT: true}
 	} else {
-		quicConf = s.QuicConfig.Clone()
+		quicConf = s.QUICConfig.Clone()
 	}
 	if s.EnableDatagrams {
 		quicConf.EnableDatagrams = true
@@ -360,8 +359,8 @@ func (s *Server) generateAltSvcHeader() {
 
 	// This code assumes that we will use protocol.SupportedVersions if no quic.Config is passed.
 	supportedVersions := protocol.SupportedVersions
-	if s.QuicConfig != nil && len(s.QuicConfig.Versions) > 0 {
-		supportedVersions = s.QuicConfig.Versions
+	if s.QUICConfig != nil && len(s.QUICConfig.Versions) > 0 {
+		supportedVersions = s.QUICConfig.Versions
 	}
 
 	// keep track of which have been seen so we don't yield duplicate values

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -884,7 +884,7 @@ var _ = Describe("Server", func() {
 
 	Context("setting http headers", func() {
 		BeforeEach(func() {
-			s.QuicConfig = &quic.Config{Versions: []protocol.Version{protocol.Version1}}
+			s.QUICConfig = &quic.Config{Versions: []protocol.Version{protocol.Version1}}
 		})
 
 		var ln1 QUICEarlyListener
@@ -945,7 +945,7 @@ var _ = Describe("Server", func() {
 		})
 
 		It("works if the quic.Config sets QUIC versions", func() {
-			s.QuicConfig.Versions = []quic.Version{quic.Version1, quic.Version2}
+			s.QUICConfig.Versions = []quic.Version{quic.Version1, quic.Version2}
 			addListener(":443", &ln1)
 			checkSetHeaders(Equal(http.Header{"Alt-Svc": {`h3=":443"; ma=2592000`}}))
 			removeListener(&ln1)
@@ -984,7 +984,7 @@ var _ = Describe("Server", func() {
 		})
 
 		It("doesn't duplicate Alt-Svc values", func() {
-			s.QuicConfig.Versions = []quic.Version{quic.Version1, quic.Version1}
+			s.QUICConfig.Versions = []quic.Version{quic.Version1, quic.Version1}
 			addListener(":443", &ln1)
 			checkSetHeaders(Equal(http.Header{"Alt-Svc": {`h3=":443"; ma=2592000`}}))
 			removeListener(&ln1)
@@ -1314,7 +1314,7 @@ var _ = Describe("Server", func() {
 				receivedConf = config
 				return nil, errors.New("listen err")
 			}
-			s.QuicConfig = conf
+			s.QUICConfig = conf
 			Expect(s.ListenAndServe()).To(HaveOccurred())
 			Expect(receivedConf).To(Equal(conf))
 		})

--- a/integrationtests/self/hotswap_test.go
+++ b/integrationtests/self/hotswap_test.go
@@ -87,11 +87,11 @@ var _ = Describe("HTTP3 Server hotswap test", func() {
 
 		server1 = &http3.Server{
 			Handler:    mux1,
-			QuicConfig: getQuicConfig(nil),
+			QUICConfig: getQuicConfig(nil),
 		}
 		server2 = &http3.Server{
 			Handler:    mux2,
-			QuicConfig: getQuicConfig(nil),
+			QUICConfig: getQuicConfig(nil),
 		}
 
 		tlsConf := http3.ConfigureTLSConfig(getTLSConfig())

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -89,7 +89,7 @@ var _ = Describe("HTTP tests", func() {
 		server = &http3.Server{
 			Handler:    mux,
 			TLSConfig:  getTLSConfig(),
-			QuicConfig: getQuicConfig(&quic.Config{Allow0RTT: true}),
+			QUICConfig: getQuicConfig(&quic.Config{Allow0RTT: true}),
 		}
 
 		addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:0")

--- a/interop/server/main.go
+++ b/interop/server/main.go
@@ -87,7 +87,7 @@ func runHTTP3Server(quicConf *quic.Config) error {
 	server := http3.Server{
 		Addr:       ":443",
 		TLSConfig:  tlsConf,
-		QuicConfig: quicConf,
+		QUICConfig: quicConf,
 	}
 	http.DefaultServeMux.Handle("/", http.FileServer(http.Dir("/www")))
 	return server.ListenAndServe()


### PR DESCRIPTION
This will cause a moderate amount of annoyance to users of the library, but it has to be done sometime.