### PR TITLE
wire: optimize parsing of long header packets

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -24,7 +24,7 @@ import (
 )
 
 type unpacker interface {
-	UnpackLongHeader(hdr *wire.Header, rcvTime time.Time, data []byte, v protocol.Version) (*unpackedPacket, error)
+	UnpackLongHeader(hdr *wire.Header, data []byte) (*unpackedPacket, error)
 	UnpackShortHeader(rcvTime time.Time, data []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error)
 }
 
@@ -961,7 +961,7 @@ func (s *connection) handleLongHeaderPacket(p receivedPacket, hdr *wire.Header) 
 		return false
 	}
 
-	packet, err := s.unpacker.UnpackLongHeader(hdr, p.rcvTime, p.data, s.version)
+	packet, err := s.unpacker.UnpackLongHeader(hdr, p.data)
 	if err != nil {
 		wasQueued = s.handleUnpackError(err, p, logging.PacketTypeFromHeader(hdr))
 		return false

--- a/fuzzing/header/fuzz.go
+++ b/fuzzing/header/fuzz.go
@@ -54,7 +54,7 @@ func Fuzz(data []byte) int {
 		extHdr = &wire.ExtendedHeader{Header: *hdr}
 	} else {
 		var err error
-		extHdr, err = hdr.ParseExtended(bytes.NewReader(data), version)
+		extHdr, err = hdr.ParseExtended(data)
 		if err != nil {
 			return 0
 		}

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -50,7 +50,7 @@ var _ = Describe("QUIC Proxy", func() {
 		hdr, data, _, err := wire.ParsePacket(b)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		Expect(hdr.Type).To(Equal(protocol.PacketTypeInitial))
-		extHdr, err := hdr.ParseExtended(bytes.NewReader(data), protocol.Version1)
+		extHdr, err := hdr.ParseExtended(data)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return extHdr.PacketNumber
 	}

--- a/internal/wire/header.go
+++ b/internal/wire/header.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/quicvarint"
 )
 
@@ -274,9 +275,9 @@ func (h *Header) ParsedLen() protocol.ByteCount {
 
 // ParseExtended parses the version dependent part of the header.
 // The Reader has to be set such that it points to the first byte of the header.
-func (h *Header) ParseExtended(b *bytes.Reader, ver protocol.Version) (*ExtendedHeader, error) {
+func (h *Header) ParseExtended(data []byte) (*ExtendedHeader, error) {
 	extHdr := h.toExtendedHeader()
-	reservedBitsValid, err := extHdr.parse(b, ver)
+	reservedBitsValid, err := extHdr.parse(data)
 	if err != nil {
 		return nil, err
 	}
@@ -293,4 +294,21 @@ func (h *Header) toExtendedHeader() *ExtendedHeader {
 // PacketType is the type of the packet, for logging purposes
 func (h *Header) PacketType() string {
 	return h.Type.String()
+}
+
+func readPacketNumber(data []byte, pnLen protocol.PacketNumberLen) (protocol.PacketNumber, error) {
+	var pn protocol.PacketNumber
+	switch pnLen {
+	case protocol.PacketNumberLen1:
+		pn = protocol.PacketNumber(data[0])
+	case protocol.PacketNumberLen2:
+		pn = protocol.PacketNumber(utils.BigEndian.Uint16(data[:2]))
+	case protocol.PacketNumberLen3:
+		pn = protocol.PacketNumber(utils.BigEndian.Uint24(data[:3]))
+	case protocol.PacketNumberLen4:
+		pn = protocol.PacketNumber(utils.BigEndian.Uint32(data[:4]))
+	default:
+		return 0, fmt.Errorf("invalid packet number length: %d", pnLen)
+	}
+	return pn, nil
 }

--- a/internal/wire/short_header.go
+++ b/internal/wire/short_header.go
@@ -2,7 +2,6 @@ package wire
 
 import (
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -28,25 +27,15 @@ func ParseShortHeader(data []byte, connIDLen int) (length int, _ protocol.Packet
 	}
 
 	pos := 1 + connIDLen
-	var pn protocol.PacketNumber
-	switch pnLen {
-	case protocol.PacketNumberLen1:
-		pn = protocol.PacketNumber(data[pos])
-	case protocol.PacketNumberLen2:
-		pn = protocol.PacketNumber(utils.BigEndian.Uint16(data[pos : pos+2]))
-	case protocol.PacketNumberLen3:
-		pn = protocol.PacketNumber(utils.BigEndian.Uint24(data[pos : pos+3]))
-	case protocol.PacketNumberLen4:
-		pn = protocol.PacketNumber(utils.BigEndian.Uint32(data[pos : pos+4]))
-	default:
-		return 0, 0, 0, 0, fmt.Errorf("invalid packet number length: %d", pnLen)
+	pn, err := readPacketNumber(data[pos:], pnLen)
+	if err != nil {
+		return 0, 0, 0, 0, err
 	}
 	kp := protocol.KeyPhaseZero
 	if data[0]&0b100 > 0 {
 		kp = protocol.KeyPhaseOne
 	}
 
-	var err error
 	if data[0]&0x18 != 0 {
 		err = ErrInvalidReservedBits
 	}

--- a/mock_unpacker_test.go
+++ b/mock_unpacker_test.go
@@ -42,18 +42,18 @@ func (m *MockUnpacker) EXPECT() *MockUnpackerMockRecorder {
 }
 
 // UnpackLongHeader mocks base method.
-func (m *MockUnpacker) UnpackLongHeader(arg0 *wire.Header, arg1 time.Time, arg2 []byte, arg3 protocol.Version) (*unpackedPacket, error) {
+func (m *MockUnpacker) UnpackLongHeader(arg0 *wire.Header, arg1 []byte) (*unpackedPacket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnpackLongHeader", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "UnpackLongHeader", arg0, arg1)
 	ret0, _ := ret[0].(*unpackedPacket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnpackLongHeader indicates an expected call of UnpackLongHeader.
-func (mr *MockUnpackerMockRecorder) UnpackLongHeader(arg0, arg1, arg2, arg3 any) *MockUnpackerUnpackLongHeaderCall {
+func (mr *MockUnpackerMockRecorder) UnpackLongHeader(arg0, arg1 any) *MockUnpackerUnpackLongHeaderCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpackLongHeader", reflect.TypeOf((*MockUnpacker)(nil).UnpackLongHeader), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpackLongHeader", reflect.TypeOf((*MockUnpacker)(nil).UnpackLongHeader), arg0, arg1)
 	return &MockUnpackerUnpackLongHeaderCall{Call: call}
 }
 
@@ -69,13 +69,13 @@ func (c *MockUnpackerUnpackLongHeaderCall) Return(arg0 *unpackedPacket, arg1 err
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnpackerUnpackLongHeaderCall) Do(f func(*wire.Header, time.Time, []byte, protocol.Version) (*unpackedPacket, error)) *MockUnpackerUnpackLongHeaderCall {
+func (c *MockUnpackerUnpackLongHeaderCall) Do(f func(*wire.Header, []byte) (*unpackedPacket, error)) *MockUnpackerUnpackLongHeaderCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnpackerUnpackLongHeaderCall) DoAndReturn(f func(*wire.Header, time.Time, []byte, protocol.Version) (*unpackedPacket, error)) *MockUnpackerUnpackLongHeaderCall {
+func (c *MockUnpackerUnpackLongHeaderCall) DoAndReturn(f func(*wire.Header, []byte) (*unpackedPacket, error)) *MockUnpackerUnpackLongHeaderCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/server.go
+++ b/server.go
@@ -808,7 +808,7 @@ func (s *baseServer) maybeSendInvalidToken(p rejectedPacket) {
 	hdr := p.hdr
 	sealer, opener := handshake.NewInitialAEAD(hdr.DestConnectionID, protocol.PerspectiveServer, hdr.Version)
 	data := p.data[:hdr.ParsedLen()+hdr.Length]
-	extHdr, err := unpackLongHeader(opener, hdr, data, hdr.Version)
+	extHdr, err := unpackLongHeader(opener, hdr, data)
 	// Only send INVALID_TOKEN if we can unprotect the packet.
 	// This makes sure that we won't send it for packets that were corrupted.
 	if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Server", func() {
 		Expect(replyHdr.SrcConnectionID).To(Equal(origHdr.DestConnectionID))
 		Expect(replyHdr.DestConnectionID).To(Equal(origHdr.SrcConnectionID))
 		_, opener := handshake.NewInitialAEAD(origHdr.DestConnectionID, protocol.PerspectiveClient, replyHdr.Version)
-		extHdr, err := unpackLongHeader(opener, replyHdr, b, origHdr.Version)
+		extHdr, err := unpackLongHeader(opener, replyHdr, b)
 		Expect(err).ToNot(HaveOccurred())
 		data, err := opener.Open(nil, b[extHdr.ParsedLen():], extHdr.PacketNumber, b[:extHdr.ParsedLen()])
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Not a huge improvement, but it's nice to operate on a `[]byte` instead of a `bytes.Reader`.
```
ParseExtendedHeader-16    67.7ns ± 4%    63.8ns ± 6%  -5.83%  (p=0.001 n=10+10)
```

The bigger improvement is in terms of allocations, because the consumer of the `wire` package doesn't need to allocate the `bytes.Reader` anymore.