### PR TITLE
simplify frame queuing logic for 0-RTT rejection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1675,10 +1675,8 @@ func (s *connection) dropEncryptionLevel(encLevel protocol.EncryptionLevel) erro
 		s.cryptoStreamHandler.DiscardInitialKeys()
 	case protocol.Encryption0RTT:
 		s.streamsMap.ResetFor0RTT()
-		if err := s.connFlowController.Reset(); err != nil {
-			return err
-		}
-		return s.framer.Handle0RTTRejection()
+		s.framer.Handle0RTTRejection()
+		return s.connFlowController.Reset()
 	}
 	return s.cryptoStreamManager.Drop(encLevel)
 }

--- a/framer_test.go
+++ b/framer_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Framer", func() {
 			for _, f := range frames {
 				framer.QueueControlFrame(f)
 			}
-			Expect(framer.Handle0RTTRejection()).To(Succeed())
+			framer.Handle0RTTRejection()
 			fs, length := framer.AppendControlFrames(nil, protocol.MaxByteCount, protocol.Version1)
 			Expect(fs).To(HaveLen(2))
 			Expect(length).To(Equal(ping.Length(version) + ncid.Length(version)))
@@ -424,7 +424,7 @@ var _ = Describe("Framer", func() {
 
 		It("drops all STREAM frames when 0-RTT is rejected", func() {
 			framer.AddActiveStream(id1, stream1)
-			Expect(framer.Handle0RTTRejection()).To(Succeed())
+			framer.Handle0RTTRejection()
 			fs, length := framer.AppendStreamFrames(nil, protocol.MaxByteCount, protocol.Version1)
 			Expect(fs).To(BeEmpty())
 			Expect(length).To(BeZero())


### PR DESCRIPTION
Even though we currently don't do so, sending MAX_DATA, MAX_STREAM_DATA and MAX_STREAMS is allowed in 0-RTT, see https://datatracker.ietf.org/doc/html/rfc9000#frame-types.