### PR TITLE
http3: remove Accept(Uni)Stream methods from the Connection interface

### DIFF
--- a/http3/conn.go
+++ b/http3/conn.go
@@ -11,10 +11,10 @@ import (
 	"github.com/quic-go/quic-go/quicvarint"
 )
 
+// Connection is an HTTP/3 connection.
+// It has all methods from the quic.Connection expect for AcceptStream, AcceptUniStream,
+// SendDatagram and ReceiveDatagram.
 type Connection interface {
-	// all methods from the quic.Connection expect for SendDatagram and ReceiveDatagram
-	AcceptStream(context.Context) (quic.Stream, error)
-	AcceptUniStream(context.Context) (quic.ReceiveStream, error)
 	OpenStream() (quic.Stream, error)
 	OpenStreamSync(context.Context) (quic.Stream, error)
 	OpenUniStream() (quic.SendStream, error)


### PR DESCRIPTION
Incoming streams are hijacked, not accepted. This might change with #4405, but at the current stage these methods make no sense.

Part of #3522.