### PR TITLE
cancel retransmissions if a STOP_SENDING is received for a closed stream

### DIFF
--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -958,6 +958,21 @@ var _ = Describe("Send Stream", func() {
 					Remote:    true,
 				}))
 			})
+
+			It("resets, even if the stream was closed before", func() {
+				mockSender.EXPECT().onHasStreamData(streamID)
+				Expect(str.Close()).To(Succeed())
+				mockSender.EXPECT().queueControlFrame(&wire.ResetStreamFrame{
+					StreamID:  streamID,
+					ErrorCode: 101,
+				})
+				mockSender.EXPECT().onStreamCompleted(gomock.Any())
+
+				str.handleStopSendingFrame(&wire.StopSendingFrame{
+					StreamID:  streamID,
+					ErrorCode: 101,
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
Fixes #4411. Depends on #4408.

