### PR TITLE
http3: implement on the HTTPStreamer on the ResponseWriter, flush header

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -572,7 +572,7 @@ func (s *Server) handleRequest(conn *connection, str quic.Stream, datagrams *dat
 		handler.ServeHTTP(r, req)
 	}()
 
-	if body.wasStreamHijacked() {
+	if r.wasStreamHijacked() {
 		return
 	}
 

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -422,9 +422,8 @@ var _ = Describe("HTTP tests", func() {
 			defer GinkgoRecover()
 			close(handlerCalled)
 			w.WriteHeader(http.StatusOK)
-			w.(http.Flusher).Flush()
 
-			str := r.Body.(http3.HTTPStreamer).HTTPStream()
+			str := w.(http3.HTTPStreamer).HTTPStream()
 			str.Write([]byte("foobar"))
 
 			// Do this in a Go routine, so that the handler returns early.
@@ -734,9 +733,8 @@ var _ = Describe("HTTP tests", func() {
 				Eventually(conn.ReceivedSettings()).Should(BeClosed())
 				Expect(conn.Settings().EnableDatagrams).To(BeTrue())
 				w.WriteHeader(http.StatusOK)
-				w.(http.Flusher).Flush()
 
-				str := r.Body.(http3.HTTPStreamer).HTTPStream()
+				str := w.(http3.HTTPStreamer).HTTPStream()
 				go str.Read([]byte{0}) // need to continue reading from stream to observe state transitions
 
 				for {


### PR DESCRIPTION
Currently the `HTTPStreamer` is implemented on the `http.Request.Body`. This complicates usage, since it's not easily possible to flush the HTTP header, requiring users to manually flash the header before taking over the stream.

With this change, the HTTP header is now flushed automatically as soon as `HTTPStream` is called.