### PR TITLE
fix(http3): handle streamStateSendAndReceiveClosed in onStreamStateChange

### DIFF
--- a/http3/conn.go
+++ b/http3/conn.go
@@ -85,6 +85,8 @@ func (c *connection) onStreamStateChange(id quic.StreamID, state streamState, e 
 		isDone = d.SetReceiveError(e)
 	case streamStateSendClosed:
 		isDone = d.SetSendError(e)
+	case streamStateSendAndReceiveClosed:
+		isDone = true
 	default:
 		return
 	}

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -70,29 +70,11 @@ func newConnection(
 	return c
 }
 
-func (c *connection) onStreamStateChange(id quic.StreamID, state streamState, e error) {
+func (c *connection) clearStream(id quic.StreamID) {
 	c.streamMx.Lock()
 	defer c.streamMx.Unlock()
 
-	d, ok := c.streams[id]
-	if !ok { // should never happen
-		return
-	}
-	var isDone bool
-	//nolint:exhaustive // These are all the cases we care about.
-	switch state {
-	case streamStateReceiveClosed:
-		isDone = d.SetReceiveError(e)
-	case streamStateSendClosed:
-		isDone = d.SetSendError(e)
-	case streamStateSendAndReceiveClosed:
-		isDone = true
-	default:
-		return
-	}
-	if isDone {
-		delete(c.streams, id)
-	}
+	delete(c.streams, id)
 }
 
 func (c *connection) openRequestStream(
@@ -110,7 +92,7 @@ func (c *connection) openRequestStream(
 	c.streamMx.Lock()
 	c.streams[str.StreamID()] = datagrams
 	c.streamMx.Unlock()
-	qstr := newStateTrackingStream(str, func(s streamState, e error) { c.onStreamStateChange(str.StreamID(), s, e) })
+	qstr := newStateTrackingStream(str, c, datagrams)
 	hstr := newStream(qstr, c, datagrams)
 	return newRequestStream(hstr, requestWriter, reqDone, c.decoder, disableCompression, maxHeaderBytes), nil
 }
@@ -126,7 +108,7 @@ func (c *connection) acceptStream(ctx context.Context) (quic.Stream, *datagramme
 		c.streamMx.Lock()
 		c.streams[strID] = datagrams
 		c.streamMx.Unlock()
-		str = newStateTrackingStream(str, func(s streamState, e error) { c.onStreamStateChange(strID, s, e) })
+		str = newStateTrackingStream(str, c, datagrams)
 	}
 	return str, datagrams, nil
 }

--- a/http3/datagram.go
+++ b/http3/datagram.go
@@ -27,21 +27,19 @@ func newDatagrammer(sendDatagram func([]byte) error) *datagrammer {
 	}
 }
 
