### PR TITLE
http3: support HTTP CONNECT and CONNECT-UDP (masque) protocols

### DIFF
--- a/http3/body.go
+++ b/http3/body.go
@@ -15,6 +15,7 @@ import (
 // When a stream is taken over, it's the caller's responsibility to close the stream.
 type HTTPStreamer interface {
 	HTTPStream() Stream
+	HTTPConnection() quic.Connection
 }
 
 type StreamCreator interface {
@@ -56,6 +57,10 @@ func newRequestBody(str Stream) *body {
 func (r *body) HTTPStream() Stream {
 	r.wasHijacked = true
 	return r.str
+}
+
+func (r *body) HTTPConnection() quic.Connection {
+	return nil
 }
 
 func (r *body) wasStreamHijacked() bool {
@@ -133,4 +138,8 @@ func (r *hijackableBody) Close() error {
 
 func (r *hijackableBody) HTTPStream() Stream {
 	return r.str
+}
+
+func (r *hijackableBody) HTTPConnection() quic.Connection {
+	return r.conn
 }

--- a/http3/client.go
+++ b/http3/client.go
@@ -273,7 +273,7 @@ func (c *client) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Respon
 }
 
 func (c *client) roundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
-	if authorityAddr("https", hostnameFromRequest(req)) != c.hostname {
+	if !validProxyMethod(req.Method) && authorityAddr("https", hostnameFromRequest(req)) != c.hostname {
 		return nil, fmt.Errorf("http3 client BUG: RoundTripOpt called for the wrong client (expected %s, got %s)", c.hostname, req.Host)
 	}
 
@@ -459,7 +459,7 @@ func (c *client) doRequest(req *http.Request, conn quic.EarlyConnection, str qui
 	_, hasTransferEncoding := res.Header["Transfer-Encoding"]
 	isInformational := res.StatusCode >= 100 && res.StatusCode < 200
 	isNoContent := res.StatusCode == http.StatusNoContent
-	isSuccessfulConnect := req.Method == http.MethodConnect && res.StatusCode >= 200 && res.StatusCode < 300
+	isSuccessfulConnect := validProxyMethod(req.Method) && res.StatusCode >= 200 && res.StatusCode < 300
 	if !hasTransferEncoding && !isInformational && !isNoContent && !isSuccessfulConnect {
 		res.ContentLength = -1
 		if clens, ok := res.Header["Content-Length"]; ok && len(clens) == 1 {

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -93,6 +93,10 @@ const (
 	settingExtendedConnect = 0x8
 	// HTTP Datagrams, RFC 9297
 	settingDatagram = 0x33
+	// For backwards compatibility with the draft datagram RFC
+	// https://datatracker.ietf.org/doc/draft-ietf-masque-connect-udp/03/
+	// https://datatracker.ietf.org/doc/html/draft-schinazi-masque-h3-datagram#name-http-settings-parameter
+	settingDatagramDraft03 = 0x276
 )
 
 type settingsFrame struct {
@@ -115,7 +119,7 @@ func parseSettingsFrame(r io.Reader, l uint64) (*settingsFrame, error) {
 	}
 	frame := &settingsFrame{}
 	b := bytes.NewReader(buf)
-	var readDatagram, readExtendedConnect bool
+	var readDatagram, readDatagramDraft03, readExtendedConnect bool
 	for b.Len() > 0 {
 		id, err := quicvarint.Read(b)
 		if err != nil { // should not happen. We allocated the whole frame already.
@@ -143,6 +147,15 @@ func parseSettingsFrame(r io.Reader, l uint64) (*settingsFrame, error) {
 			readDatagram = true
 			if val != 0 && val != 1 {
 				return nil, fmt.Errorf("invalid value for SETTINGS_H3_DATAGRAM: %d", val)
+			}
+			frame.Datagram = val == 1
+		case settingDatagramDraft03:
+			if readDatagramDraft03 {
+				return nil, fmt.Errorf("duplicate setting: %d", id)
+			}
+			readDatagramDraft03 = true
+			if val != 0 && val != 1 {
+				return nil, fmt.Errorf("invalid value for Draft03 SETTINGS_H3_DATAGRAM: %d", val)
 			}
 			frame.Datagram = val == 1
 		default:
@@ -173,6 +186,8 @@ func (f *settingsFrame) Append(b []byte) []byte {
 	b = quicvarint.Append(b, uint64(l))
 	if f.Datagram {
 		b = quicvarint.Append(b, settingDatagram)
+		b = quicvarint.Append(b, 1)
+		b = quicvarint.Append(b, settingDatagramDraft03)
 		b = quicvarint.Append(b, 1)
 	}
 	if f.ExtendedConnect {

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -128,12 +128,25 @@ var _ = Describe("Frames", func() {
 		})
 
 		Context("HTTP Datagrams", func() {
-			It("reads the SETTINGS_H3_DATAGRAM value", func() {
+			It("reads the rfc SETTINGS_H3_DATAGRAM value", func() {
 				settings := quicvarint.Append(nil, settingDatagram)
 				settings = quicvarint.Append(settings, 1)
 				data := quicvarint.Append(nil, 4) // type byte
 				data = quicvarint.Append(data, uint64(len(settings)))
 				data = append(data, settings...)
+				f, err := parseNextFrame(bytes.NewReader(data), nil)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(f).To(BeAssignableToTypeOf(&settingsFrame{}))
+				sf := f.(*settingsFrame)
+				Expect(sf.Datagram).To(BeTrue())
+			})
+
+			It("reads the draft03 SETTINGS_H3_DATAGRAM value", func() {
+				settingsDraft03 := quicvarint.Append(nil, settingDatagramDraft03)
+				settingsDraft03 = quicvarint.Append(settingsDraft03, 1)
+				data := quicvarint.Append(nil, 4) // type byte
+				data = quicvarint.Append(data, uint64(len(settingsDraft03)))
+				data = append(data, settingsDraft03...)
 				f, err := parseNextFrame(bytes.NewReader(data), nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(f).To(BeAssignableToTypeOf(&settingsFrame{}))

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -83,6 +84,17 @@ type RoundTripper struct {
 	// Zero means to use a default limit.
 	MaxResponseHeaderBytes int64
 
+	// Proxy specifies a function to return a proxy for a given
+	// Request. If the function returns a non-nil error, the
+	// request is aborted with the provided error.
+	//
+	// The proxy type is determined by the URL scheme. "http",
+	// "https", and "socks5" are supported. If the scheme is empty,
+	// "http" is assumed.
+	//
+	// If Proxy is nil or returns a nil *URL, no proxy is used.
+	Proxy func(*http.Request) (*url.URL, error)
+
 	newClient func(hostname string, tlsConf *tls.Config, opts *roundTripperOpts, conf *quic.Config, dialer dialFunc) (roundTripCloser, error) // so we can mock it in tests
 	clients   map[string]*roundTripCloserWithCount
 	transport *quic.Transport
@@ -112,7 +124,7 @@ func (r *RoundTripper) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.
 		closeRequestBody(req)
 		return nil, errors.New("http3: nil Request.URL")
 	}
-	if req.URL.Scheme != "https" {
+	if req.URL.Scheme != "https" && req.URL.Scheme != "masque" {
 		closeRequestBody(req)
 		return nil, fmt.Errorf("http3: unsupported protocol scheme: %s", req.URL.Scheme)
 	}
@@ -140,7 +152,20 @@ func (r *RoundTripper) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.
 		return nil, fmt.Errorf("http3: invalid method %q", req.Method)
 	}
 
-	hostname := authorityAddr("https", hostnameFromRequest(req))
+	if validProxyMethod(req.Method) {
+		opt.DontCloseRequestStream = true
+	}
+
+	hostname := ""
+	if r.Proxy != nil {
+		if proxyURI, _ := r.Proxy(req); proxyURI != nil {
+			hostname = authorityAddr("https", proxyURI.Host)
+		}
+	}
+	if hostname == "" {
+		hostname = authorityAddr("https", hostnameFromRequest(req))
+	}
+
 	cl, isReused, err := r.getClient(hostname, opt.OnlyCachedConn)
 	if err != nil {
 		return nil, err
@@ -254,6 +279,10 @@ func closeRequestBody(req *http.Request) {
 	if req.Body != nil {
 		req.Body.Close()
 	}
+}
+
+func validProxyMethod(method string) bool {
+	return method == http.MethodConnect || method == "CONNECT-UDP"
 }
 
 func validMethod(method string) bool {


### PR DESCRIPTION
We'd like to propose these changes in order for us to support client http3 CONNECT and CONNECT-UDP.

We've rolled up a few changes into this single PR:
- Adding a `Proxy` method to the http3.RoundTripper
- Allowing access to the underlying `quic.Connection` from a `hijackableBody`
- Some slight adjustments to the handling of methods in the http3 `Client`/`RoundTripper`
- Adding support for the draft03 version of RFC 9297
  - We think this is a reasonable approach, in particular since it's the behavior of [quiche](https://github.com/cloudflare/quiche/blob/e71c51b8cd9aa3b78749fa7cb82f35699d23e7bf/quiche/src/h3/frame.rs#L243-L247) and [h2o](https://github.com/h2o/h2o/blob/7545f5fe55ccdc9a12bdeb246b5d7110f8bee225/lib/http3/common.c#L1145-L1150)

We're currently using quic-go along with these changes for our implementation of a MASQUE proxy client: https://github.com/Invisv-Privacy/masque/pull/4

I'm aware that we've not had any previous interaction w/ y'all so we're *very* open to any/all feedback/changes/etc.

I think that this would address the client sides of https://github.com/quic-go/quic-go/issues/3370 and https://github.com/quic-go/quic-go/issues/3543
