### PR TITLE
simplify generation of STREAM_DATA_BLOCKED frames

### DIFF
--- a/internal/flowcontrol/interface.go
+++ b/internal/flowcontrol/interface.go
@@ -9,7 +9,6 @@ type flowController interface {
 	AddBytesSent(protocol.ByteCount)
 	// for receiving
 	GetWindowUpdate() protocol.ByteCount // returns 0 if no update is necessary
-	IsNewlyBlocked() (bool, protocol.ByteCount)
 }
 
 // A StreamFlowController is a flow controller for a QUIC stream.
@@ -23,6 +22,7 @@ type StreamFlowController interface {
 	// Abandon is called when reading from the stream is aborted early,
 	// and there won't be any further calls to AddBytesRead.
 	Abandon()
+	IsNewlyBlocked() bool
 }
 
 // The ConnectionFlowController is the flow controller for the connection.
@@ -30,6 +30,7 @@ type ConnectionFlowController interface {
 	flowController
 	AddBytesRead(protocol.ByteCount)
 	Reset() error
+	IsNewlyBlocked() (bool, protocol.ByteCount)
 }
 
 type connectionFlowControllerI interface {

--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -121,6 +121,11 @@ func (c *streamFlowController) SendWindowSize() protocol.ByteCount {
 	return min(c.baseFlowController.sendWindowSize(), c.connection.SendWindowSize())
 }
 
+func (c *streamFlowController) IsNewlyBlocked() bool {
+	blocked, _ := c.baseFlowController.IsNewlyBlocked()
+	return blocked
+}
+
 func (c *streamFlowController) shouldQueueWindowUpdate() bool {
 	return !c.receivedFinalOffset && c.hasWindowUpdate()
 }

--- a/internal/mocks/stream_flow_controller.go
+++ b/internal/mocks/stream_flow_controller.go
@@ -188,12 +188,11 @@ func (c *MockStreamFlowControllerGetWindowUpdateCall) DoAndReturn(f func() proto
 }
 
 // IsNewlyBlocked mocks base method.
-func (m *MockStreamFlowController) IsNewlyBlocked() (bool, protocol.ByteCount) {
+func (m *MockStreamFlowController) IsNewlyBlocked() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsNewlyBlocked")
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(protocol.ByteCount)
-	return ret0, ret1
+	return ret0
 }
 
 // IsNewlyBlocked indicates an expected call of IsNewlyBlocked.
@@ -209,19 +208,19 @@ type MockStreamFlowControllerIsNewlyBlockedCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStreamFlowControllerIsNewlyBlockedCall) Return(arg0 bool, arg1 protocol.ByteCount) *MockStreamFlowControllerIsNewlyBlockedCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockStreamFlowControllerIsNewlyBlockedCall) Return(arg0 bool) *MockStreamFlowControllerIsNewlyBlockedCall {
+	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStreamFlowControllerIsNewlyBlockedCall) Do(f func() (bool, protocol.ByteCount)) *MockStreamFlowControllerIsNewlyBlockedCall {
+func (c *MockStreamFlowControllerIsNewlyBlockedCall) Do(f func() bool) *MockStreamFlowControllerIsNewlyBlockedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStreamFlowControllerIsNewlyBlockedCall) DoAndReturn(f func() (bool, protocol.ByteCount)) *MockStreamFlowControllerIsNewlyBlockedCall {
+func (c *MockStreamFlowControllerIsNewlyBlockedCall) DoAndReturn(f func() bool) *MockStreamFlowControllerIsNewlyBlockedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/send_stream.go
+++ b/send_stream.go
@@ -262,10 +262,10 @@ func (s *sendStream) popNewOrRetransmittedStreamFrame(maxBytes protocol.ByteCoun
 
 	sendWindow := s.flowController.SendWindowSize()
 	if sendWindow == 0 {
-		if isBlocked, offset := s.flowController.IsNewlyBlocked(); isBlocked {
+		if s.flowController.IsNewlyBlocked() {
 			s.sender.queueControlFrame(&wire.StreamDataBlockedFrame{
 				StreamID:          s.streamID,
-				MaximumStreamData: offset,
+				MaximumStreamData: s.writeOffset,
 			})
 			return nil, false
 		}


### PR DESCRIPTION
The stream always gets blocked at the current write offset. There's no need to return this offset from the flow controller.