### PR TITLE
ackhandler: reduce allocations for tracking sent packets

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -28,7 +28,7 @@ const (
 )
 
 type packetNumberSpace struct {
-	history *sentPacketHistory
+	history sentPacketHistory
 	pns     packetNumberGenerator
 
 	lossTime                   time.Time
@@ -38,15 +38,15 @@ type packetNumberSpace struct {
 	largestSent  protocol.PacketNumber
 }
 
-func newPacketNumberSpace(initialPN protocol.PacketNumber, skipPNs bool) *packetNumberSpace {
+func newPacketNumberSpace(initialPN protocol.PacketNumber, isAppData bool) *packetNumberSpace {
 	var pns packetNumberGenerator
-	if skipPNs {
+	if isAppData {
 		pns = newSkippingPacketNumberGenerator(initialPN, protocol.SkipPacketInitialPeriod, protocol.SkipPacketMaxPeriod)
 	} else {
 		pns = newSequentialPacketNumberGenerator(initialPN)
 	}
 	return &packetNumberSpace{
-		history:      newSentPacketHistory(),
+		history:      *newSentPacketHistory(isAppData),
 		pns:          pns,
 		largestSent:  protocol.InvalidPacketNumber,
 		largestAcked: protocol.InvalidPacketNumber,

--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -14,11 +14,16 @@ type sentPacketHistory struct {
 	highestPacketNumber protocol.PacketNumber
 }
 
-func newSentPacketHistory() *sentPacketHistory {
-	return &sentPacketHistory{
-		packets:             make([]*packet, 0, 32),
+func newSentPacketHistory(isAppData bool) *sentPacketHistory {
+	h := &sentPacketHistory{
 		highestPacketNumber: protocol.InvalidPacketNumber,
 	}
+	if isAppData {
+		h.packets = make([]*packet, 0, 32)
+	} else {
+		h.packets = make([]*packet, 0, 6)
+	}
+	return h
 }
 
 func (h *sentPacketHistory) checkSequentialPacketNumberUse(pn protocol.PacketNumber) {

--- a/internal/ackhandler/sent_packet_history_test.go
+++ b/internal/ackhandler/sent_packet_history_test.go
@@ -42,7 +42,7 @@ var _ = Describe("SentPacketHistory", func() {
 	}
 
 	BeforeEach(func() {
-		hist = newSentPacketHistory()
+		hist = newSentPacketHistory(true)
 	})
 
 	It("saves sent packets", func() {


### PR DESCRIPTION
Part of #3663.

```
name          old time/op    new time/op    delta
Handshake-16     604µs ± 1%     607µs ± 2%    ~     (p=0.421 n=5+5)

name          old alloc/op   new alloc/op   delta
Handshake-16     245kB ± 0%     245kB ± 0%  -0.35%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
Handshake-16     2.50k ± 0%     2.50k ± 0%  -0.30%  (p=0.000 n=5+4)
```