### PR TITLE
http3: expose an OpenStream method on the RoundTripper

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -171,9 +171,9 @@ func requestFromHeaders(headerFields []qpack.HeaderField) (*http.Request, error)
 	}, nil
 }
 
-func hostnameFromRequest(req *http.Request) string {
-	if req.URL != nil {
-		return req.URL.Host
+func hostnameFromURL(url *url.URL) string {
+	if url != nil {
+		return url.Host
 	}
 	return ""
 }

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -293,21 +293,12 @@ var _ = Describe("Request", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("uses req.URL.Host", func() {
-			req := &http.Request{URL: url}
-			Expect(hostnameFromRequest(req)).To(Equal("quic.clemente.io:1337"))
-		})
-
-		It("uses req.URL.Host even if req.Host is available", func() {
-			req := &http.Request{
-				Host: "www.example.org",
-				URL:  url,
-			}
-			Expect(hostnameFromRequest(req)).To(Equal("quic.clemente.io:1337"))
+		It("uses URL.Host", func() {
+			Expect(hostnameFromURL(url)).To(Equal("quic.clemente.io:1337"))
 		})
 
 		It("returns an empty hostname if nothing is set", func() {
-			Expect(hostnameFromRequest(&http.Request{})).To(BeEmpty())
+			Expect(hostnameFromURL(nil)).To(BeEmpty())
 		})
 	})
 })

--- a/http3/http_stream.go
+++ b/http3/http_stream.go
@@ -3,32 +3,52 @@ package http3
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
 
 	"github.com/quic-go/quic-go"
+
+	"github.com/quic-go/qpack"
 )
 
-// A Stream is a HTTP/3 stream.
+// A Stream is an HTTP/3 request stream.
 // When writing to and reading from the stream, data is framed in HTTP/3 DATA frames.
-type Stream quic.Stream
+type Stream = quic.Stream
 
