### PR TITLE
remove unneeded stream context cancellation on shutdown

### DIFF
--- a/send_stream.go
+++ b/send_stream.go
@@ -478,7 +478,6 @@ func (s *sendStream) SetWriteDeadline(t time.Time) error {
 // The peer will NOT be informed about this: the stream is closed without sending a FIN or RST.
 func (s *sendStream) closeForShutdown(err error) {
 	s.mutex.Lock()
-	s.ctxCancel(err)
 	s.closeForShutdownErr = err
 	s.mutex.Unlock()
 	s.signalWrite()

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -665,13 +665,6 @@ var _ = Describe("Send Stream", func() {
 				Expect(hasMoreData).To(BeFalse())
 				Eventually(done).Should(BeClosed())
 			})
-
-			It("cancels the context", func() {
-				Expect(str.Context().Done()).ToNot(BeClosed())
-				str.closeForShutdown(testErr)
-				Expect(str.Context().Done()).To(BeClosed())
-				Expect(context.Cause(str.Context())).To(MatchError(testErr))
-			})
 		})
 	})
 


### PR DESCRIPTION
The connection already cancels the base context, so we don't need to manually cancel the stream context (which is derived from the connection context).