### PR TITLE
wire: use quicvarint.Parse when parsing frames

### DIFF
--- a/internal/wire/ack_frame.go
+++ b/internal/wire/ack_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"errors"
 	"sort"
 	"time"
@@ -22,18 +21,21 @@ type AckFrame struct {
 }
 
 // parseAckFrame reads an ACK frame
-func parseAckFrame(frame *AckFrame, r *bytes.Reader, typ uint64, ackDelayExponent uint8, _ protocol.Version) error {
+func parseAckFrame(frame *AckFrame, b []byte, typ uint64, ackDelayExponent uint8, _ protocol.Version) (int, error) {
+	startLen := len(b)
 	ecn := typ == ackECNFrameType
 
-	la, err := quicvarint.Read(r)
+	la, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return err
+		return 0, err
 	}
+	b = b[l:]
 	largestAcked := protocol.PacketNumber(la)
-	delay, err := quicvarint.Read(r)
+	delay, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return err
+		return 0, err
 	}
+	b = b[l:]
 
 	delayTime := time.Duration(delay*1<<ackDelayExponent) * time.Microsecond
 	if delayTime < 0 {
@@ -42,71 +44,78 @@ func parseAckFrame(frame *AckFrame, r *bytes.Reader, typ uint64, ackDelayExponen
 	}
 	frame.DelayTime = delayTime
 
-	numBlocks, err := quicvarint.Read(r)
+	numBlocks, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return err
+		return 0, err
 	}
+	b = b[l:]
 
 	// read the first ACK range
-	ab, err := quicvarint.Read(r)
+	ab, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return err
+		return 0, err
 	}
+	b = b[l:]
 	ackBlock := protocol.PacketNumber(ab)
 	if ackBlock > largestAcked {
-		return errors.New("invalid first ACK range")
+		return 0, errors.New("invalid first ACK range")
 	}
 	smallest := largestAcked - ackBlock
 	frame.AckRanges = append(frame.AckRanges, AckRange{Smallest: smallest, Largest: largestAcked})
 
 	// read all the other ACK ranges
 	for i := uint64(0); i < numBlocks; i++ {
-		g, err := quicvarint.Read(r)
+		g, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return err
+			return 0, err
 		}
+		b = b[l:]
 		gap := protocol.PacketNumber(g)
 		if smallest < gap+2 {
-			return errInvalidAckRanges
+			return 0, errInvalidAckRanges
 		}
 		largest := smallest - gap - 2
 
-		ab, err := quicvarint.Read(r)
+		ab, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return err
+			return 0, err
 		}
+		b = b[l:]
 		ackBlock := protocol.PacketNumber(ab)
 
 		if ackBlock > largest {
-			return errInvalidAckRanges
+			return 0, errInvalidAckRanges
 		}
 		smallest = largest - ackBlock
 		frame.AckRanges = append(frame.AckRanges, AckRange{Smallest: smallest, Largest: largest})
 	}
 
 	if !frame.validateAckRanges() {
-		return errInvalidAckRanges
+		return 0, errInvalidAckRanges
 	}
 
 	if ecn {
-		ect0, err := quicvarint.Read(r)
+		ect0, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return err
+			return 0, err
 		}
+		b = b[l:]
 		frame.ECT0 = ect0
-		ect1, err := quicvarint.Read(r)
+		ect1, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return err
+			return 0, err
 		}
+		b = b[l:]
 		frame.ECT1 = ect1
-		ecnce, err := quicvarint.Read(r)
+		ecnce, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return err
+			return 0, err
 		}
+		b = b[l:]
 		frame.ECNCE = ecnce
 	}
 
-	return nil
+	return startLen - len(b), nil
 }
 
 // Append appends an ACK frame.

