### PR TITLE
logging / qlog: add support for DPLPMTUD

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1783,6 +1783,7 @@ func (s *connection) applyTransportParameters() {
 		protocol.ByteCount(s.config.InitialPacketSize),
 		maxPacketSize,
 		s.onMTUIncreased,
+		s.tracer,
 	)
 }
 

--- a/internal/mocks/logging/connection_tracer.go
+++ b/internal/mocks/logging/connection_tracer.go
@@ -68,6 +68,9 @@ func NewMockConnectionTracer(ctrl *gomock.Controller) (*logging.ConnectionTracer
 		LostPacket: func(encLevel logging.EncryptionLevel, pn logging.PacketNumber, reason logging.PacketLossReason) {
 			t.LostPacket(encLevel, pn, reason)
 		},
+		UpdatedMTU: func(mtu logging.ByteCount, done bool) {
+			t.UpdatedMTU(mtu, done)
+		},
 		UpdatedCongestionState: func(state logging.CongestionState) {
 			t.UpdatedCongestionState(state)
 		},

--- a/internal/mocks/logging/internal/connection_tracer.go
+++ b/internal/mocks/logging/internal/connection_tracer.go
@@ -1052,6 +1052,42 @@ func (c *MockConnectionTracerUpdatedKeyFromTLSCall) DoAndReturn(f func(protocol.
 	return c
 }
 
+// UpdatedMTU mocks base method.
+func (m *MockConnectionTracer) UpdatedMTU(arg0 protocol.ByteCount, arg1 bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdatedMTU", arg0, arg1)
+}
+
+// UpdatedMTU indicates an expected call of UpdatedMTU.
+func (mr *MockConnectionTracerMockRecorder) UpdatedMTU(arg0, arg1 any) *MockConnectionTracerUpdatedMTUCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatedMTU", reflect.TypeOf((*MockConnectionTracer)(nil).UpdatedMTU), arg0, arg1)
+	return &MockConnectionTracerUpdatedMTUCall{Call: call}
+}
+
+// MockConnectionTracerUpdatedMTUCall wrap *gomock.Call
+type MockConnectionTracerUpdatedMTUCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockConnectionTracerUpdatedMTUCall) Return() *MockConnectionTracerUpdatedMTUCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockConnectionTracerUpdatedMTUCall) Do(f func(protocol.ByteCount, bool)) *MockConnectionTracerUpdatedMTUCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockConnectionTracerUpdatedMTUCall) DoAndReturn(f func(protocol.ByteCount, bool)) *MockConnectionTracerUpdatedMTUCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UpdatedMetrics mocks base method.
 func (m *MockConnectionTracer) UpdatedMetrics(arg0 *utils.RTTStats, arg1, arg2 protocol.ByteCount, arg3 int) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/logging/mockgen.go
