### PR TITLE
qlog: rename DefaultTracer to DefaultConnectionTracer

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -47,7 +47,7 @@ func main() {
 			KeyLogWriter:       keyLog,
 		},
 		QUICConfig: &quic.Config{
-			Tracer: qlog.DefaultTracer,
+			Tracer: qlog.DefaultConnectionTracer,
 		},
 	}
 	defer roundTripper.Close()

--- a/example/main.go
+++ b/example/main.go
@@ -169,7 +169,7 @@ func main() {
 					Handler: handler,
 					Addr:    bCap,
 					QUICConfig: &quic.Config{
-						Tracer: qlog.DefaultTracer,
+						Tracer: qlog.DefaultConnectionTracer,
 					},
 				}
 				err = server.ListenAndServeTLS(certFile, keyFile)

--- a/integrationtests/self/qlog_dir_test.go
+++ b/integrationtests/self/qlog_dir_test.go
@@ -36,7 +36,7 @@ var _ = Describe("qlog dir tests", Serial, func() {
 			"localhost:0",
 			getTLSConfig(),
 			&quic.Config{
-				Tracer: qlog.DefaultTracer,
+				Tracer: qlog.DefaultConnectionTracer,
 			},
 		)
 		Expect(err).ToNot(HaveOccurred())
@@ -56,7 +56,7 @@ var _ = Describe("qlog dir tests", Serial, func() {
 			server.Addr().String(),
 			getTLSClientConfig(),
 			&quic.Config{
-				Tracer: qlog.DefaultTracer,
+				Tracer: qlog.DefaultConnectionTracer,
 			},
 		)
 		Expect(err).ToNot(HaveOccurred())

--- a/qlog/qlog_dir.go
+++ b/qlog/qlog_dir.go
@@ -13,9 +13,15 @@ import (
 )
 
 // DefaultTracer creates a qlog file in the qlog directory specified by the QLOGDIR environment variable.
+// Deprecated: use DefaultConnectionTracer instead.
+func DefaultTracer(ctx context.Context, p logging.Perspective, connID logging.ConnectionID) *logging.ConnectionTracer {
+	return DefaultConnectionTracer(ctx, p, connID)
+}
+
+// DefaultConnectionTracer creates a qlog file in the qlog directory specified by the QLOGDIR environment variable.
 // File names are <odcid>_<perspective>.qlog.
 // Returns nil if QLOGDIR is not set.
-func DefaultTracer(_ context.Context, p logging.Perspective, connID logging.ConnectionID) *logging.ConnectionTracer {
+func DefaultConnectionTracer(_ context.Context, p logging.Perspective, connID logging.ConnectionID) *logging.ConnectionTracer {
 	var label string
 	switch p {
 	case logging.PerspectiveClient:

--- a/qlog/qlog_dir_test.go
+++ b/qlog/qlog_dir_test.go
@@ -36,7 +36,7 @@ var _ = Describe("qlog dir tests", Serial, func() {
 		qlogDir := path.Join(tempTestDirPath, "qlogs")
 		err := os.Setenv("QLOGDIR", qlogDir)
 		Expect(err).ToNot(HaveOccurred())
-		tracer := DefaultTracer(ctx, perspective, connID)
+		tracer := DefaultConnectionTracer(ctx, perspective, connID)
 		Expect(tracer).ToNot(BeNil())
 		tracer.Close()
 		_, err = os.Stat(qlogDir)
@@ -50,7 +50,7 @@ var _ = Describe("qlog dir tests", Serial, func() {
 	It("environment variable is not set", func() {
 		err := os.Setenv("QLOGDIR", "")
 		Expect(err).ToNot(HaveOccurred())
-		tracer := DefaultTracer(ctx, perspective, connID)
+		tracer := DefaultConnectionTracer(ctx, perspective, connID)
 		Expect(tracer).To(BeNil())
 	})
 })


### PR DESCRIPTION
There's a `logging.Tracer` and a `logging.ConnectionTracer`. It's confusing that `qlog.DefaultTracer` returns a `ConnectionTracer`.