### PR TITLE
use a net.ErrClosed when returning Accept from a closed server

### DIFF
--- a/server.go
+++ b/server.go
@@ -18,7 +18,12 @@ import (
 )
 
 // ErrServerClosed is returned by the Listener or EarlyListener's Accept method after a call to Close.
-var ErrServerClosed = errors.New("quic: server closed")
+var ErrServerClosed = errServerClosed{}
+
+type errServerClosed struct{}
+
+func (errServerClosed) Error() string { return "quic: server closed" }
+func (errServerClosed) Unwrap() error { return net.ErrClosed }
 
 // packetHandler handles packets
 type packetHandler interface {

--- a/server_test.go
+++ b/server_test.go
@@ -941,6 +941,7 @@ var _ = Describe("Server", func() {
 					defer GinkgoRecover()
 					_, err := serv.Accept(context.Background())
 					Expect(err).To(MatchError(ErrServerClosed))
+					Expect(err).To(MatchError(net.ErrClosed))
 					close(done)
 				}()
 


### PR DESCRIPTION
Fixes #4566.