### PR TITLE
utils: speed up timer by embedding the time.Timer

### DIFF
--- a/internal/utils/timer.go
+++ b/internal/utils/timer.go
@@ -7,14 +7,14 @@ import (
 
 // A Timer wrapper that behaves correctly when resetting
 type Timer struct {
-	t        *time.Timer
+	t        time.Timer
 	read     bool
 	deadline time.Time
 }
 
 // NewTimer creates a new timer that is not set
 func NewTimer() *Timer {
-	return &Timer{t: time.NewTimer(time.Duration(math.MaxInt64))}
+	return &Timer{t: *time.NewTimer(time.Duration(math.MaxInt64))}
 }
 
 // Chan returns the channel of the wrapped timer

--- a/internal/utils/timer_test.go
+++ b/internal/utils/timer_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -93,3 +94,14 @@ var _ = Describe("Timer", func() {
 		Consistently(t.Chan()).ShouldNot(Receive())
 	})
 })
+
+func BenchmarkTimer(b *testing.B) {
+	t := NewTimer()
+	defer t.Stop()
+	for i := 0; i < b.N; i++ {
+		t.Reset(time.Now().Add(50 * time.Millisecond))
+		if i%2 == 0 {
+			t.SetRead()
+		}
+	}
+}


### PR DESCRIPTION
Note a huge speedup, but we're resetting timers _a lot_ since we're using it to pace packets.
```
name      old time/op  new time/op  delta
Timer-16  77.9ns ± 4%  75.8ns ± 3%  -2.59%  (p=0.000 n=50+47)
```