### PR TITLE
http3: simplify buffering of small responses

### DIFF
--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -26,7 +26,7 @@ func encodeResponse(status int) []byte {
 	buf := &bytes.Buffer{}
 	rstr := mockquic.NewMockStream(mockCtrl)
 	rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
-	rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
+	rw := newResponseWriter(rstr, nil, false, utils.DefaultLogger)
 	rw.WriteHeader(status)
 	rw.Flush()
 	return buf.Bytes()
@@ -738,7 +738,7 @@ var _ = Describe("Client", func() {
 				buf := &bytes.Buffer{}
 				rstr := mockquic.NewMockStream(mockCtrl)
 				rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
-				rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
+				rw := newResponseWriter(rstr, nil, false, utils.DefaultLogger)
 				rw.Header().Set("Content-Encoding", "gzip")
 				gz := gzip.NewWriter(rw)
 				gz.Write([]byte("gzipped response"))
@@ -764,7 +764,7 @@ var _ = Describe("Client", func() {
 				buf := &bytes.Buffer{}
 				rstr := mockquic.NewMockStream(mockCtrl)
 				rstr.EXPECT().Write(gomock.Any()).Do(buf.Write).AnyTimes()
-				rw := newResponseWriter(rstr, nil, utils.DefaultLogger)
+				rw := newResponseWriter(rstr, nil, false, utils.DefaultLogger)
 				rw.Write([]byte("not gzipped"))
 				rw.Flush()
 				str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Response Writer", func() {
 		str.EXPECT().Write(gomock.Any()).DoAndReturn(strBuf.Write).AnyTimes()
 		str.EXPECT().SetReadDeadline(gomock.Any()).Return(nil).AnyTimes()
 		str.EXPECT().SetWriteDeadline(gomock.Any()).Return(nil).AnyTimes()
-		rw = newResponseWriter(str, nil, utils.DefaultLogger)
+		rw = newResponseWriter(str, nil, false, utils.DefaultLogger)
 	})
 
 	decodeHeader := func(str io.Reader) map[string][]string {

--- a/http3/server.go
+++ b/http3/server.go
@@ -554,10 +554,7 @@ func (s *Server) handleRequest(conn *connection, str quic.Stream, decoder *qpack
 		}
 	}
 	req = req.WithContext(ctx)
-	r := newResponseWriter(str, conn, s.logger)
-	if req.Method == http.MethodHead {
-		r.isHead = true
-	}
+	r := newResponseWriter(str, conn, req.Method == http.MethodHead, s.logger)
 	handler := s.Handler
 	if handler == nil {
 		handler = http.DefaultServeMux
@@ -588,7 +585,7 @@ func (s *Server) handleRequest(conn *connection, str quic.Stream, decoder *qpack
 	// only write response when there is no panic
 	if !panicked {
 		// response not written to the client yet, set Content-Length
-		if !r.written {
+		if !r.headerWritten {
 			if _, haveCL := r.header["Content-Length"]; !haveCL {
 				r.header.Set("Content-Length", strconv.FormatInt(r.numWritten, 10))
 			}

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -228,12 +228,12 @@ var _ = Describe("Server", func() {
 			Expect(hfs).To(HaveLen(3))
 		})
 
-		It("response to HEAD request should not have body", func() {
+		It("ignores calls to Write for responses to HEAD requests", func() {
 			s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte("foobar"))
 			})
 
-			headRequest, err := http.NewRequest("HEAD", "https://www.example.com", nil)
+			headRequest, err := http.NewRequest(http.MethodHead, "https://www.example.com", nil)
 			Expect(err).ToNot(HaveOccurred())
 			responseBuf := &bytes.Buffer{}
 			setRequest(encodeRequest(headRequest))
@@ -245,7 +245,7 @@ var _ = Describe("Server", func() {
 			s.handleRequest(conn, str, qpackDecoder)
 			hfs := decodeHeader(responseBuf)
 			Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
-			Expect(responseBuf.Bytes()).To(HaveLen(0))
+			Expect(responseBuf.Bytes()).To(BeEmpty())
 		})
 
 		It("response to HEAD request should also do content sniffing", func() {
@@ -253,7 +253,7 @@ var _ = Describe("Server", func() {
 				w.Write([]byte("<html></html>"))
 			})
 
-			headRequest, err := http.NewRequest("HEAD", "https://www.example.com", nil)
+			headRequest, err := http.NewRequest(http.MethodHead, "https://www.example.com", nil)
 			Expect(err).ToNot(HaveOccurred())
 			responseBuf := &bytes.Buffer{}
 			setRequest(encodeRequest(headRequest))

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -136,13 +136,14 @@ var _ = Describe("HTTP tests", func() {
 	It("sets content-length for small response", func() {
 		mux.HandleFunc("/small", func(w http.ResponseWriter, r *http.Request) {
 			defer GinkgoRecover()
-			w.Write([]byte("foobar"))
+			w.Write([]byte("foo"))
+			w.Write([]byte("bar"))
 		})
 
 		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/small", port))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(200))
-		Expect(resp.Header.Get("Content-Length")).To(Equal(strconv.Itoa(len("foobar"))))
+		Expect(resp.Header.Get("Content-Length")).To(Equal("6"))
 	})
 
 	It("detects stream errors when server panics when writing response", func() {


### PR DESCRIPTION
This should also reduce our memory consumption, since we don't have to keep a `bytes.Buffer` around indefinitely.
This simplification will help a refactor that will eventually let us implement #3522.