-// The stream conforms to the quic.Stream interface, but instead of writing to and reading directly
-// from the QUIC stream, it writes to and reads from the HTTP stream.
-type stream struct {
+// A RequestStream is an HTTP/3 request stream.
+// When writing to and reading from the stream, data is framed in HTTP/3 DATA frames.
+type RequestStream interface {
 	quic.Stream
 
-	buf []byte
+	// SendRequestHeader sends the HTTP request.
+	// It is invalid to call it more than once.
+	// It is invalid to call it after Write has been called.
+	SendRequestHeader(req *http.Request) error
 
-	onFrameError          func()
+	// ReadResponse reads the HTTP response from the stream.
+	// It is invalid to call it more than once.
+	// It doesn't set Response.Request and Response.TLS.
+	// It is invalid to call it after Read has been called.
+	ReadResponse() (*http.Response, error)
+}
+
+type stream struct {
+	quic.Stream
+	closeConnection func(ErrCode)
+
+	buf []byte // used as a temporary buffer when writing the HTTP/3 frame headers
+
 	bytesRemainingInFrame uint64
 }
 
 var _ Stream = &stream{}
 
-func newStream(str quic.Stream, onFrameError func()) *stream {
+func newStream(str quic.Stream, closeConnection func(ErrCode)) *stream {
 	return &stream{
-		Stream:       str,
-		onFrameError: onFrameError,
-		buf:          make([]byte, 0, 16),
+		Stream:          str,
+		closeConnection: closeConnection,
+		buf:             make([]byte, 0, 16),
 	}
 }
 
@@ -48,7 +68,7 @@ func (s *stream) Read(b []byte) (int, error) {
 				s.bytesRemainingInFrame = f.Length
 				break parseLoop
 			default:
-				s.onFrameError()
+				s.closeConnection(ErrCodeFrameUnexpected)
 				// parseNextFrame skips over unknown frame types
 				// Therefore, this condition is only entered when we parsed another known frame type.
 				return 0, fmt.Errorf("peer sent an unexpected frame: %T", f)
@@ -80,10 +100,150 @@ func (s *stream) Write(b []byte) (int, error) {
 	return s.Stream.Write(b)
 }
 
+// The stream conforms to the quic.Stream interface, but instead of writing to and reading directly
+// from the QUIC stream, it writes to and reads from the HTTP stream.
+type requestStream struct {
+	*stream
+
+	conn quic.Connection
+
+	responseBody io.ReadCloser // set by ReadResponse
+
+	decoder            *qpack.Decoder
+	requestWriter      *requestWriter
+	closeConnection    func(ErrCode)
+	maxHeaderBytes     uint64
+	reqDone            chan<- struct{}
+	disableCompression bool
+
+	sentRequest   bool
+	requestedGzip bool
+	isConnect     bool
+}
+
+var _ RequestStream = &requestStream{}
+
+func newRequestStream(
+	str *stream,
+	conn quic.Connection,
+	requestWriter *requestWriter,
+	reqDone chan<- struct{},
+	decoder *qpack.Decoder,
+	disableCompression bool,
+	maxHeaderBytes uint64,
+	closeConnection func(ErrCode),
+) *requestStream {
+	return &requestStream{
+		stream:             str,
+		conn:               conn,
+		requestWriter:      requestWriter,
+		reqDone:            reqDone,
+		decoder:            decoder,
+		disableCompression: disableCompression,
+		closeConnection:    closeConnection,
+		maxHeaderBytes:     maxHeaderBytes,
+	}
+}
+
+func (s *requestStream) Read(b []byte) (int, error) {
+	if s.responseBody == nil {
+		return 0, errors.New("http3: invalid use of RequestStream.Read: need to call ReadResponse first")
+	}
+	return s.responseBody.Read(b)
+}
+
+func (s *requestStream) SendRequestHeader(req *http.Request) error {
+	if s.sentRequest {
+		return errors.New("http3: invalid duplicate use of SendRequestHeader")
+	}
+	if !s.disableCompression && req.Method != http.MethodHead &&
+		req.Header.Get("Accept-Encoding") == "" && req.Header.Get("Range") == "" {
+		s.requestedGzip = true
+	}
+	s.isConnect = req.Method == http.MethodConnect
+	s.sentRequest = true
+	return s.requestWriter.WriteRequestHeader(s.Stream, req, s.requestedGzip)
+}
+
+func (s *requestStream) ReadResponse() (*http.Response, error) {
+	frame, err := parseNextFrame(s.Stream, nil)
+	if err != nil {
+		s.Stream.CancelRead(quic.StreamErrorCode(ErrCodeFrameError))
+		s.Stream.CancelWrite(quic.StreamErrorCode(ErrCodeFrameError))
+		return nil, fmt.Errorf("http3: parsing frame failed: %w", err)
+	}
+	hf, ok := frame.(*headersFrame)
+	if !ok {
+		s.closeConnection(ErrCodeFrameUnexpected)
+		return nil, errors.New("http3: expected first frame to be a HEADERS frame")
+	}
+	if hf.Length > s.maxHeaderBytes {
+		s.Stream.CancelRead(quic.StreamErrorCode(ErrCodeFrameError))
+		s.Stream.CancelWrite(quic.StreamErrorCode(ErrCodeFrameError))
+		return nil, fmt.Errorf("http3: HEADERS frame too large: %d bytes (max: %d)", hf.Length, s.maxHeaderBytes)
+	}
+	headerBlock := make([]byte, hf.Length)
+	if _, err := io.ReadFull(s.Stream, headerBlock); err != nil {
+		s.Stream.CancelRead(quic.StreamErrorCode(ErrCodeRequestIncomplete))
+		s.Stream.CancelWrite(quic.StreamErrorCode(ErrCodeRequestIncomplete))
+		return nil, fmt.Errorf("http3: failed to read response headers: %w", err)
+	}
+	hfs, err := s.decoder.DecodeFull(headerBlock)
+	if err != nil {
+		// TODO: use the right error code
+		s.closeConnection(ErrCodeGeneralProtocolError)
+		return nil, fmt.Errorf("http3: failed to decode response headers: %w", err)
+	}
+
+	res, err := responseFromHeaders(hfs)
+	if err != nil {
+		s.Stream.CancelRead(quic.StreamErrorCode(ErrCodeMessageError))
+		s.Stream.CancelWrite(quic.StreamErrorCode(ErrCodeMessageError))
+		return nil, fmt.Errorf("http3: invalid response: %w", err)
+	}
+
+	// Check that the server doesn't send more data in DATA frames than indicated by the Content-Length header (if set).
+	// See section 4.1.2 of RFC 9114.
+	var httpStr Stream
+	if _, ok := res.Header["Content-Length"]; ok && res.ContentLength >= 0 {
+		httpStr = newLengthLimitedStream(s.stream, res.ContentLength)
+	} else {
+		httpStr = s.stream
+	}
+	respBody := newResponseBody(httpStr, s.conn, s.reqDone)
+
+	// Rules for when to set Content-Length are defined in https://tools.ietf.org/html/rfc7230#section-3.3.2.
+	_, hasTransferEncoding := res.Header["Transfer-Encoding"]
+	isInformational := res.StatusCode >= 100 && res.StatusCode < 200
+	isNoContent := res.StatusCode == http.StatusNoContent
+	isSuccessfulConnect := s.isConnect && res.StatusCode >= 200 && res.StatusCode < 300
+	if !hasTransferEncoding && !isInformational && !isNoContent && !isSuccessfulConnect {
+		res.ContentLength = -1
+		if clens, ok := res.Header["Content-Length"]; ok && len(clens) == 1 {
+			if clen64, err := strconv.ParseInt(clens[0], 10, 64); err == nil {
+				res.ContentLength = clen64
+			}
+		}
+	}
+
+	if s.requestedGzip && res.Header.Get("Content-Encoding") == "gzip" {
+		res.Header.Del("Content-Encoding")
+		res.Header.Del("Content-Length")
+		res.ContentLength = -1
+		s.responseBody = newGzipReader(respBody)
+		res.Uncompressed = true
+	} else {
+		s.responseBody = respBody
+	}
+	res.Body = s.responseBody
+	return res, nil
+}
+
 var errTooMuchData = errors.New("peer sent too much data")
 
 type lengthLimitedStream struct {
 	*stream
+
 	contentLength int64
 	read          int64
 	resetStream   bool

--- a/http3/mock_roundtripcloser_test.go
+++ b/http3/mock_roundtripcloser_test.go
@@ -10,6 +10,7 @@
 package http3
 
 import (
+	context "context"
 	http "net/http"
 	reflect "reflect"
 
@@ -111,6 +112,45 @@ func (c *MockRoundTripCloserHandshakeCompleteCall) Do(f func() bool) *MockRoundT
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockRoundTripCloserHandshakeCompleteCall) DoAndReturn(f func() bool) *MockRoundTripCloserHandshakeCompleteCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// OpenStream mocks base method.
+func (m *MockRoundTripCloser) OpenStream(arg0 context.Context) (RequestStream, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenStream", arg0)
+	ret0, _ := ret[0].(RequestStream)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenStream indicates an expected call of OpenStream.
+func (mr *MockRoundTripCloserMockRecorder) OpenStream(arg0 any) *MockRoundTripCloserOpenStreamCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenStream", reflect.TypeOf((*MockRoundTripCloser)(nil).OpenStream), arg0)
+	return &MockRoundTripCloserOpenStreamCall{Call: call}
+}
+
+// MockRoundTripCloserOpenStreamCall wrap *gomock.Call
+type MockRoundTripCloserOpenStreamCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRoundTripCloserOpenStreamCall) Return(arg0 RequestStream, arg1 error) *MockRoundTripCloserOpenStreamCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRoundTripCloserOpenStreamCall) Do(f func(context.Context) (RequestStream, error)) *MockRoundTripCloserOpenStreamCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRoundTripCloserOpenStreamCall) DoAndReturn(f func(context.Context) (RequestStream, error)) *MockRoundTripCloserOpenStreamCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/http3/request_writer.go
+++ b/http3/request_writer.go
@@ -215,13 +215,10 @@ func (w *requestWriter) encodeHeaders(req *http.Request, addGzipHeader bool, tra
 
 // authorityAddr returns a given authority (a host/IP, or host:port / ip:port)
 // and returns a host:port. The port 443 is added if needed.
-func authorityAddr(scheme string, authority string) (addr string) {
+func authorityAddr(authority string) (addr string) {
 	host, port, err := net.SplitHostPort(authority)
 	if err != nil { // authority didn't have a port
 		port = "443"
-		if scheme == "http" {
-			port = "80"
-		}
 		host = authority
 	}
 	if a, err := idna.ToASCII(host); err == nil {

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -431,11 +431,13 @@ var _ = Describe("HTTP tests", func() {
 
 		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/httpstreamer", port), nil)
 		Expect(err).ToNot(HaveOccurred())
-		rsp, err := client.Transport.(*http3.RoundTripper).RoundTripOpt(req, http3.RoundTripOpt{DontCloseRequestStream: true})
+		str, err := client.Transport.(*http3.RoundTripper).OpenStream(context.Background(), req.URL)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(str.SendRequestHeader(req)).To(Succeed())
+		rsp, err := str.ReadResponse()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rsp.StatusCode).To(Equal(200))
 
-		str := rsp.Body.(http3.HTTPStreamer).HTTPStream()
 		b := make([]byte, 6)
 		_, err = io.ReadFull(str, b)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Part of #3522.

The stream exposes two methods required for doing an HTTP request: `SendRequestHeader` and `ReadResponse`. This can be used by applications that wish to use the stream for non-HTTP content afterwards. This will lead to a simplification in the API we need to expose for WebTransport, and will make it easier to send HTTP Datagrams associated with this stream.