### PR TITLE
http3: rename Settings.EnableDatagram to EnableDatagrams

### DIFF
--- a/http3/conn.go
+++ b/http3/conn.go
@@ -212,7 +212,7 @@ func (c *connection) HandleUnidirectionalStreams(hijack func(StreamType, quic.Co
 				return
 			}
 			c.settings = &Settings{
-				EnableDatagram:        sf.Datagram,
+				EnableDatagrams:       sf.Datagram,
 				EnableExtendedConnect: sf.ExtendedConnect,
 				Other:                 sf.Other,
 			}

--- a/http3/conn_test.go
+++ b/http3/conn_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Connection", func() {
 				conn.HandleUnidirectionalStreams(nil)
 			}()
 			Eventually(conn.ReceivedSettings()).Should(BeClosed())
-			Expect(conn.Settings().EnableDatagram).To(BeTrue())
+			Expect(conn.Settings().EnableDatagrams).To(BeTrue())
 			Expect(conn.Settings().EnableExtendedConnect).To(BeTrue())
 			Expect(conn.Settings().Other).To(HaveKeyWithValue(uint64(1337), uint64(42)))
 			Eventually(done).Should(BeClosed())

--- a/http3/roundtrip.go
+++ b/http3/roundtrip.go
@@ -21,7 +21,7 @@ import (
 // Settings are HTTP/3 settings that apply to the underlying connection.
 type Settings struct {
 	// Support for HTTP/3 datagrams (RFC 9297)
-	EnableDatagram bool
+	EnableDatagrams bool
 	// Extended CONNECT, RFC 9220
 	EnableExtendedConnect bool
 	// Other settings, defined by the application

--- a/http3/roundtrip_test.go
+++ b/http3/roundtrip_test.go
@@ -181,7 +181,7 @@ var _ = Describe("RoundTripper", func() {
 		Expect(err).To(MatchError(testErr))
 	})
 
-	It("requires quic.Config.EnableDatagram if HTTP/3 datagrams are enabled", func() {
+	It("requires quic.Config.EnableDatagrams if HTTP/3 datagrams are enabled", func() {
 		rt := &RoundTripper{
 			QUICConfig:      &quic.Config{EnableDatagrams: false},
 			EnableDatagrams: true,

--- a/http3/server.go
+++ b/http3/server.go
@@ -167,7 +167,7 @@ type Server struct {
 	Handler http.Handler
 
 	// EnableDatagrams enables support for HTTP/3 datagrams (RFC 9297).
-	// If set to true, QUICConfig.EnableDatagram will be set.
+	// If set to true, QUICConfig.EnableDatagrams will be set.
 	EnableDatagrams bool
 
 	// MaxHeaderBytes controls the maximum number of bytes the server will

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -611,7 +611,7 @@ var _ = Describe("HTTP tests", func() {
 		Eventually(hconn.ReceivedSettings(), 5*time.Second, 10*time.Millisecond).Should(BeClosed())
 		settings := hconn.Settings()
 		Expect(settings.EnableExtendedConnect).To(BeTrue())
-		Expect(settings.EnableDatagram).To(BeFalse())
+		Expect(settings.EnableDatagrams).To(BeFalse())
 		Expect(settings.Other).To(BeEmpty())
 	})
 
@@ -642,7 +642,7 @@ var _ = Describe("HTTP tests", func() {
 		var settings *http3.Settings
 		Expect(settingsChan).To(Receive(&settings))
 		Expect(settings).ToNot(BeNil())
-		Expect(settings.EnableDatagram).To(BeTrue())
+		Expect(settings.EnableDatagrams).To(BeTrue())
 		Expect(settings.EnableExtendedConnect).To(BeFalse())
 		Expect(settings.Other).To(HaveKeyWithValue(uint64(1337), uint64(42)))
 	})
@@ -732,7 +732,7 @@ var _ = Describe("HTTP tests", func() {
 				Expect(r.Method).To(Equal(http.MethodConnect))
 				conn := w.(http3.Hijacker).Connection()
 				Eventually(conn.ReceivedSettings()).Should(BeClosed())
-				Expect(conn.Settings().EnableDatagram).To(BeTrue())
+				Expect(conn.Settings().EnableDatagrams).To(BeTrue())
 				w.WriteHeader(http.StatusOK)
 				w.(http.Flusher).Flush()
 


### PR DESCRIPTION
This makes it consistent with the `quic.Config` and the config flag on the `http3.Server` and `http3.RoundTripper`.