### PR TITLE
http3: move length limiting to the body

### DIFF
--- a/http3/body_test.go
+++ b/http3/body_test.go
@@ -1,7 +1,9 @@
 package http3
 
 import (
+	"bytes"
 	"errors"
+	"io"
 
 	"github.com/quic-go/quic-go"
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
@@ -19,7 +21,7 @@ var _ = Describe("Response Body", func() {
 	It("closes the reqDone channel when Read errors", func() {
 		str := mockquic.NewMockStream(mockCtrl)
 		str.EXPECT().Read(gomock.Any()).Return(0, errors.New("test error"))
-		rb := newResponseBody(str, reqDone)
+		rb := newResponseBody(&stream{Stream: str}, -1, reqDone)
 		_, err := rb.Read([]byte{0})
 		Expect(err).To(MatchError("test error"))
 		Expect(reqDone).To(BeClosed())
@@ -28,7 +30,7 @@ var _ = Describe("Response Body", func() {
 	It("allows multiple calls to Read, when Read errors", func() {
 		str := mockquic.NewMockStream(mockCtrl)
 		str.EXPECT().Read(gomock.Any()).Return(0, errors.New("test error")).Times(2)
-		rb := newResponseBody(str, reqDone)
+		rb := newResponseBody(&stream{Stream: str}, -1, reqDone)
 		_, err := rb.Read([]byte{0})
 		Expect(err).To(HaveOccurred())
 		Expect(reqDone).To(BeClosed())
@@ -38,17 +40,62 @@ var _ = Describe("Response Body", func() {
 
 	It("closes responses", func() {
 		str := mockquic.NewMockStream(mockCtrl)
-		rb := newResponseBody(str, reqDone)
+		rb := newResponseBody(&stream{Stream: str}, -1, reqDone)
 		str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeRequestCanceled))
 		Expect(rb.Close()).To(Succeed())
 	})
 
 	It("allows multiple calls to Close", func() {
 		str := mockquic.NewMockStream(mockCtrl)
-		rb := newResponseBody(str, reqDone)
+		rb := newResponseBody(&stream{Stream: str}, -1, reqDone)
 		str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeRequestCanceled)).MaxTimes(2)
 		Expect(rb.Close()).To(Succeed())
 		Expect(reqDone).To(BeClosed())
 		Expect(rb.Close()).To(Succeed())
+	})
+
+	Context("length limiting", func() {
+		It("reads all frames", func() {
+			var buf bytes.Buffer
+			buf.Write(getDataFrame([]byte("foobar")))
+			str := mockquic.NewMockStream(mockCtrl)
+			str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+			rb := newResponseBody(&stream{Stream: str}, 6, reqDone)
+			data, err := io.ReadAll(rb)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).To(Equal([]byte("foobar")))
+		})
+
+		It("errors if more data than the maximum length is sent, in the middle of a frame", func() {
+			var buf bytes.Buffer
+			buf.Write(getDataFrame([]byte("foo")))
+			buf.Write(getDataFrame([]byte("bar")))
+			str := mockquic.NewMockStream(mockCtrl)
+			str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeMessageError))
+			str.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeMessageError))
+			str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+			rb := newResponseBody(&stream{Stream: str}, 4, reqDone)
+			data, err := io.ReadAll(rb)
+			Expect(data).To(Equal([]byte("foob")))
+			Expect(err).To(MatchError(errTooMuchData))
+			// check that repeated calls to Read also return the right error
+			n, err := rb.Read([]byte{0})
+			Expect(n).To(BeZero())
+			Expect(err).To(MatchError(errTooMuchData))
+		})
+
+		It("errors if more data than the maximum length is sent, as an additional frame", func() {
+			var buf bytes.Buffer
+			buf.Write(getDataFrame([]byte("foo")))
+			buf.Write(getDataFrame([]byte("bar")))
+			str := mockquic.NewMockStream(mockCtrl)
+			str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeMessageError))
+			str.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeMessageError))
+			str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+			rb := newResponseBody(&stream{Stream: str}, 3, reqDone)
+			data, err := io.ReadAll(rb)
+			Expect(err).To(MatchError(errTooMuchData))
+			Expect(data).To(Equal([]byte("foo")))
+		})
 	})
 })

--- a/http3/server.go
+++ b/http3/server.go
@@ -527,13 +527,11 @@ func (s *Server) handleRequest(conn *connection, str quic.Stream, decoder *qpack
 
 	// Check that the client doesn't send more data in DATA frames than indicated by the Content-Length header (if set).
 	// See section 4.1.2 of RFC 9114.
-	var httpStr Stream
+	contentLength := int64(-1)
 	if _, ok := req.Header["Content-Length"]; ok && req.ContentLength >= 0 {
-		httpStr = newLengthLimitedStream(newStream(str, conn), req.ContentLength)
-	} else {
-		httpStr = newStream(str, conn)
+		contentLength = req.ContentLength
 	}
-	body := newRequestBody(httpStr, conn.Context(), conn.ReceivedSettings(), conn.Settings)
+	body := newRequestBody(newStream(str, conn), contentLength, conn.Context(), conn.ReceivedSettings(), conn.Settings)
 	req.Body = body
 
 	if s.logger.Debug() {


### PR DESCRIPTION
The length limit is a property of the (request and response) body. As such, it's better implemented there than by wrapping the HTTP stream.

Needed for the refactor for #3522.