### PR TITLE
http3: Pass original Conn to ConnContext

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -537,7 +537,7 @@ func (s *Server) handleRequest(conn *connection, str quic.Stream, datagrams *dat
 	ctx = context.WithValue(ctx, http.LocalAddrContextKey, conn.LocalAddr())
 	ctx = context.WithValue(ctx, RemoteAddrContextKey, conn.RemoteAddr())
 	if s.ConnContext != nil {
-		ctx = s.ConnContext(ctx, conn)
+		ctx = s.ConnContext(ctx, conn.Connection)
 		if ctx == nil {
 			panic("http3: ConnContext returned nil")
 		}

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Server", func() {
 			Expect(req.Host).To(Equal("www.example.com"))
 			Expect(req.RemoteAddr).To(Equal("127.0.0.1:1337"))
 			Expect(req.Context().Value(ServerContextKey)).To(Equal(s))
-			Expect(req.Context().Value(testConnContextKey("test"))).ToNot(Equal(nil))
+			Expect(req.Context().Value(testConnContextKey("test"))).To(Equal(conn.Connection))
 		})
 
 		It("returns 200 with an empty handler", func() {


### PR DESCRIPTION
`Server.ConnContext` should receive the original `quic.Connection` instead of an internal wrapper.

https://github.com/quic-go/quic-go/issues/4479