### PR TITLE
flowcontrol: make it possible to call Abandon multiple times

### DIFF
--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -111,6 +111,7 @@ func (c *streamFlowController) AddBytesRead(n protocol.ByteCount) {
 func (c *streamFlowController) Abandon() {
 	c.mutex.Lock()
 	unread := c.highestReceived - c.bytesRead
+	c.bytesRead = c.highestReceived
 	c.mutex.Unlock()
 	if unread > 0 {
 		c.connection.AddBytesRead(unread)

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -159,6 +159,15 @@ var _ = Describe("Stream Flow controller", func() {
 				controller.Abandon()
 				Expect(controller.connection.(*connectionFlowController).bytesRead).To(Equal(protocol.ByteCount(100)))
 			})
+
+			It("tolerates repeated calls to Abandon", func() {
+				controller.AddBytesRead(5)
+				Expect(controller.UpdateHighestReceived(100, true)).To(Succeed())
+				controller.Abandon()
+				controller.Abandon()
+				controller.Abandon()
+				Expect(controller.connection.(*connectionFlowController).bytesRead).To(Equal(protocol.ByteCount(100)))
+			})
 		})
 
 		It("saves when data is read", func() {


### PR DESCRIPTION
`Abandon` is called when a RESET_STREAM frame is received, and marks the bytes between the highest read position and the final offset as consumed. Making it possible to call `Abandon` multiple times makes using this API a bit easier, since the stream doesn't need to track if it already called it.