-func (d *datagrammer) SetReceiveError(err error) (isDone bool) {
+func (d *datagrammer) SetReceiveError(err error) {
 	d.mx.Lock()
 	defer d.mx.Unlock()
 
 	d.receiveErr = err
 	d.signalHasData()
-	return d.sendErr != nil
 }
 
-func (d *datagrammer) SetSendError(err error) (isDone bool) {
+func (d *datagrammer) SetSendError(err error) {
 	d.mx.Lock()
 	defer d.mx.Unlock()
 
 	d.sendErr = err
-	return d.receiveErr != nil
 }
 
 func (d *datagrammer) Send(b []byte) error {

--- a/http3/datagram_test.go
+++ b/http3/datagram_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Datagrams", func() {
 		dg := newDatagrammer(nil)
 		dg.enqueue([]byte("foo"))
 		testErr := errors.New("test error")
-		Expect(dg.SetReceiveError(testErr)).To(BeFalse())
+		dg.SetReceiveError(testErr)
 		dg.enqueue([]byte("bar"))
 		data, err := dg.Receive(context.Background())
 		Expect(err).ToNot(HaveOccurred())

--- a/http3/state_tracking_stream_test.go
+++ b/http3/state_tracking_stream_test.go
@@ -24,8 +24,8 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 		var (
-			clearer streamClearerSpy
-			setter  errorSetterSpy
+			clearer mockStreamClearer
+			setter  mockErrorSetter
 			str     = newStateTrackingStream(qstr, &clearer, &setter)
 		)
 
@@ -52,8 +52,8 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 		var (
-			clearer streamClearerSpy
-			setter  errorSetterSpy
+			clearer mockStreamClearer
+			setter  mockErrorSetter
 			str     = newStateTrackingStream(qstr, &clearer, &setter)
 		)
 
@@ -79,8 +79,8 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 		var (
-			clearer streamClearerSpy
-			setter  errorSetterSpy
+			clearer mockStreamClearer
+			setter  mockErrorSetter
 			str     = newStateTrackingStream(qstr, &clearer, &setter)
 		)
 
@@ -100,8 +100,8 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 		var (
-			clearer streamClearerSpy
-			setter  errorSetterSpy
+			clearer mockStreamClearer
+			setter  mockErrorSetter
 			str     = newStateTrackingStream(qstr, &clearer, &setter)
 		)
 
@@ -119,8 +119,8 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 		var (
-			clearer streamClearerSpy
-			setter  errorSetterSpy
+			clearer mockStreamClearer
+			setter  mockErrorSetter
 			str     = newStateTrackingStream(qstr, &clearer, &setter)
 		)
 
@@ -148,8 +148,8 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 		var (
-			clearer streamClearerSpy
-			setter  errorSetterSpy
+			clearer mockStreamClearer
+			setter  mockErrorSetter
 			str     = newStateTrackingStream(qstr, &clearer, &setter)
 		)
 
@@ -171,8 +171,8 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 		var (
-			clearer streamClearerSpy
-			setter  errorSetterSpy
+			clearer mockStreamClearer
+			setter  mockErrorSetter
 			str     = newStateTrackingStream(qstr, &clearer, &setter)
 		)
 
@@ -198,8 +198,8 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().Context().Return(ctx).AnyTimes()
 
 		var (
-			clearer streamClearerSpy
-			setter  = errorSetterSpy{
+			clearer mockStreamClearer
+			setter  = mockErrorSetter{
 				sendSent: make(chan struct{}),
 			}
 		)
@@ -224,8 +224,8 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 		var (
-			clearer streamClearerSpy
-			setter  errorSetterSpy
+			clearer mockStreamClearer
+			setter  mockErrorSetter
 			str     = newStateTrackingStream(qstr, &clearer, &setter)
 		)
 
@@ -255,8 +255,8 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
 
 		var (
-			clearer streamClearerSpy
-			setter  errorSetterSpy
+			clearer mockStreamClearer
+			setter  mockErrorSetter
 			str     = newStateTrackingStream(qstr, &clearer, &setter)
 		)
 
@@ -281,22 +281,22 @@ var _ = Describe("State Tracking Stream", func() {
 	})
 })
 
-type streamClearerSpy struct {
+type mockStreamClearer struct {
 	cleared *quic.StreamID
 }
 
-func (s *streamClearerSpy) clearStream(id quic.StreamID) {
+func (s *mockStreamClearer) clearStream(id quic.StreamID) {
 	s.cleared = &id
 }
 
-type errorSetterSpy struct {
+type mockErrorSetter struct {
 	sendErrs []error
 	recvErrs []error
 
 	sendSent chan struct{}
 }
 
-func (e *errorSetterSpy) SetSendError(err error) {
+func (e *mockErrorSetter) SetSendError(err error) {
 	e.sendErrs = append(e.sendErrs, err)
 
 	if e.sendSent != nil {
@@ -304,6 +304,6 @@ func (e *errorSetterSpy) SetSendError(err error) {
 	}
 }
 
-func (e *errorSetterSpy) SetReceiveError(err error) {
+func (e *mockErrorSetter) SetReceiveError(err error) {
 	e.recvErrs = append(e.recvErrs, err)
 }

--- a/http3/state_tracking_stream_test.go
+++ b/http3/state_tracking_stream_test.go
@@ -15,145 +15,180 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-type stateTransition struct {
-	state streamState
-	err   error
-}
+var someStreamID = quic.StreamID(12)
 
 var _ = Describe("State Tracking Stream", func() {
 	It("recognizes when the receive side is closed", func() {
 		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes()
+		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-		var states []stateTransition
-		str := newStateTrackingStream(qstr, func(state streamState, err error) {
-			states = append(states, stateTransition{state, err})
-		})
+
+		var (
+			clearer streamClearerSpy
+			setter  errorSetterSpy
+			str     = newStateTrackingStream(qstr, &clearer, &setter)
+		)
 
 		buf := bytes.NewBuffer([]byte("foobar"))
 		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 		for i := 0; i < 3; i++ {
 			_, err := str.Read([]byte{0})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(states).To(BeEmpty())
+			Expect(clearer.cleared).To(BeNil())
+			Expect(setter.recvErrs).To(BeEmpty())
+			Expect(setter.sendErrs).To(BeEmpty())
 		}
 		_, err := io.ReadAll(str)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(states).To(HaveLen(1))
-		Expect(states[0].state).To(Equal(streamStateReceiveClosed))
-		Expect(states[0].err).To(Equal(io.EOF))
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(HaveLen(1))
+		Expect(setter.recvErrs[0]).To(Equal(io.EOF))
+		Expect(setter.sendErrs).To(BeEmpty())
 	})
 
 	It("recognizes local read cancellations", func() {
 		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes()
+		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-		var states []stateTransition
-		str := newStateTrackingStream(qstr, func(state streamState, err error) {
-			states = append(states, stateTransition{state, err})
-		})
+
+		var (
+			clearer streamClearerSpy
+			setter  errorSetterSpy
+			str     = newStateTrackingStream(qstr, &clearer, &setter)
+		)
 
 		buf := bytes.NewBuffer([]byte("foobar"))
 		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 		qstr.EXPECT().CancelRead(quic.StreamErrorCode(1337))
 		_, err := str.Read(make([]byte, 3))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(states).To(BeEmpty())
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(BeEmpty())
+		Expect(setter.sendErrs).To(BeEmpty())
+
 		str.CancelRead(1337)
-		Expect(states).To(HaveLen(1))
-		Expect(states[0].state).To(Equal(streamStateReceiveClosed))
-		Expect(states[0].err).To(Equal(&quic.StreamError{ErrorCode: 1337}))
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(HaveLen(1))
+		Expect(setter.recvErrs[0]).To(Equal(&quic.StreamError{StreamID: someStreamID, ErrorCode: 1337}))
+		Expect(setter.sendErrs).To(BeEmpty())
 	})
 
 	It("recognizes remote cancellations", func() {
 		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes()
+		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-		var states []stateTransition
-		str := newStateTrackingStream(qstr, func(state streamState, err error) {
-			states = append(states, stateTransition{state, err})
-		})
+
+		var (
+			clearer streamClearerSpy
+			setter  errorSetterSpy
+			str     = newStateTrackingStream(qstr, &clearer, &setter)
+		)
 
 		testErr := errors.New("test error")
 		qstr.EXPECT().Read(gomock.Any()).Return(0, testErr)
 		_, err := str.Read(make([]byte, 3))
 		Expect(err).To(MatchError(testErr))
-		Expect(states).To(HaveLen(1))
-		Expect(states[0].state).To(Equal(streamStateReceiveClosed))
-		Expect(states[0].err).To(MatchError(testErr))
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(HaveLen(1))
+		Expect(setter.recvErrs[0]).To(Equal(testErr))
+		Expect(setter.sendErrs).To(BeEmpty())
 	})
 
 	It("doesn't misinterpret read deadline errors", func() {
 		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes()
+		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-		var states []stateTransition
-		str := newStateTrackingStream(qstr, func(state streamState, err error) {
-			states = append(states, stateTransition{state, err})
-		})
+
+		var (
+			clearer streamClearerSpy
+			setter  errorSetterSpy
+			str     = newStateTrackingStream(qstr, &clearer, &setter)
+		)
 
 		qstr.EXPECT().Read(gomock.Any()).Return(0, os.ErrDeadlineExceeded)
 		_, err := str.Read(make([]byte, 3))
 		Expect(err).To(MatchError(os.ErrDeadlineExceeded))
-		Expect(states).To(BeEmpty())
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(BeEmpty())
+		Expect(setter.sendErrs).To(BeEmpty())
 	})
 
 	It("recognizes when the send side is closed, when write errors", func() {
 		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes()
+		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-		var states []stateTransition
-		str := newStateTrackingStream(qstr, func(state streamState, err error) {
-			states = append(states, stateTransition{state, err})
-		})
+
+		var (
+			clearer streamClearerSpy
+			setter  errorSetterSpy
+			str     = newStateTrackingStream(qstr, &clearer, &setter)
+		)
 
 		testErr := errors.New("test error")
 		qstr.EXPECT().Write([]byte("foo")).Return(3, nil)
 		qstr.EXPECT().Write([]byte("bar")).Return(0, testErr)
+
 		_, err := str.Write([]byte("foo"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(states).To(BeEmpty())
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(BeEmpty())
+		Expect(setter.sendErrs).To(BeEmpty())
+
 		_, err = str.Write([]byte("bar"))
 		Expect(err).To(MatchError(testErr))
-		Expect(states).To(HaveLen(1))
-		Expect(states[0].state).To(Equal(streamStateSendClosed))
-		Expect(states[0].err).To(Equal(testErr))
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(BeEmpty())
+		Expect(setter.sendErrs).To(HaveLen(1))
+		Expect(setter.sendErrs[0]).To(Equal(testErr))
 	})
 
 	It("recognizes when the send side is closed, when write errors", func() {
 		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes()
+		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-		var states []stateTransition
-		str := newStateTrackingStream(qstr, func(state streamState, err error) {
-			states = append(states, stateTransition{state, err})
-		})
+
+		var (
+			clearer streamClearerSpy
+			setter  errorSetterSpy
+			str     = newStateTrackingStream(qstr, &clearer, &setter)
+		)
 
 		qstr.EXPECT().Write([]byte("foo")).Return(0, os.ErrDeadlineExceeded)
-		Expect(states).To(BeEmpty())
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(BeEmpty())
+		Expect(setter.sendErrs).To(BeEmpty())
+
 		_, err := str.Write([]byte("foo"))
 		Expect(err).To(MatchError(os.ErrDeadlineExceeded))
-		Expect(states).To(BeEmpty())
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(BeEmpty())
+		Expect(setter.sendErrs).To(BeEmpty())
 	})
 
 	It("recognizes when the send side is closed, when CancelWrite is called", func() {
 		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes()
+		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
 		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-		var states []stateTransition
-		str := newStateTrackingStream(qstr, func(state streamState, err error) {
-			states = append(states, stateTransition{state, err})
-		})
+
+		var (
+			clearer streamClearerSpy
+			setter  errorSetterSpy
+			str     = newStateTrackingStream(qstr, &clearer, &setter)
+		)
 
 		qstr.EXPECT().Write(gomock.Any())
 		qstr.EXPECT().CancelWrite(quic.StreamErrorCode(1337))
 		_, err := str.Write([]byte("foobar"))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(states).To(BeEmpty())
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(BeEmpty())
+		Expect(setter.sendErrs).To(BeEmpty())
+
 		str.CancelWrite(1337)
-		Expect(states).To(HaveLen(1))
-		Expect(states[0].state).To(Equal(streamStateSendClosed))
-		Expect(states[0].err).To(Equal(&quic.StreamError{ErrorCode: 1337}))
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(BeEmpty())
+		Expect(setter.sendErrs).To(HaveLen(1))
+		Expect(setter.sendErrs[0]).To(Equal(&quic.StreamError{StreamID: someStreamID, ErrorCode: 1337}))
 	})
 
 	It("recognizes when the send side is closed, when the stream context is canceled", func() {
@@ -161,20 +196,145 @@ var _ = Describe("State Tracking Stream", func() {
 		qstr.EXPECT().StreamID().AnyTimes()
 		ctx, cancel := context.WithCancelCause(context.Background())
 		qstr.EXPECT().Context().Return(ctx).AnyTimes()
-		var states []stateTransition
 
-		done := make(chan struct{})
-		newStateTrackingStream(qstr, func(state streamState, err error) {
-			states = append(states, stateTransition{state, err})
-			close(done)
-		})
+		var (
+			clearer streamClearerSpy
+			setter  = errorSetterSpy{
+				sendSent: make(chan struct{}),
+			}
+		)
 
-		Expect(states).To(BeEmpty())
+		_ = newStateTrackingStream(qstr, &clearer, &setter)
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(BeEmpty())
+		Expect(setter.sendErrs).To(BeEmpty())
+
 		testErr := errors.New("test error")
 		cancel(testErr)
-		Eventually(done).Should(BeClosed())
-		Expect(states).To(HaveLen(1))
-		Expect(states[0].state).To(Equal(streamStateSendClosed))
-		Expect(states[0].err).To(Equal(testErr))
+		Eventually(setter.sendSent).Should(BeClosed())
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(BeEmpty())
+		Expect(setter.sendErrs).To(HaveLen(1))
+		Expect(setter.sendErrs[0]).To(Equal(testErr))
+	})
+
+	It("clears the stream when both send and receive side is closed", func() {
+		qstr := mockquic.NewMockStream(mockCtrl)
+		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
+		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
+
+		var (
+			clearer streamClearerSpy
+			setter  errorSetterSpy
+			str     = newStateTrackingStream(qstr, &clearer, &setter)
+		)
+
+		buf := bytes.NewBuffer([]byte("foobar"))
+		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+		_, err := io.ReadAll(str)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(HaveLen(1))
+		Expect(setter.recvErrs[0]).To(Equal(io.EOF))
+		Expect(setter.sendErrs).To(BeEmpty())
+
+		testErr := errors.New("test error")
+		qstr.EXPECT().Write([]byte("bar")).Return(0, testErr)
+
+		_, err = str.Write([]byte("bar"))
+		Expect(err).To(MatchError(testErr))
+
+		Expect(clearer.cleared).To(Equal(&someStreamID))
+	})
+
+	It("clears the stream when receive is closed followed by send is closed", func() {
+		qstr := mockquic.NewMockStream(mockCtrl)
+		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
+		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
+
+		var (
+			clearer streamClearerSpy
+			setter  errorSetterSpy
+			str     = newStateTrackingStream(qstr, &clearer, &setter)
+		)
+
+		buf := bytes.NewBuffer([]byte("foobar"))
+		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+		_, err := io.ReadAll(str)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.recvErrs).To(HaveLen(1))
+		Expect(setter.recvErrs[0]).To(Equal(io.EOF))
+		Expect(setter.sendErrs).To(BeEmpty())
+
+		testErr := errors.New("test error")
+		qstr.EXPECT().Write([]byte("bar")).Return(0, testErr)
+
+		_, err = str.Write([]byte("bar"))
+		Expect(err).To(MatchError(testErr))
+		Expect(setter.sendErrs).To(HaveLen(1))
+		Expect(setter.sendErrs[0]).To(Equal(testErr))
+
+		Expect(clearer.cleared).To(Equal(&someStreamID))
+	})
+
+	It("clears the stream when send is closed followed by receive is closed", func() {
+		qstr := mockquic.NewMockStream(mockCtrl)
+		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
+		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
+
+		var (
+			clearer streamClearerSpy
+			setter  errorSetterSpy
+			str     = newStateTrackingStream(qstr, &clearer, &setter)
+		)
+
+		testErr := errors.New("test error")
+		qstr.EXPECT().Write([]byte("bar")).Return(0, testErr)
+
+		_, err := str.Write([]byte("bar"))
+		Expect(err).To(MatchError(testErr))
+		Expect(clearer.cleared).To(BeNil())
+		Expect(setter.sendErrs).To(HaveLen(1))
+		Expect(setter.sendErrs[0]).To(Equal(testErr))
+
+		buf := bytes.NewBuffer([]byte("foobar"))
+		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+
+		_, err = io.ReadAll(str)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(setter.recvErrs).To(HaveLen(1))
+		Expect(setter.recvErrs[0]).To(Equal(io.EOF))
+
+		Expect(clearer.cleared).To(Equal(&someStreamID))
 	})
 })
+
+type streamClearerSpy struct {
+	cleared *quic.StreamID
+}
+
+func (s *streamClearerSpy) clearStream(id quic.StreamID) {
+	s.cleared = &id
+}
+
+type errorSetterSpy struct {
+	sendErrs []error
+	recvErrs []error
+
+	sendSent chan struct{}
+}
+
+func (e *errorSetterSpy) SetSendError(err error) {
+	e.sendErrs = append(e.sendErrs, err)
+
+	if e.sendSent != nil {
+		close(e.sendSent)
+	}
+}
+
+func (e *errorSetterSpy) SetReceiveError(err error) {
+	e.recvErrs = append(e.recvErrs, err)
+}


### PR DESCRIPTION
Fixes #4513

This updates the `onStreamStateChange` to handle the `streamStateSendAndReceiveClosed` state.
Prior to this, when the client failed to observe this, the datagram previously tracked in the streams map was left behind. This caused the memory leak observed in the issue above. Adding this case causes the entry to be deleted and memory in our project is stable.