--- a/internal/wire/ack_frame.go
+++ b/internal/wire/ack_frame.go
@@ -27,13 +27,13 @@ func parseAckFrame(frame *AckFrame, b []byte, typ uint64, ackDelayExponent uint8
 
 	la, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return 0, err
+		return 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	largestAcked := protocol.PacketNumber(la)
 	delay, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return 0, err
+		return 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 
@@ -46,14 +46,14 @@ func parseAckFrame(frame *AckFrame, b []byte, typ uint64, ackDelayExponent uint8
 
 	numBlocks, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return 0, err
+		return 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 
 	// read the first ACK range
 	ab, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return 0, err
+		return 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	ackBlock := protocol.PacketNumber(ab)
@@ -67,7 +67,7 @@ func parseAckFrame(frame *AckFrame, b []byte, typ uint64, ackDelayExponent uint8
 	for i := uint64(0); i < numBlocks; i++ {
 		g, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return 0, err
+			return 0, replaceUnexpectedEOF(err)
 		}
 		b = b[l:]
 		gap := protocol.PacketNumber(g)
@@ -78,7 +78,7 @@ func parseAckFrame(frame *AckFrame, b []byte, typ uint64, ackDelayExponent uint8
 
 		ab, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return 0, err
+			return 0, replaceUnexpectedEOF(err)
 		}
 		b = b[l:]
 		ackBlock := protocol.PacketNumber(ab)
@@ -97,19 +97,19 @@ func parseAckFrame(frame *AckFrame, b []byte, typ uint64, ackDelayExponent uint8
 	if ecn {
 		ect0, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return 0, err
+			return 0, replaceUnexpectedEOF(err)
 		}
 		b = b[l:]
 		frame.ECT0 = ect0
 		ect1, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return 0, err
+			return 0, replaceUnexpectedEOF(err)
 		}
 		b = b[l:]
 		frame.ECT1 = ect1
 		ecnce, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return 0, err
+			return 0, replaceUnexpectedEOF(err)
 		}
 		b = b[l:]
 		frame.ECNCE = ecnce

--- a/internal/wire/connection_close_frame.go
+++ b/internal/wire/connection_close_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -16,40 +15,38 @@ type ConnectionCloseFrame struct {
 	ReasonPhrase       string
 }
 
-func parseConnectionCloseFrame(r *bytes.Reader, typ uint64, _ protocol.Version) (*ConnectionCloseFrame, error) {
+func parseConnectionCloseFrame(b []byte, typ uint64, _ protocol.Version) (*ConnectionCloseFrame, int, error) {
+	startLen := len(b)
 	f := &ConnectionCloseFrame{IsApplicationError: typ == applicationCloseFrameType}
-	ec, err := quicvarint.Read(r)
+	ec, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
+	b = b[l:]
 	f.ErrorCode = ec
 	// read the Frame Type, if this is not an application error
 	if !f.IsApplicationError {
-		ft, err := quicvarint.Read(r)
+		ft, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
+		b = b[l:]
 		f.FrameType = ft
 	}
 	var reasonPhraseLen uint64
-	reasonPhraseLen, err = quicvarint.Read(r)
+	reasonPhraseLen, l, err = quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	// shortcut to prevent the unnecessary allocation of dataLen bytes
-	// if the dataLen is larger than the remaining length of the packet
-	// reading the whole reason phrase would result in EOF when attempting to READ
-	if int(reasonPhraseLen) > r.Len() {
-		return nil, io.EOF
+	b = b[l:]
+	if int(reasonPhraseLen) > len(b) {
+		return nil, 0, io.EOF
 	}
 
 	reasonPhrase := make([]byte, reasonPhraseLen)
-	if _, err := io.ReadFull(r, reasonPhrase); err != nil {
-		// this should never happen, since we already checked the reasonPhraseLen earlier
-		return nil, err
-	}
+	copy(reasonPhrase, b)
 	f.ReasonPhrase = string(reasonPhrase)
-	return f, nil
+	return f, startLen - len(b) + int(reasonPhraseLen), nil
 }
 
 // Length of a written frame

--- a/internal/wire/connection_close_frame.go
+++ b/internal/wire/connection_close_frame.go
@@ -20,7 +20,7 @@ func parseConnectionCloseFrame(b []byte, typ uint64, _ protocol.Version) (*Conne
 	f := &ConnectionCloseFrame{IsApplicationError: typ == applicationCloseFrameType}
 	ec, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	f.ErrorCode = ec
@@ -28,7 +28,7 @@ func parseConnectionCloseFrame(b []byte, typ uint64, _ protocol.Version) (*Conne
 	if !f.IsApplicationError {
 		ft, l, err := quicvarint.Parse(b)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, replaceUnexpectedEOF(err)
 		}
 		b = b[l:]
 		f.FrameType = ft
@@ -36,7 +36,7 @@ func parseConnectionCloseFrame(b []byte, typ uint64, _ protocol.Version) (*Conne
 	var reasonPhraseLen uint64
 	reasonPhraseLen, l, err = quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	if int(reasonPhraseLen) > len(b) {

--- a/internal/wire/crypto_frame.go
+++ b/internal/wire/crypto_frame.go
@@ -18,13 +18,13 @@ func parseCryptoFrame(b []byte, _ protocol.Version) (*CryptoFrame, int, error) {
 	frame := &CryptoFrame{}
 	offset, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	frame.Offset = protocol.ByteCount(offset)
 	dataLen, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	if dataLen > uint64(len(b)) {

--- a/internal/wire/crypto_frame.go
+++ b/internal/wire/crypto_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -14,28 +13,28 @@ type CryptoFrame struct {
 	Data   []byte
 }
 
-func parseCryptoFrame(r *bytes.Reader, _ protocol.Version) (*CryptoFrame, error) {
+func parseCryptoFrame(b []byte, _ protocol.Version) (*CryptoFrame, int, error) {
+	startLen := len(b)
 	frame := &CryptoFrame{}
-	offset, err := quicvarint.Read(r)
+	offset, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
+	b = b[l:]
 	frame.Offset = protocol.ByteCount(offset)
-	dataLen, err := quicvarint.Read(r)
+	dataLen, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	if dataLen > uint64(r.Len()) {
-		return nil, io.EOF
+	b = b[l:]
+	if dataLen > uint64(len(b)) {
+		return nil, 0, io.EOF
 	}
 	if dataLen != 0 {
 		frame.Data = make([]byte, dataLen)
-		if _, err := io.ReadFull(r, frame.Data); err != nil {
-			// this should never happen, since we already checked the dataLen earlier
-			return nil, err
-		}
+		copy(frame.Data, b)
 	}
-	return frame, nil
+	return frame, startLen - len(b) + int(dataLen), nil
 }
 
 func (f *CryptoFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/data_blocked_frame.go
+++ b/internal/wire/data_blocked_frame.go
@@ -1,8 +1,6 @@
 package wire
 
 import (
-	"bytes"
-
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
 )
@@ -12,12 +10,12 @@ type DataBlockedFrame struct {
 	MaximumData protocol.ByteCount
 }
 
-func parseDataBlockedFrame(r *bytes.Reader, _ protocol.Version) (*DataBlockedFrame, error) {
-	offset, err := quicvarint.Read(r)
+func parseDataBlockedFrame(b []byte, _ protocol.Version) (*DataBlockedFrame, int, error) {
+	offset, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return &DataBlockedFrame{MaximumData: protocol.ByteCount(offset)}, nil
+	return &DataBlockedFrame{MaximumData: protocol.ByteCount(offset)}, l, nil
 }
 
 func (f *DataBlockedFrame) Append(b []byte, version protocol.Version) ([]byte, error) {

--- a/internal/wire/data_blocked_frame.go
+++ b/internal/wire/data_blocked_frame.go
@@ -13,7 +13,7 @@ type DataBlockedFrame struct {
 func parseDataBlockedFrame(b []byte, _ protocol.Version) (*DataBlockedFrame, int, error) {
 	offset, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	return &DataBlockedFrame{MaximumData: protocol.ByteCount(offset)}, l, nil
 }

--- a/internal/wire/data_blocked_frame_test.go
+++ b/internal/wire/data_blocked_frame_test.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -15,19 +14,19 @@ var _ = Describe("DATA_BLOCKED frame", func() {
 	Context("when parsing", func() {
 		It("accepts sample frame", func() {
 			data := encodeVarInt(0x12345678)
-			b := bytes.NewReader(data)
-			frame, err := parseDataBlockedFrame(b, protocol.Version1)
+			frame, l, err := parseDataBlockedFrame(data, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.MaximumData).To(Equal(protocol.ByteCount(0x12345678)))
-			Expect(b.Len()).To(BeZero())
+			Expect(l).To(Equal(len(data)))
 		})
 
 		It("errors on EOFs", func() {
 			data := encodeVarInt(0x12345678)
-			_, err := parseDataBlockedFrame(bytes.NewReader(data), protocol.Version1)
+			_, l, err := parseDataBlockedFrame(data, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(l).To(Equal(len(data)))
 			for i := range data {
-				_, err := parseDataBlockedFrame(bytes.NewReader(data[:i]), protocol.Version1)
+				_, _, err := parseDataBlockedFrame(data[:i], protocol.Version1)
 				Expect(err).To(MatchError(io.EOF))
 			}
 		})

--- a/internal/wire/datagram_frame.go
+++ b/internal/wire/datagram_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -20,29 +19,29 @@ type DatagramFrame struct {
 	Data           []byte
 }
 
-func parseDatagramFrame(r *bytes.Reader, typ uint64, _ protocol.Version) (*DatagramFrame, error) {
+func parseDatagramFrame(b []byte, typ uint64, _ protocol.Version) (*DatagramFrame, int, error) {
+	startLen := len(b)
 	f := &DatagramFrame{}
 	f.DataLenPresent = typ&0x1 > 0
 
 	var length uint64
 	if f.DataLenPresent {
 		var err error
-		len, err := quicvarint.Read(r)
+		var l int
+		length, l, err = quicvarint.Parse(b)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
-		if len > uint64(r.Len()) {
-			return nil, io.EOF
+		b = b[l:]
+		if length > uint64(len(b)) {
+			return nil, 0, io.EOF
 		}
-		length = len
 	} else {
-		length = uint64(r.Len())
+		length = uint64(len(b))
 	}
 	f.Data = make([]byte, length)
-	if _, err := io.ReadFull(r, f.Data); err != nil {
-		return nil, err
-	}
-	return f, nil
+	copy(f.Data, b)
+	return f, startLen - len(b) + int(length), nil
 }
 
 func (f *DatagramFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/datagram_frame.go
+++ b/internal/wire/datagram_frame.go
@@ -30,7 +30,7 @@ func parseDatagramFrame(b []byte, typ uint64, _ protocol.Version) (*DatagramFram
 		var l int
 		length, l, err = quicvarint.Parse(b)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, replaceUnexpectedEOF(err)
 		}
 		b = b[l:]
 		if length > uint64(len(b)) {

--- a/internal/wire/frame_parser.go
+++ b/internal/wire/frame_parser.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"reflect"
@@ -38,8 +37,6 @@ const (
 
 // The FrameParser parses QUIC frames, one by one.
 type FrameParser struct {
-	r bytes.Reader // cached bytes.Reader, so we don't have to repeatedly allocate them
-
 	ackDelayExponent  uint8
 	supportsDatagrams bool
 
@@ -51,7 +48,6 @@ type FrameParser struct {
 // NewFrameParser creates a new frame parser.
 func NewFrameParser(supportsDatagrams bool) *FrameParser {
 	return &FrameParser{
-		r:                 *bytes.NewReader(nil),
 		supportsDatagrams: supportsDatagrams,
 		ackFrame:          &AckFrame{},
 	}
@@ -60,45 +56,46 @@ func NewFrameParser(supportsDatagrams bool) *FrameParser {
 // ParseNext parses the next frame.
 // It skips PADDING frames.
 func (p *FrameParser) ParseNext(data []byte, encLevel protocol.EncryptionLevel, v protocol.Version) (int, Frame, error) {
-	startLen := len(data)
-	p.r.Reset(data)
-	frame, err := p.parseNext(&p.r, encLevel, v)
-	n := startLen - p.r.Len()
-	p.r.Reset(nil)
-	return n, frame, err
+	frame, l, err := p.parseNext(data, encLevel, v)
+	return l, frame, err
 }
 
-func (p *FrameParser) parseNext(r *bytes.Reader, encLevel protocol.EncryptionLevel, v protocol.Version) (Frame, error) {
-	for r.Len() != 0 {
-		typ, err := quicvarint.Read(r)
+func (p *FrameParser) parseNext(b []byte, encLevel protocol.EncryptionLevel, v protocol.Version) (Frame, int, error) {
+	var parsed int
+	for len(b) != 0 {
+		typ, l, err := quicvarint.Parse(b)
+		parsed += l
 		if err != nil {
-			return nil, &qerr.TransportError{
+			return nil, parsed, &qerr.TransportError{
 				ErrorCode:    qerr.FrameEncodingError,
 				ErrorMessage: err.Error(),
 			}
 		}
+		b = b[l:]
 		if typ == 0x0 { // skip PADDING frames
 			continue
 		}
 
-		f, err := p.parseFrame(r, typ, encLevel, v)
+		f, l, err := p.parseFrame(b, typ, encLevel, v)
+		parsed += l
 		if err != nil {
-			return nil, &qerr.TransportError{
+			return nil, parsed, &qerr.TransportError{
 				FrameType:    typ,
 				ErrorCode:    qerr.FrameEncodingError,
 				ErrorMessage: err.Error(),
 			}
 		}
-		return f, nil
+		return f, parsed, nil
 	}
-	return nil, nil
+	return nil, parsed, nil
 }
 
-func (p *FrameParser) parseFrame(r *bytes.Reader, typ uint64, encLevel protocol.EncryptionLevel, v protocol.Version) (Frame, error) {
+func (p *FrameParser) parseFrame(b []byte, typ uint64, encLevel protocol.EncryptionLevel, v protocol.Version) (Frame, int, error) {
 	var frame Frame
 	var err error
+	var l int
 	if typ&0xf8 == 0x8 {
-		frame, err = parseStreamFrame(r, typ, v)
+		frame, l, err = parseStreamFrame(b, typ, v)
 	} else {
 		switch typ {
 		case pingFrameType:
@@ -109,43 +106,43 @@ func (p *FrameParser) parseFrame(r *bytes.Reader, typ uint64, encLevel protocol.
 				ackDelayExponent = protocol.DefaultAckDelayExponent
 			}
 			p.ackFrame.Reset()
-			err = parseAckFrame(p.ackFrame, r, typ, ackDelayExponent, v)
+			l, err = parseAckFrame(p.ackFrame, b, typ, ackDelayExponent, v)
 			frame = p.ackFrame
 		case resetStreamFrameType:
-			frame, err = parseResetStreamFrame(r, v)
+			frame, l, err = parseResetStreamFrame(b, v)
 		case stopSendingFrameType:
-			frame, err = parseStopSendingFrame(r, v)
+			frame, l, err = parseStopSendingFrame(b, v)
 		case cryptoFrameType:
-			frame, err = parseCryptoFrame(r, v)
+			frame, l, err = parseCryptoFrame(b, v)
 		case newTokenFrameType:
-			frame, err = parseNewTokenFrame(r, v)
+			frame, l, err = parseNewTokenFrame(b, v)
 		case maxDataFrameType:
-			frame, err = parseMaxDataFrame(r, v)
+			frame, l, err = parseMaxDataFrame(b, v)
 		case maxStreamDataFrameType:
-			frame, err = parseMaxStreamDataFrame(r, v)
+			frame, l, err = parseMaxStreamDataFrame(b, v)
 		case bidiMaxStreamsFrameType, uniMaxStreamsFrameType:
-			frame, err = parseMaxStreamsFrame(r, typ, v)
+			frame, l, err = parseMaxStreamsFrame(b, typ, v)
 		case dataBlockedFrameType:
-			frame, err = parseDataBlockedFrame(r, v)
+			frame, l, err = parseDataBlockedFrame(b, v)
 		case streamDataBlockedFrameType:
-			frame, err = parseStreamDataBlockedFrame(r, v)
+			frame, l, err = parseStreamDataBlockedFrame(b, v)
 		case bidiStreamBlockedFrameType, uniStreamBlockedFrameType:
-			frame, err = parseStreamsBlockedFrame(r, typ, v)
+			frame, l, err = parseStreamsBlockedFrame(b, typ, v)
 		case newConnectionIDFrameType:
-			frame, err = parseNewConnectionIDFrame(r, v)
+			frame, l, err = parseNewConnectionIDFrame(b, v)
 		case retireConnectionIDFrameType:
-			frame, err = parseRetireConnectionIDFrame(r, v)
+			frame, l, err = parseRetireConnectionIDFrame(b, v)
 		case pathChallengeFrameType:
-			frame, err = parsePathChallengeFrame(r, v)
+			frame, l, err = parsePathChallengeFrame(b, v)
 		case pathResponseFrameType:
-			frame, err = parsePathResponseFrame(r, v)
+			frame, l, err = parsePathResponseFrame(b, v)
 		case connectionCloseFrameType, applicationCloseFrameType:
-			frame, err = parseConnectionCloseFrame(r, typ, v)
+			frame, l, err = parseConnectionCloseFrame(b, typ, v)
 		case handshakeDoneFrameType:
 			frame = &HandshakeDoneFrame{}
 		case 0x30, 0x31:
 			if p.supportsDatagrams {
-				frame, err = parseDatagramFrame(r, typ, v)
+				frame, l, err = parseDatagramFrame(b, typ, v)
 				break
 			}
 			fallthrough
@@ -154,12 +151,12 @@ func (p *FrameParser) parseFrame(r *bytes.Reader, typ uint64, encLevel protocol.
 		}
 	}
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if !p.isAllowedAtEncLevel(frame, encLevel) {
-		return nil, fmt.Errorf("%s not allowed at encryption level %s", reflect.TypeOf(frame).Elem().Name(), encLevel)
+		return nil, l, fmt.Errorf("%s not allowed at encryption level %s", reflect.TypeOf(frame).Elem().Name(), encLevel)
 	}
-	return frame, nil
+	return frame, l, nil
 }
 
 func (p *FrameParser) isAllowedAtEncLevel(f Frame, encLevel protocol.EncryptionLevel) bool {

--- a/internal/wire/frame_parser.go
+++ b/internal/wire/frame_parser.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -186,4 +187,11 @@ func (p *FrameParser) isAllowedAtEncLevel(f Frame, encLevel protocol.EncryptionL
 // This value is used to scale the ACK Delay field in the ACK frame.
 func (p *FrameParser) SetAckDelayExponent(exp uint8) {
 	p.ackDelayExponent = exp
+}
+
+func replaceUnexpectedEOF(e error) error {
+	if e == io.ErrUnexpectedEOF {
+		return io.EOF
+	}
+	return e
 }

--- a/internal/wire/max_data_frame.go
+++ b/internal/wire/max_data_frame.go
@@ -15,7 +15,7 @@ func parseMaxDataFrame(b []byte, _ protocol.Version) (*MaxDataFrame, int, error)
 	frame := &MaxDataFrame{}
 	byteOffset, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	frame.MaximumData = protocol.ByteCount(byteOffset)
 	return frame, l, nil

--- a/internal/wire/max_data_frame.go
+++ b/internal/wire/max_data_frame.go
@@ -1,8 +1,6 @@
 package wire
 
 import (
-	"bytes"
-
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
 )
@@ -13,14 +11,14 @@ type MaxDataFrame struct {
 }
 
 // parseMaxDataFrame parses a MAX_DATA frame
-func parseMaxDataFrame(r *bytes.Reader, _ protocol.Version) (*MaxDataFrame, error) {
+func parseMaxDataFrame(b []byte, _ protocol.Version) (*MaxDataFrame, int, error) {
 	frame := &MaxDataFrame{}
-	byteOffset, err := quicvarint.Read(r)
+	byteOffset, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	frame.MaximumData = protocol.ByteCount(byteOffset)
-	return frame, nil
+	return frame, l, nil
 }
 
 func (f *MaxDataFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/max_data_frame_test.go
+++ b/internal/wire/max_data_frame_test.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -15,19 +14,19 @@ var _ = Describe("MAX_DATA frame", func() {
 	Context("when parsing", func() {
 		It("accepts sample frame", func() {
 			data := encodeVarInt(0xdecafbad123456) // byte offset
-			b := bytes.NewReader(data)
-			frame, err := parseMaxDataFrame(b, protocol.Version1)
+			frame, l, err := parseMaxDataFrame(data, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.MaximumData).To(Equal(protocol.ByteCount(0xdecafbad123456)))
-			Expect(b.Len()).To(BeZero())
+			Expect(l).To(Equal(len(data)))
 		})
 
 		It("errors on EOFs", func() {
 			data := encodeVarInt(0xdecafbad1234567) // byte offset
-			_, err := parseMaxDataFrame(bytes.NewReader(data), protocol.Version1)
+			_, l, err := parseMaxDataFrame(data, protocol.Version1)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(l).To(Equal(len(data)))
 			for i := range data {
-				_, err := parseMaxDataFrame(bytes.NewReader(data[:i]), protocol.Version1)
+				_, _, err := parseMaxDataFrame(data[:i], protocol.Version1)
 				Expect(err).To(MatchError(io.EOF))
 			}
 		})

--- a/internal/wire/max_stream_data_frame.go
+++ b/internal/wire/max_stream_data_frame.go
@@ -15,12 +15,12 @@ func parseMaxStreamDataFrame(b []byte, _ protocol.Version) (*MaxStreamDataFrame,
 	startLen := len(b)
 	sid, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	offset, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 

--- a/internal/wire/max_stream_data_frame.go
+++ b/internal/wire/max_stream_data_frame.go
@@ -1,8 +1,6 @@
 package wire
 
 import (
-	"bytes"
-
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
 )
@@ -13,20 +11,23 @@ type MaxStreamDataFrame struct {
 	MaximumStreamData protocol.ByteCount
 }
 
-func parseMaxStreamDataFrame(r *bytes.Reader, _ protocol.Version) (*MaxStreamDataFrame, error) {
-	sid, err := quicvarint.Read(r)
+func parseMaxStreamDataFrame(b []byte, _ protocol.Version) (*MaxStreamDataFrame, int, error) {
+	startLen := len(b)
+	sid, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	offset, err := quicvarint.Read(r)
+	b = b[l:]
+	offset, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
+	b = b[l:]
 
 	return &MaxStreamDataFrame{
 		StreamID:          protocol.StreamID(sid),
 		MaximumStreamData: protocol.ByteCount(offset),
-	}, nil
+	}, startLen - len(b), nil
 }
 
 func (f *MaxStreamDataFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/max_stream_data_frame_test.go
+++ b/internal/wire/max_stream_data_frame_test.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -16,22 +15,21 @@ var _ = Describe("MAX_STREAM_DATA frame", func() {
 		It("accepts sample frame", func() {
 			data := encodeVarInt(0xdeadbeef)                 // Stream ID
 			data = append(data, encodeVarInt(0x12345678)...) // Offset
-			b := bytes.NewReader(data)
-			frame, err := parseMaxStreamDataFrame(b, protocol.Version1)
+			frame, l, err := parseMaxStreamDataFrame(data, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdeadbeef)))
 			Expect(frame.MaximumStreamData).To(Equal(protocol.ByteCount(0x12345678)))
-			Expect(b.Len()).To(BeZero())
+			Expect(l).To(Equal(len(data)))
 		})
 
 		It("errors on EOFs", func() {
 			data := encodeVarInt(0xdeadbeef)                 // Stream ID
 			data = append(data, encodeVarInt(0x12345678)...) // Offset
-			b := bytes.NewReader(data)
-			_, err := parseMaxStreamDataFrame(b, protocol.Version1)
+			_, l, err := parseMaxStreamDataFrame(data, protocol.Version1)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(l).To(Equal(len(data)))
 			for i := range data {
-				_, err := parseMaxStreamDataFrame(bytes.NewReader(data[:i]), protocol.Version1)
+				_, _, err := parseMaxStreamDataFrame(data[:i], protocol.Version1)
 				Expect(err).To(MatchError(io.EOF))
 			}
 		})

--- a/internal/wire/max_streams_frame.go
+++ b/internal/wire/max_streams_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -14,7 +13,7 @@ type MaxStreamsFrame struct {
 	MaxStreamNum protocol.StreamNum
 }
 
-func parseMaxStreamsFrame(r *bytes.Reader, typ uint64, _ protocol.Version) (*MaxStreamsFrame, error) {
+func parseMaxStreamsFrame(b []byte, typ uint64, _ protocol.Version) (*MaxStreamsFrame, int, error) {
 	f := &MaxStreamsFrame{}
 	switch typ {
 	case bidiMaxStreamsFrameType:
@@ -22,15 +21,15 @@ func parseMaxStreamsFrame(r *bytes.Reader, typ uint64, _ protocol.Version) (*Max
 	case uniMaxStreamsFrameType:
 		f.Type = protocol.StreamTypeUni
 	}
-	streamID, err := quicvarint.Read(r)
+	streamID, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	f.MaxStreamNum = protocol.StreamNum(streamID)
 	if f.MaxStreamNum > protocol.MaxStreamCount {
-		return nil, fmt.Errorf("%d exceeds the maximum stream count", f.MaxStreamNum)
+		return nil, 0, fmt.Errorf("%d exceeds the maximum stream count", f.MaxStreamNum)
 	}
-	return f, nil
+	return f, l, nil
 }
 
 func (f *MaxStreamsFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/max_streams_frame.go
+++ b/internal/wire/max_streams_frame.go
@@ -23,7 +23,7 @@ func parseMaxStreamsFrame(b []byte, typ uint64, _ protocol.Version) (*MaxStreams
 	}
 	streamID, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	f.MaxStreamNum = protocol.StreamNum(streamID)
 	if f.MaxStreamNum > protocol.MaxStreamCount {

--- a/internal/wire/max_streams_frame_test.go
+++ b/internal/wire/max_streams_frame_test.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
@@ -16,31 +15,30 @@ var _ = Describe("MAX_STREAMS frame", func() {
 	Context("parsing", func() {
 		It("accepts a frame for a bidirectional stream", func() {
 			data := encodeVarInt(0xdecaf)
-			b := bytes.NewReader(data)
-			f, err := parseMaxStreamsFrame(b, bidiMaxStreamsFrameType, protocol.Version1)
+			f, l, err := parseMaxStreamsFrame(data, bidiMaxStreamsFrameType, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(f.Type).To(Equal(protocol.StreamTypeBidi))
 			Expect(f.MaxStreamNum).To(BeEquivalentTo(0xdecaf))
-			Expect(b.Len()).To(BeZero())
+			Expect(l).To(Equal(len(data)))
 		})
 
 		It("accepts a frame for a bidirectional stream", func() {
 			data := encodeVarInt(0xdecaf)
-			b := bytes.NewReader(data)
-			f, err := parseMaxStreamsFrame(b, uniMaxStreamsFrameType, protocol.Version1)
+			f, l, err := parseMaxStreamsFrame(data, uniMaxStreamsFrameType, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(f.Type).To(Equal(protocol.StreamTypeUni))
 			Expect(f.MaxStreamNum).To(BeEquivalentTo(0xdecaf))
-			Expect(b.Len()).To(BeZero())
+			Expect(l).To(Equal(len(data)))
 		})
 
 		It("errors on EOFs", func() {
 			const typ = 0x1d
 			data := encodeVarInt(0xdeadbeefcafe13)
-			_, err := parseMaxStreamsFrame(bytes.NewReader(data), typ, protocol.Version1)
+			_, l, err := parseMaxStreamsFrame(data, typ, protocol.Version1)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(l).To(Equal(len(data)))
 			for i := range data {
-				_, err = parseMaxStreamsFrame(bytes.NewReader(data[:i]), typ, protocol.Version1)
+				_, _, err := parseMaxStreamsFrame(data[:i], typ, protocol.Version1)
 				Expect(err).To(MatchError(io.EOF))
 			}
 		})
@@ -55,10 +53,10 @@ var _ = Describe("MAX_STREAMS frame", func() {
 				}
 				b, err := f.Append(nil, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
-				r := bytes.NewReader(b)
-				typ, err := quicvarint.Read(r)
+				typ, l, err := quicvarint.Parse(b)
 				Expect(err).ToNot(HaveOccurred())
-				frame, err := parseMaxStreamsFrame(r, typ, protocol.Version1)
+				b = b[l:]
+				frame, _, err := parseMaxStreamsFrame(b, typ, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(frame).To(Equal(f))
 			})
@@ -70,10 +68,10 @@ var _ = Describe("MAX_STREAMS frame", func() {
 				}
 				b, err := f.Append(nil, protocol.Version1)
 				Expect(err).ToNot(HaveOccurred())
-				r := bytes.NewReader(b)
-				typ, err := quicvarint.Read(r)
+				typ, l, err := quicvarint.Parse(b)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = parseMaxStreamsFrame(r, typ, protocol.Version1)
+				b = b[l:]
+				_, _, err = parseMaxStreamsFrame(b, typ, protocol.Version1)
 				Expect(err).To(MatchError(fmt.Sprintf("%d exceeds the maximum stream count", protocol.MaxStreamCount+1)))
 			})
 		}

--- a/internal/wire/new_connection_id_frame.go
+++ b/internal/wire/new_connection_id_frame.go
@@ -21,12 +21,12 @@ func parseNewConnectionIDFrame(b []byte, _ protocol.Version) (*NewConnectionIDFr
 	startLen := len(b)
 	seq, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	ret, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	if ret > seq {

--- a/internal/wire/new_connection_id_frame.go
+++ b/internal/wire/new_connection_id_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -18,43 +17,47 @@ type NewConnectionIDFrame struct {
 	StatelessResetToken protocol.StatelessResetToken
 }
 
-func parseNewConnectionIDFrame(r *bytes.Reader, _ protocol.Version) (*NewConnectionIDFrame, error) {
-	seq, err := quicvarint.Read(r)
+func parseNewConnectionIDFrame(b []byte, _ protocol.Version) (*NewConnectionIDFrame, int, error) {
+	startLen := len(b)
+	seq, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	ret, err := quicvarint.Read(r)
+	b = b[l:]
+	ret, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
+	b = b[l:]
 	if ret > seq {
 		//nolint:stylecheck
-		return nil, fmt.Errorf("Retire Prior To value (%d) larger than Sequence Number (%d)", ret, seq)
+		return nil, 0, fmt.Errorf("Retire Prior To value (%d) larger than Sequence Number (%d)", ret, seq)
 	}
-	connIDLen, err := r.ReadByte()
-	if err != nil {
-		return nil, err
+	if len(b) == 0 {
+		return nil, 0, io.EOF
 	}
+	connIDLen := int(b[0])
+	b = b[1:]
 	if connIDLen == 0 {
-		return nil, errors.New("invalid zero-length connection ID")
+		return nil, 0, errors.New("invalid zero-length connection ID")
 	}
-	connID, err := protocol.ReadConnectionID(r, int(connIDLen))
-	if err != nil {
-		return nil, err
+	if connIDLen > protocol.MaxConnIDLen {
+		return nil, 0, protocol.ErrInvalidConnectionIDLen
+	}
+	if len(b) < connIDLen {
+		return nil, 0, io.EOF
 	}
 	frame := &NewConnectionIDFrame{
 		SequenceNumber: seq,
 		RetirePriorTo:  ret,
-		ConnectionID:   connID,
+		ConnectionID:   protocol.ParseConnectionID(b[:connIDLen]),
 	}
-	if _, err := io.ReadFull(r, frame.StatelessResetToken[:]); err != nil {
-		if err == io.ErrUnexpectedEOF {
-			return nil, io.EOF
-		}
-		return nil, err
+	b = b[connIDLen:]
+	if len(b) < len(frame.StatelessResetToken) {
+		return nil, 0, io.EOF
 	}
-
-	return frame, nil
+	copy(frame.StatelessResetToken[:], b)
+	return frame, startLen - len(b) + len(frame.StatelessResetToken), nil
 }
 
 func (f *NewConnectionIDFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/new_token_frame.go
+++ b/internal/wire/new_token_frame.go
@@ -16,7 +16,7 @@ type NewTokenFrame struct {
 func parseNewTokenFrame(b []byte, _ protocol.Version) (*NewTokenFrame, int, error) {
 	tokenLen, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	if tokenLen == 0 {

--- a/internal/wire/new_token_frame.go
+++ b/internal/wire/new_token_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"errors"
 	"io"
 
@@ -14,22 +13,21 @@ type NewTokenFrame struct {
 	Token []byte
 }
 
-func parseNewTokenFrame(r *bytes.Reader, _ protocol.Version) (*NewTokenFrame, error) {
-	tokenLen, err := quicvarint.Read(r)
+func parseNewTokenFrame(b []byte, _ protocol.Version) (*NewTokenFrame, int, error) {
+	tokenLen, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	if uint64(r.Len()) < tokenLen {
-		return nil, io.EOF
-	}
+	b = b[l:]
 	if tokenLen == 0 {
-		return nil, errors.New("token must not be empty")
+		return nil, 0, errors.New("token must not be empty")
+	}
+	if uint64(len(b)) < tokenLen {
+		return nil, 0, io.EOF
 	}
 	token := make([]byte, int(tokenLen))
-	if _, err := io.ReadFull(r, token); err != nil {
-		return nil, err
-	}
-	return &NewTokenFrame{Token: token}, nil
+	copy(token, b)
+	return &NewTokenFrame{Token: token}, l + int(tokenLen), nil
 }
 
 func (f *NewTokenFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/path_challenge_frame.go
+++ b/internal/wire/path_challenge_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -12,15 +11,13 @@ type PathChallengeFrame struct {
 	Data [8]byte
 }
 
-func parsePathChallengeFrame(r *bytes.Reader, _ protocol.Version) (*PathChallengeFrame, error) {
-	frame := &PathChallengeFrame{}
-	if _, err := io.ReadFull(r, frame.Data[:]); err != nil {
-		if err == io.ErrUnexpectedEOF {
-			return nil, io.EOF
-		}
-		return nil, err
+func parsePathChallengeFrame(b []byte, _ protocol.Version) (*PathChallengeFrame, int, error) {
+	f := &PathChallengeFrame{}
+	if len(b) < 8 {
+		return nil, 0, io.EOF
 	}
-	return frame, nil
+	copy(f.Data[:], b)
+	return f, 8, nil
 }
 
 func (f *PathChallengeFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/path_challenge_frame_test.go
+++ b/internal/wire/path_challenge_frame_test.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -13,20 +12,20 @@ import (
 var _ = Describe("PATH_CHALLENGE frame", func() {
 	Context("when parsing", func() {
 		It("accepts sample frame", func() {
-			b := bytes.NewReader([]byte{1, 2, 3, 4, 5, 6, 7, 8})
-			f, err := parsePathChallengeFrame(b, protocol.Version1)
+			b := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+			f, l, err := parsePathChallengeFrame(b, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(b.Len()).To(BeZero())
 			Expect(f.Data).To(Equal([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+			Expect(l).To(Equal(len(b)))
 		})
 
 		It("errors on EOFs", func() {
 			data := []byte{1, 2, 3, 4, 5, 6, 7, 8}
-			b := bytes.NewReader(data)
-			_, err := parsePathChallengeFrame(b, protocol.Version1)
+			_, l, err := parsePathChallengeFrame(data, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(l).To(Equal(len(data)))
 			for i := range data {
-				_, err := parsePathChallengeFrame(bytes.NewReader(data[:i]), protocol.Version1)
+				_, _, err := parsePathChallengeFrame(data[:i], protocol.Version1)
 				Expect(err).To(MatchError(io.EOF))
 			}
 		})

--- a/internal/wire/path_response_frame.go
+++ b/internal/wire/path_response_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -12,15 +11,13 @@ type PathResponseFrame struct {
 	Data [8]byte
 }
 
-func parsePathResponseFrame(r *bytes.Reader, _ protocol.Version) (*PathResponseFrame, error) {
-	frame := &PathResponseFrame{}
-	if _, err := io.ReadFull(r, frame.Data[:]); err != nil {
-		if err == io.ErrUnexpectedEOF {
-			return nil, io.EOF
-		}
-		return nil, err
+func parsePathResponseFrame(b []byte, _ protocol.Version) (*PathResponseFrame, int, error) {
+	f := &PathResponseFrame{}
+	if len(b) < 8 {
+		return nil, 0, io.EOF
 	}
-	return frame, nil
+	copy(f.Data[:], b)
+	return f, 8, nil
 }
 
 func (f *PathResponseFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/path_response_frame_test.go
+++ b/internal/wire/path_response_frame_test.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -13,19 +12,20 @@ import (
 var _ = Describe("PATH_RESPONSE frame", func() {
 	Context("when parsing", func() {
 		It("accepts sample frame", func() {
-			b := bytes.NewReader([]byte{1, 2, 3, 4, 5, 6, 7, 8})
-			f, err := parsePathResponseFrame(b, protocol.Version1)
+			b := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+			f, l, err := parsePathResponseFrame(b, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(b.Len()).To(BeZero())
 			Expect(f.Data).To(Equal([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+			Expect(l).To(Equal(len(b)))
 		})
 
 		It("errors on EOFs", func() {
 			data := []byte{1, 2, 3, 4, 5, 6, 7, 8}
-			_, err := parsePathResponseFrame(bytes.NewReader(data), protocol.Version1)
+			_, l, err := parsePathResponseFrame(data, protocol.Version1)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(l).To(Equal(len(data)))
 			for i := range data {
-				_, err := parsePathResponseFrame(bytes.NewReader(data[:i]), protocol.Version1)
+				_, _, err := parsePathResponseFrame(data[:i], protocol.Version1)
 				Expect(err).To(MatchError(io.EOF))
 			}
 		})

--- a/internal/wire/reset_stream_frame.go
+++ b/internal/wire/reset_stream_frame.go
@@ -1,8 +1,6 @@
 package wire
 
 import (
-	"bytes"
-
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/quicvarint"
@@ -15,21 +13,24 @@ type ResetStreamFrame struct {
 	FinalSize protocol.ByteCount
 }
 
-func parseResetStreamFrame(r *bytes.Reader, _ protocol.Version) (*ResetStreamFrame, error) {
+func parseResetStreamFrame(b []byte, _ protocol.Version) (*ResetStreamFrame, int, error) {
+	startLen := len(b)
 	var streamID protocol.StreamID
 	var byteOffset protocol.ByteCount
-	sid, err := quicvarint.Read(r)
+	sid, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
+	b = b[l:]
 	streamID = protocol.StreamID(sid)
-	errorCode, err := quicvarint.Read(r)
+	errorCode, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	bo, err := quicvarint.Read(r)
+	b = b[l:]
+	bo, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	byteOffset = protocol.ByteCount(bo)
 
@@ -37,7 +38,7 @@ func parseResetStreamFrame(r *bytes.Reader, _ protocol.Version) (*ResetStreamFra
 		StreamID:  streamID,
 		ErrorCode: qerr.StreamErrorCode(errorCode),
 		FinalSize: byteOffset,
-	}, nil
+	}, startLen - len(b) + l, nil
 }
 
 func (f *ResetStreamFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/reset_stream_frame.go
+++ b/internal/wire/reset_stream_frame.go
@@ -19,18 +19,18 @@ func parseResetStreamFrame(b []byte, _ protocol.Version) (*ResetStreamFrame, int
 	var byteOffset protocol.ByteCount
 	sid, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	streamID = protocol.StreamID(sid)
 	errorCode, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	bo, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	byteOffset = protocol.ByteCount(bo)
 

--- a/internal/wire/retire_connection_id_frame.go
+++ b/internal/wire/retire_connection_id_frame.go
@@ -13,7 +13,7 @@ type RetireConnectionIDFrame struct {
 func parseRetireConnectionIDFrame(b []byte, _ protocol.Version) (*RetireConnectionIDFrame, int, error) {
 	seq, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	return &RetireConnectionIDFrame{SequenceNumber: seq}, l, nil
 }

--- a/internal/wire/retire_connection_id_frame.go
+++ b/internal/wire/retire_connection_id_frame.go
@@ -1,8 +1,6 @@
 package wire
 
 import (
-	"bytes"
-
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
 )
@@ -12,12 +10,12 @@ type RetireConnectionIDFrame struct {
 	SequenceNumber uint64
 }
 
-func parseRetireConnectionIDFrame(r *bytes.Reader, _ protocol.Version) (*RetireConnectionIDFrame, error) {
-	seq, err := quicvarint.Read(r)
+func parseRetireConnectionIDFrame(b []byte, _ protocol.Version) (*RetireConnectionIDFrame, int, error) {
+	seq, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return &RetireConnectionIDFrame{SequenceNumber: seq}, nil
+	return &RetireConnectionIDFrame{SequenceNumber: seq}, l, nil
 }
 
 func (f *RetireConnectionIDFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/retire_connection_id_frame_test.go
+++ b/internal/wire/retire_connection_id_frame_test.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -14,18 +13,19 @@ var _ = Describe("NEW_CONNECTION_ID frame", func() {
 	Context("when parsing", func() {
 		It("accepts a sample frame", func() {
 			data := encodeVarInt(0xdeadbeef) // sequence number
-			b := bytes.NewReader(data)
-			frame, err := parseRetireConnectionIDFrame(b, protocol.Version1)
+			frame, l, err := parseRetireConnectionIDFrame(data, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.SequenceNumber).To(Equal(uint64(0xdeadbeef)))
+			Expect(l).To(Equal(len(data)))
 		})
 
 		It("errors on EOFs", func() {
 			data := encodeVarInt(0xdeadbeef) // sequence number
-			_, err := parseRetireConnectionIDFrame(bytes.NewReader(data), protocol.Version1)
+			_, l, err := parseRetireConnectionIDFrame(data, protocol.Version1)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(l).To(Equal(len(data)))
 			for i := range data {
-				_, err := parseRetireConnectionIDFrame(bytes.NewReader(data[:i]), protocol.Version1)
+				_, _, err := parseRetireConnectionIDFrame(data[:i], protocol.Version1)
 				Expect(err).To(MatchError(io.EOF))
 			}
 		})

--- a/internal/wire/stop_sending_frame.go
+++ b/internal/wire/stop_sending_frame.go
@@ -17,12 +17,12 @@ func parseStopSendingFrame(b []byte, _ protocol.Version) (*StopSendingFrame, int
 	startLen := len(b)
 	streamID, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	errorCode, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 

--- a/internal/wire/stop_sending_frame.go
+++ b/internal/wire/stop_sending_frame.go
@@ -1,8 +1,6 @@
 package wire
 
 import (
-	"bytes"
-
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/quicvarint"
@@ -15,20 +13,23 @@ type StopSendingFrame struct {
 }
 
 // parseStopSendingFrame parses a STOP_SENDING frame
-func parseStopSendingFrame(r *bytes.Reader, _ protocol.Version) (*StopSendingFrame, error) {
-	streamID, err := quicvarint.Read(r)
+func parseStopSendingFrame(b []byte, _ protocol.Version) (*StopSendingFrame, int, error) {
+	startLen := len(b)
+	streamID, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	errorCode, err := quicvarint.Read(r)
+	b = b[l:]
+	errorCode, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
+	b = b[l:]
 
 	return &StopSendingFrame{
 		StreamID:  protocol.StreamID(streamID),
 		ErrorCode: qerr.StreamErrorCode(errorCode),
-	}, nil
+	}, startLen - len(b), nil
 }
 
 // Length of a written frame

--- a/internal/wire/stream_data_blocked_frame.go
+++ b/internal/wire/stream_data_blocked_frame.go
@@ -1,8 +1,6 @@
 package wire
 
 import (
-	"bytes"
-
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
 )
@@ -13,20 +11,22 @@ type StreamDataBlockedFrame struct {
 	MaximumStreamData protocol.ByteCount
 }
 
-func parseStreamDataBlockedFrame(r *bytes.Reader, _ protocol.Version) (*StreamDataBlockedFrame, error) {
-	sid, err := quicvarint.Read(r)
+func parseStreamDataBlockedFrame(b []byte, _ protocol.Version) (*StreamDataBlockedFrame, int, error) {
+	startLen := len(b)
+	sid, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	offset, err := quicvarint.Read(r)
+	b = b[l:]
+	offset, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	return &StreamDataBlockedFrame{
 		StreamID:          protocol.StreamID(sid),
 		MaximumStreamData: protocol.ByteCount(offset),
-	}, nil
+	}, startLen - len(b) + l, nil
 }
 
 func (f *StreamDataBlockedFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {

--- a/internal/wire/stream_data_blocked_frame.go
+++ b/internal/wire/stream_data_blocked_frame.go
@@ -15,12 +15,12 @@ func parseStreamDataBlockedFrame(b []byte, _ protocol.Version) (*StreamDataBlock
 	startLen := len(b)
 	sid, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	offset, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 
 	return &StreamDataBlockedFrame{

--- a/internal/wire/stream_data_blocked_frame_test.go
+++ b/internal/wire/stream_data_blocked_frame_test.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -16,21 +15,21 @@ var _ = Describe("STREAM_DATA_BLOCKED frame", func() {
 		It("accepts sample frame", func() {
 			data := encodeVarInt(0xdeadbeef)                 // stream ID
 			data = append(data, encodeVarInt(0xdecafbad)...) // offset
-			b := bytes.NewReader(data)
-			frame, err := parseStreamDataBlockedFrame(b, protocol.Version1)
+			frame, l, err := parseStreamDataBlockedFrame(data, protocol.Version1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame.StreamID).To(Equal(protocol.StreamID(0xdeadbeef)))
 			Expect(frame.MaximumStreamData).To(Equal(protocol.ByteCount(0xdecafbad)))
-			Expect(b.Len()).To(BeZero())
+			Expect(l).To(Equal(len(data)))
 		})
 
 		It("errors on EOFs", func() {
 			data := encodeVarInt(0xdeadbeef)
 			data = append(data, encodeVarInt(0xc0010ff)...)
-			_, err := parseStreamDataBlockedFrame(bytes.NewReader(data), protocol.Version1)
+			_, l, err := parseStreamDataBlockedFrame(data, protocol.Version1)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(l).To(Equal(len(data)))
 			for i := range data {
-				_, err := parseStreamDataBlockedFrame(bytes.NewReader(data[:i]), protocol.Version1)
+				_, _, err := parseStreamDataBlockedFrame(data[:i], protocol.Version1)
 				Expect(err).To(MatchError(io.EOF))
 			}
 		})

--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -27,14 +27,14 @@ func parseStreamFrame(b []byte, typ uint64, _ protocol.Version) (*StreamFrame, i
 
 	streamID, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	b = b[l:]
 	var offset uint64
 	if hasOffset {
 		offset, l, err = quicvarint.Parse(b)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, replaceUnexpectedEOF(err)
 		}
 		b = b[l:]
 	}
@@ -45,7 +45,7 @@ func parseStreamFrame(b []byte, typ uint64, _ protocol.Version) (*StreamFrame, i
 		var l int
 		dataLen, l, err = quicvarint.Parse(b)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, replaceUnexpectedEOF(err)
 		}
 		b = b[l:]
 		if dataLen > uint64(len(b)) {

--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"errors"
 	"io"
 
@@ -20,33 +19,41 @@ type StreamFrame struct {
 	fromPool bool
 }
 
-func parseStreamFrame(r *bytes.Reader, typ uint64, _ protocol.Version) (*StreamFrame, error) {
+func parseStreamFrame(b []byte, typ uint64, _ protocol.Version) (*StreamFrame, int, error) {
+	startLen := len(b)
 	hasOffset := typ&0b100 > 0
 	fin := typ&0b1 > 0
 	hasDataLen := typ&0b10 > 0
 
-	streamID, err := quicvarint.Read(r)
+	streamID, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
+	b = b[l:]
 	var offset uint64
 	if hasOffset {
-		offset, err = quicvarint.Read(r)
+		offset, l, err = quicvarint.Parse(b)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
+		b = b[l:]
 	}
 
 	var dataLen uint64
 	if hasDataLen {
 		var err error
-		dataLen, err = quicvarint.Read(r)
+		var l int
+		dataLen, l, err = quicvarint.Parse(b)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
+		}
+		b = b[l:]
+		if dataLen > uint64(len(b)) {
+			return nil, 0, io.EOF
 		}
 	} else {
 		// The rest of the packet is data
-		dataLen = uint64(r.Len())
+		dataLen = uint64(len(b))
 	}
 
 	var frame *StreamFrame
@@ -57,7 +64,7 @@ func parseStreamFrame(r *bytes.Reader, typ uint64, _ protocol.Version) (*StreamF
 		// The STREAM frame can't be larger than the StreamFrame we obtained from the buffer,
 		// since those StreamFrames have a buffer length of the maximum packet size.
 		if dataLen > uint64(cap(frame.Data)) {
-			return nil, io.EOF
+			return nil, 0, io.EOF
 		}
 		frame.Data = frame.Data[:dataLen]
 	}
@@ -68,17 +75,14 @@ func parseStreamFrame(r *bytes.Reader, typ uint64, _ protocol.Version) (*StreamF
 	frame.DataLenPresent = hasDataLen
 
 	if dataLen != 0 {
-		if _, err := io.ReadFull(r, frame.Data); err != nil {
-			return nil, err
-		}
+		copy(frame.Data, b)
 	}
 	if frame.Offset+frame.DataLen() > protocol.MaxByteCount {
-		return nil, errors.New("stream data overflows maximum offset")
+		return nil, 0, errors.New("stream data overflows maximum offset")
 	}
-	return frame, nil
+	return frame, startLen - len(b) + int(dataLen), nil
 }
 
-// Write writes a STREAM frame
 func (f *StreamFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {
 	if len(f.Data) == 0 && !f.Fin {
 		return nil, errors.New("StreamFrame: attempting to write empty frame without FIN")

--- a/internal/wire/streams_blocked_frame.go
+++ b/internal/wire/streams_blocked_frame.go
@@ -23,7 +23,7 @@ func parseStreamsBlockedFrame(b []byte, typ uint64, _ protocol.Version) (*Stream
 	}
 	streamLimit, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, replaceUnexpectedEOF(err)
 	}
 	f.StreamLimit = protocol.StreamNum(streamLimit)
 	if f.StreamLimit > protocol.MaxStreamCount {

--- a/internal/wire/streams_blocked_frame.go
+++ b/internal/wire/streams_blocked_frame.go
@@ -1,7 +1,6 @@
 package wire
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -14,7 +13,7 @@ type StreamsBlockedFrame struct {
 	StreamLimit protocol.StreamNum
 }
 
-func parseStreamsBlockedFrame(r *bytes.Reader, typ uint64, _ protocol.Version) (*StreamsBlockedFrame, error) {
+func parseStreamsBlockedFrame(b []byte, typ uint64, _ protocol.Version) (*StreamsBlockedFrame, int, error) {
 	f := &StreamsBlockedFrame{}
 	switch typ {
 	case bidiStreamBlockedFrameType:
@@ -22,15 +21,15 @@ func parseStreamsBlockedFrame(r *bytes.Reader, typ uint64, _ protocol.Version) (
 	case uniStreamBlockedFrameType:
 		f.Type = protocol.StreamTypeUni
 	}
-	streamLimit, err := quicvarint.Read(r)
+	streamLimit, l, err := quicvarint.Parse(b)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	f.StreamLimit = protocol.StreamNum(streamLimit)
 	if f.StreamLimit > protocol.MaxStreamCount {
-		return nil, fmt.Errorf("%d exceeds the maximum stream count", f.StreamLimit)
+		return nil, 0, fmt.Errorf("%d exceeds the maximum stream count", f.StreamLimit)
 	}
-	return f, nil
+	return f, l, nil
 }
 
 func (f *StreamsBlockedFrame) Append(b []byte, _ protocol.Version) ([]byte, error) {


### PR DESCRIPTION
```
name                  old time/op    new time/op    delta
ParseStreamAndACK-16     290ns ± 6%     244ns ± 4%  -15.80%  (p=0.000 n=9+10)
ParseOtherFrames-16      217ns ± 3%     171ns ± 3%  -21.43%  (p=0.000 n=9+10)

name                  old alloc/op   new alloc/op   delta
ParseStreamAndACK-16    1.58kB ± 0%    1.58kB ± 0%     ~     (all equal)
ParseOtherFrames-16       224B ± 0%      224B ± 0%     ~     (all equal)

name                  old allocs/op  new allocs/op  delta
ParseStreamAndACK-16      2.00 ± 0%      2.00 ± 0%     ~     (all equal)
ParseOtherFrames-16       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
```