### PR TITLE
initialize the MTU discoverer when processing the transport parameters

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -1439,15 +1439,15 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().SentPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 			sph.EXPECT().ECNMode(true).Return(protocol.ECT1).Times(4)
 			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(3)
-			payload1 := make([]byte, conn.mtuDiscoverer.CurrentSize())
+			payload1 := make([]byte, conn.maxPacketSize())
 			rand.Read(payload1)
-			payload2 := make([]byte, conn.mtuDiscoverer.CurrentSize())
+			payload2 := make([]byte, conn.maxPacketSize())
 			rand.Read(payload2)
 			expectAppendPacket(packer, shortHeaderPacket{PacketNumber: 10}, payload1)
 			expectAppendPacket(packer, shortHeaderPacket{PacketNumber: 11}, payload2)
 			packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any()).Return(shortHeaderPacket{}, errNothingToPack)
 			sender.EXPECT().WouldBlock().AnyTimes()
-			sender.EXPECT().Send(gomock.Any(), uint16(conn.mtuDiscoverer.CurrentSize()), gomock.Any()).Do(func(b *packetBuffer, _ uint16, _ protocol.ECN) {
+			sender.EXPECT().Send(gomock.Any(), uint16(conn.maxPacketSize()), gomock.Any()).Do(func(b *packetBuffer, _ uint16, _ protocol.ECN) {
 				Expect(b.Data).To(Equal(append(payload1, payload2...)))
 			})
 			go func() {
@@ -1466,20 +1466,20 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAny).Times(3)
 			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone)
 			sph.EXPECT().ECNMode(true).Times(4)
-			payload1 := make([]byte, conn.mtuDiscoverer.CurrentSize())
+			payload1 := make([]byte, conn.maxPacketSize())
 			rand.Read(payload1)
-			payload2 := make([]byte, conn.mtuDiscoverer.CurrentSize()-1)
+			payload2 := make([]byte, conn.maxPacketSize()-1)
 			rand.Read(payload2)
-			payload3 := make([]byte, conn.mtuDiscoverer.CurrentSize())
+			payload3 := make([]byte, conn.maxPacketSize())
 			rand.Read(payload3)
 			expectAppendPacket(packer, shortHeaderPacket{PacketNumber: 10}, payload1)
 			expectAppendPacket(packer, shortHeaderPacket{PacketNumber: 11}, payload2)
 			expectAppendPacket(packer, shortHeaderPacket{PacketNumber: 12}, payload3)
 			sender.EXPECT().WouldBlock().AnyTimes()
-			sender.EXPECT().Send(gomock.Any(), uint16(conn.mtuDiscoverer.CurrentSize()), gomock.Any()).Do(func(b *packetBuffer, _ uint16, _ protocol.ECN) {
+			sender.EXPECT().Send(gomock.Any(), uint16(conn.maxPacketSize()), gomock.Any()).Do(func(b *packetBuffer, _ uint16, _ protocol.ECN) {
 				Expect(b.Data).To(Equal(append(payload1, payload2...)))
 			})
-			sender.EXPECT().Send(gomock.Any(), uint16(conn.mtuDiscoverer.CurrentSize()), gomock.Any()).Do(func(b *packetBuffer, _ uint16, _ protocol.ECN) {
+			sender.EXPECT().Send(gomock.Any(), uint16(conn.maxPacketSize()), gomock.Any()).Do(func(b *packetBuffer, _ uint16, _ protocol.ECN) {
 				Expect(b.Data).To(Equal(payload3))
 			})
 			go func() {
@@ -1499,20 +1499,20 @@ var _ = Describe("Connection", func() {
 			sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendNone)
 			sph.EXPECT().ECNMode(true).Return(protocol.ECT1).Times(2)
 			sph.EXPECT().ECNMode(true).Return(protocol.ECT0).Times(2)
-			payload1 := make([]byte, conn.mtuDiscoverer.CurrentSize())
+			payload1 := make([]byte, conn.maxPacketSize())
 			rand.Read(payload1)
-			payload2 := make([]byte, conn.mtuDiscoverer.CurrentSize())
+			payload2 := make([]byte, conn.maxPacketSize())
 			rand.Read(payload2)
-			payload3 := make([]byte, conn.mtuDiscoverer.CurrentSize())
+			payload3 := make([]byte, conn.maxPacketSize())
 			rand.Read(payload3)
 			expectAppendPacket(packer, shortHeaderPacket{PacketNumber: 10}, payload1)
 			expectAppendPacket(packer, shortHeaderPacket{PacketNumber: 11}, payload2)
 			expectAppendPacket(packer, shortHeaderPacket{PacketNumber: 11}, payload3)
 			sender.EXPECT().WouldBlock().AnyTimes()
-			sender.EXPECT().Send(gomock.Any(), uint16(conn.mtuDiscoverer.CurrentSize()), gomock.Any()).Do(func(b *packetBuffer, _ uint16, _ protocol.ECN) {
+			sender.EXPECT().Send(gomock.Any(), uint16(conn.maxPacketSize()), gomock.Any()).Do(func(b *packetBuffer, _ uint16, _ protocol.ECN) {
 				Expect(b.Data).To(Equal(append(payload1, payload2...)))
 			})
-			sender.EXPECT().Send(gomock.Any(), uint16(conn.mtuDiscoverer.CurrentSize()), gomock.Any()).Do(func(b *packetBuffer, _ uint16, _ protocol.ECN) {
+			sender.EXPECT().Send(gomock.Any(), uint16(conn.maxPacketSize()), gomock.Any()).Do(func(b *packetBuffer, _ uint16, _ protocol.ECN) {
 				Expect(b.Data).To(Equal(payload3))
 			})
 			go func() {
@@ -2504,7 +2504,6 @@ var _ = Describe("Connection", func() {
 			Expect(err).To(BeAssignableToTypeOf(&DatagramTooLargeError{}))
 			derr := err.(*DatagramTooLargeError)
 			Expect(derr.MaxDatagramPayloadSize).To(BeNumerically("<", 1000))
-			fmt.Println(derr.MaxDatagramPayloadSize)
 			Expect(conn.SendDatagram(make([]byte, derr.MaxDatagramPayloadSize))).To(Succeed())
 		})
 

--- a/mock_mtu_discoverer_test.go
+++ b/mock_mtu_discoverer_test.go
@@ -157,15 +157,15 @@ func (c *MockMTUDiscovererShouldSendProbeCall) DoAndReturn(f func(time.Time) boo
 }
 
 // Start mocks base method.
-func (m *MockMTUDiscoverer) Start(arg0 protocol.ByteCount) {
+func (m *MockMTUDiscoverer) Start() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start", arg0)
+	m.ctrl.Call(m, "Start")
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockMTUDiscovererMockRecorder) Start(arg0 any) *MockMTUDiscovererStartCall {
+func (mr *MockMTUDiscovererMockRecorder) Start() *MockMTUDiscovererStartCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockMTUDiscoverer)(nil).Start), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockMTUDiscoverer)(nil).Start))
 	return &MockMTUDiscovererStartCall{Call: call}
 }
 
@@ -181,13 +181,13 @@ func (c *MockMTUDiscovererStartCall) Return() *MockMTUDiscovererStartCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMTUDiscovererStartCall) Do(f func(protocol.ByteCount)) *MockMTUDiscovererStartCall {
+func (c *MockMTUDiscovererStartCall) Do(f func()) *MockMTUDiscovererStartCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMTUDiscovererStartCall) DoAndReturn(f func(protocol.ByteCount)) *MockMTUDiscovererStartCall {
+func (c *MockMTUDiscovererStartCall) DoAndReturn(f func()) *MockMTUDiscovererStartCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mtu_discoverer_test.go
+++ b/mtu_discoverer_test.go
@@ -29,8 +29,8 @@ var _ = Describe("MTU Discoverer", func() {
 		rttStats = &utils.RTTStats{}
 		rttStats.SetInitialRTT(rtt)
 		Expect(rttStats.SmoothedRTT()).To(Equal(rtt))
-		d = newMTUDiscoverer(rttStats, startMTU, func(s protocol.ByteCount) { discoveredMTU = s })
-		d.Start(maxMTU)
+		d = newMTUDiscoverer(rttStats, startMTU, maxMTU, func(s protocol.ByteCount) { discoveredMTU = s })
+		d.Start()
 		now = time.Now()
 	})
 
@@ -78,7 +78,7 @@ var _ = Describe("MTU Discoverer", func() {
 	})
 
 	It("doesn't do discovery before being started", func() {
-		d := newMTUDiscoverer(rttStats, startMTU, func(s protocol.ByteCount) {})
+		d := newMTUDiscoverer(rttStats, startMTU, protocol.MaxByteCount, func(s protocol.ByteCount) {})
 		for i := 0; i < 5; i++ {
 			Expect(d.ShouldSendProbe(time.Now())).To(BeFalse())
 		}
@@ -90,8 +90,8 @@ var _ = Describe("MTU Discoverer", func() {
 		for i := 0; i < rep; i++ {
 			maxMTU := protocol.ByteCount(rand.Intn(int(3000-startMTU))) + startMTU + 1
 			currentMTU := startMTU
-			d := newMTUDiscoverer(rttStats, startMTU, func(s protocol.ByteCount) { currentMTU = s })
-			d.Start(maxMTU)
+			d := newMTUDiscoverer(rttStats, startMTU, maxMTU, func(s protocol.ByteCount) { currentMTU = s })
+			d.Start()
 			now := time.Now()
 			realMTU := protocol.ByteCount(rand.Intn(int(maxMTU-startMTU))) + startMTU
 			t := now.Add(mtuProbeDelay * rtt)


### PR DESCRIPTION
On the client side, we always use the configured packet size. This comes with the risk of failing the handshake if the path doesn't support this MTU. If the server sends a max_udp_payload_size that's smaller than this size, we can safely ignore this: Obviously, the server still processed the (fully padded) Initial packet, despite claiming that it wouldn't do so.

On the server side, there's no downside to using 1200 bytes until we received the client's transport parameters:
* If the first packet didn't contain the entire ClientHello, all we can do is ACK that packet. We don't need a lot of bytes for that.
* If it did, we will have processed the transport parameters and initialized the MTU discoverer.