### PR TITLE
include the maximum payload size in the DatagramTooLargeError

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2358,9 +2358,10 @@ func (s *connection) SendDatagram(p []byte) error {
 	}
 
 	f := &wire.DatagramFrame{DataLenPresent: true}
-	if protocol.ByteCount(len(p)) > f.MaxDataLen(s.peerParams.MaxDatagramFrameSize, s.version) {
+	maxDataLen := f.MaxDataLen(s.peerParams.MaxDatagramFrameSize, s.version)
+	if protocol.ByteCount(len(p)) > maxDataLen {
 		return &DatagramTooLargeError{
-			PeerMaxDatagramFrameSize: int64(s.peerParams.MaxDatagramFrameSize),
+			PeerMaxDatagramFrameSize: int64(maxDataLen),
 		}
 	}
 	f.Data = make([]byte, len(p))

--- a/connection.go
+++ b/connection.go
@@ -2360,9 +2360,7 @@ func (s *connection) SendDatagram(p []byte) error {
 	f := &wire.DatagramFrame{DataLenPresent: true}
 	maxDataLen := f.MaxDataLen(s.peerParams.MaxDatagramFrameSize, s.version)
 	if protocol.ByteCount(len(p)) > maxDataLen {
-		return &DatagramTooLargeError{
-			PeerMaxDatagramFrameSize: int64(maxDataLen),
-		}
+		return &DatagramTooLargeError{MaxDatagramPayloadSize: int64(maxDataLen)}
 	}
 	f.Data = make([]byte, len(p))
 	copy(f.Data, p)

--- a/errors.go
+++ b/errors.go
@@ -64,7 +64,7 @@ func (e *StreamError) Error() string {
 
 // DatagramTooLargeError is returned from Connection.SendDatagram if the payload is too large to be sent.
 type DatagramTooLargeError struct {
-	PeerMaxDatagramFrameSize int64
+	MaxDatagramPayloadSize int64
 }
 
 func (e *DatagramTooLargeError) Is(target error) bool {

--- a/integrationtests/self/datagram_test.go
+++ b/integrationtests/self/datagram_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Datagram test", func() {
 					maxDatagramMessageSize := f.MaxDataLen(maxDatagramSize, conn.ConnectionState().Version)
 					b := make([]byte, maxDatagramMessageSize+1)
 					Expect(conn.SendDatagram(b)).To(MatchError(&quic.DatagramTooLargeError{
-						PeerMaxDatagramFrameSize: int64(maxDatagramMessageSize),
+						MaxDatagramPayloadSize: int64(maxDatagramMessageSize),
 					}))
 					wg.Wait()
 				}


### PR DESCRIPTION
Closes #4436.

This is more useful than the maximum frame size. The user of the library shouldn't have to care about the QUIC framing layer.