+++ b/internal/mocks/logging/mockgen.go
@@ -34,6 +34,7 @@ type ConnectionTracer interface {
 	ReceivedShortHeaderPacket(*logging.ShortHeader, logging.ByteCount, logging.ECN, []logging.Frame)
 	BufferedPacket(logging.PacketType, logging.ByteCount)
 	DroppedPacket(logging.PacketType, logging.PacketNumber, logging.ByteCount, logging.PacketDropReason)
+	UpdatedMTU(mtu logging.ByteCount, done bool)
 	UpdatedMetrics(rttStats *logging.RTTStats, cwnd, bytesInFlight logging.ByteCount, packetsInFlight int)
 	AcknowledgedPacket(logging.EncryptionLevel, logging.PacketNumber)
 	LostPacket(logging.EncryptionLevel, logging.PacketNumber, logging.PacketLossReason)

--- a/logging/connection_tracer.go
+++ b/logging/connection_tracer.go
@@ -24,6 +24,7 @@ type ConnectionTracer struct {
 	UpdatedMetrics                   func(rttStats *RTTStats, cwnd, bytesInFlight ByteCount, packetsInFlight int)
 	AcknowledgedPacket               func(EncryptionLevel, PacketNumber)
 	LostPacket                       func(EncryptionLevel, PacketNumber, PacketLossReason)
+	UpdatedMTU                       func(mtu ByteCount, done bool)
 	UpdatedCongestionState           func(CongestionState)
 	UpdatedPTOCount                  func(value uint32)
 	UpdatedKeyFromTLS                func(EncryptionLevel, Perspective)
@@ -165,6 +166,13 @@ func NewMultiplexedConnectionTracer(tracers ...*ConnectionTracer) *ConnectionTra
 			for _, t := range tracers {
 				if t.LostPacket != nil {
 					t.LostPacket(encLevel, pn, reason)
+				}
+			}
+		},
+		UpdatedMTU: func(mtu ByteCount, done bool) {
+			for _, t := range tracers {
+				if t.UpdatedMTU != nil {
+					t.UpdatedMTU(mtu, done)
 				}
 			}
 		},

--- a/logging/multiplex_test.go
+++ b/logging/multiplex_test.go
@@ -201,6 +201,12 @@ var _ = Describe("Tracing", func() {
 			tracer.DroppedPacket(PacketTypeInitial, 42, 1337, PacketDropHeaderParseError)
 		})
 
+		It("traces the UpdatedMTU event", func() {
+			tr1.EXPECT().UpdatedMTU(ByteCount(1337), true)
+			tr2.EXPECT().UpdatedMTU(ByteCount(1337), true)
+			tracer.UpdatedMTU(1337, true)
+		})
+
 		It("traces the UpdatedCongestionState event", func() {
 			tr1.EXPECT().UpdatedCongestionState(CongestionStateRecovery)
 			tr2.EXPECT().UpdatedCongestionState(CongestionStateRecovery)

--- a/mtu_discoverer.go
+++ b/mtu_discoverer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/internal/wire"
+	"github.com/quic-go/quic-go/logging"
 )
 
 type mtuDiscoverer interface {
@@ -34,17 +35,25 @@ type mtuFinder struct {
 	inFlight protocol.ByteCount // the size of the probe packet currently in flight. InvalidByteCount if none is in flight
 	current  protocol.ByteCount
 	max      protocol.ByteCount // the maximum value, as advertised by the peer (or our maximum size buffer)
+
+	tracer *logging.ConnectionTracer
 }
 
 var _ mtuDiscoverer = &mtuFinder{}
 
-func newMTUDiscoverer(rttStats *utils.RTTStats, start, max protocol.ByteCount, mtuIncreased func(protocol.ByteCount)) *mtuFinder {
+func newMTUDiscoverer(
+	rttStats *utils.RTTStats,
+	start, max protocol.ByteCount,
+	mtuIncreased func(protocol.ByteCount),
+	tracer *logging.ConnectionTracer,
+) *mtuFinder {
 	return &mtuFinder{
 		inFlight:     protocol.InvalidByteCount,
 		current:      start,
 		max:          max,
 		rttStats:     rttStats,
 		mtuIncreased: mtuIncreased,
+		tracer:       tracer,
 	}
 }
 
@@ -79,7 +88,7 @@ func (f *mtuFinder) GetPing() (ackhandler.Frame, protocol.ByteCount) {
 	f.inFlight = size
 	return ackhandler.Frame{
 		Frame:   &wire.PingFrame{},
-		Handler: (*mtuFinderAckHandler)(f),
+		Handler: &mtuFinderAckHandler{f},
 	}, size
 }
 
@@ -87,7 +96,9 @@ func (f *mtuFinder) CurrentSize() protocol.ByteCount {
 	return f.current
 }
 
-type mtuFinderAckHandler mtuFinder
+type mtuFinderAckHandler struct {
+	*mtuFinder
+}
 
 var _ ackhandler.FrameHandler = &mtuFinderAckHandler{}
 
@@ -98,6 +109,9 @@ func (h *mtuFinderAckHandler) OnAcked(wire.Frame) {
 	}
 	h.inFlight = protocol.InvalidByteCount
 	h.current = size
+	if h.tracer != nil && h.tracer.UpdatedMTU != nil {
+		h.tracer.UpdatedMTU(size, h.done())
+	}
 	h.mtuIncreased(size)
 }
 

--- a/mtu_discoverer_test.go
+++ b/mtu_discoverer_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/logging"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,7 +30,13 @@ var _ = Describe("MTU Discoverer", func() {
 		rttStats = &utils.RTTStats{}
 		rttStats.SetInitialRTT(rtt)
 		Expect(rttStats.SmoothedRTT()).To(Equal(rtt))
-		d = newMTUDiscoverer(rttStats, startMTU, maxMTU, func(s protocol.ByteCount) { discoveredMTU = s })
+		d = newMTUDiscoverer(
+			rttStats,
+			startMTU,
+			maxMTU,
+			func(s protocol.ByteCount) { discoveredMTU = s },
+			nil,
+		)
 		d.Start()
 		now = time.Now()
 	})
@@ -78,7 +85,7 @@ var _ = Describe("MTU Discoverer", func() {
 	})
 
 	It("doesn't do discovery before being started", func() {
-		d := newMTUDiscoverer(rttStats, startMTU, protocol.MaxByteCount, func(s protocol.ByteCount) {})
+		d := newMTUDiscoverer(rttStats, startMTU, protocol.MaxByteCount, func(s protocol.ByteCount) {}, nil)
 		for i := 0; i < 5; i++ {
 			Expect(d.ShouldSendProbe(time.Now())).To(BeFalse())
 		}
@@ -90,7 +97,20 @@ var _ = Describe("MTU Discoverer", func() {
 		for i := 0; i < rep; i++ {
 			maxMTU := protocol.ByteCount(rand.Intn(int(3000-startMTU))) + startMTU + 1
 			currentMTU := startMTU
-			d := newMTUDiscoverer(rttStats, startMTU, maxMTU, func(s protocol.ByteCount) { currentMTU = s })
+			var tracedMTU protocol.ByteCount
+			var tracerDone bool
+			d := newMTUDiscoverer(
+				rttStats,
+				startMTU,
+				maxMTU,
+				func(s protocol.ByteCount) { currentMTU = s },
+				&logging.ConnectionTracer{
+					UpdatedMTU: func(mtu logging.ByteCount, done bool) {
+						tracedMTU = mtu
+						tracerDone = done
+					},
+				},
+			)
 			d.Start()
 			now := time.Now()
 			realMTU := protocol.ByteCount(rand.Intn(int(maxMTU-startMTU))) + startMTU
@@ -113,6 +133,10 @@ var _ = Describe("MTU Discoverer", func() {
 			diff := realMTU - currentMTU
 			Expect(diff).To(BeNumerically(">=", 0))
 			maxDiff = max(maxDiff, diff)
+			if maxMTU > currentMTU+maxMTU {
+				Expect(tracedMTU).To(Equal(currentMTU))
+				Expect(tracerDone).To(BeTrue())
+			}
 		}
 		Expect(maxDiff).To(BeEquivalentTo(maxMTUDiff))
 	})

--- a/qlog/connection_tracer.go
+++ b/qlog/connection_tracer.go
@@ -76,6 +76,9 @@ func NewConnectionTracer(w io.WriteCloser, p logging.Perspective, odcid protocol
 		LostPacket: func(encLevel protocol.EncryptionLevel, pn protocol.PacketNumber, lossReason logging.PacketLossReason) {
 			t.LostPacket(encLevel, pn, lossReason)
 		},
+		UpdatedMTU: func(mtu logging.ByteCount, done bool) {
+			t.UpdatedMTU(mtu, done)
+		},
 		UpdatedCongestionState: func(state logging.CongestionState) {
 			t.UpdatedCongestionState(state)
 		},
@@ -365,6 +368,10 @@ func (t *connectionTracer) LostPacket(encLevel protocol.EncryptionLevel, pn prot
 		PacketNumber: pn,
 		Trigger:      packetLossReason(lossReason),
 	})
+}
+
+func (t *connectionTracer) UpdatedMTU(mtu protocol.ByteCount, done bool) {
+	t.recordEvent(time.Now(), &eventMTUUpdated{mtu: mtu, done: done})
 }
 
 func (t *connectionTracer) UpdatedCongestionState(state logging.CongestionState) {

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -294,6 +294,20 @@ type metrics struct {
 	PacketsInFlight  int
 }
 
+type eventMTUUpdated struct {
+	mtu  protocol.ByteCount
+	done bool
+}
+
+func (e eventMTUUpdated) Category() category { return categoryRecovery }
+func (e eventMTUUpdated) Name() string       { return "mtu_updated" }
+func (e eventMTUUpdated) IsNil() bool        { return false }
+
+func (e eventMTUUpdated) MarshalJSONObject(enc *gojay.Encoder) {
+	enc.Uint64Key("mtu", uint64(e.mtu))
+	enc.BoolKey("done", e.done)
+}
+
 type eventMetricsUpdated struct {
 	Last    *metrics
 	Current *metrics


### PR DESCRIPTION
As defined in https://github.com/quicwg/qlog/pull/210/. This PR doesn't add support for the `is_mtu_probe_packet` on the `TransportPacketSent` event.