### PR TITLE
reduce allocations when handling crypto data

### DIFF
--- a/crypto_stream_test.go
+++ b/crypto_stream_test.go
@@ -41,12 +41,30 @@ var _ = Describe("Crypto Stream", func() {
 		It("handles out-of-order CRYPTO frames", func() {
 			Expect(str.HandleCryptoFrame(&wire.CryptoFrame{Offset: 3, Data: []byte("bar")})).To(Succeed())
 			Expect(str.HandleCryptoFrame(&wire.CryptoFrame{Data: []byte("foo")})).To(Succeed())
-			Expect(str.GetCryptoData()).To(Equal([]byte("foobar")))
+			var data []byte
+			for {
+				b := str.GetCryptoData()
+				if b == nil {
+					break
+				}
+				data = append(data, b...)
+			}
+			Expect(data).To(Equal([]byte("foobar")))
 			Expect(str.GetCryptoData()).To(BeNil())
 		})
 
 		Context("finishing", func() {
-			It("errors if there's still data to read after finishing", func() {
+			It("errors if there's still data to read at the current offset after finishing", func() {
+				Expect(str.HandleCryptoFrame(&wire.CryptoFrame{
+					Data: []byte("foo"),
+				})).To(Succeed())
+				Expect(str.Finish()).To(MatchError(&qerr.TransportError{
+					ErrorCode:    qerr.ProtocolViolation,
+					ErrorMessage: "encryption level changed, but crypto stream has more data to read",
+				}))
+			})
+
+			It("errors if there's still data to read at a higher offset after finishing", func() {
 				Expect(str.HandleCryptoFrame(&wire.CryptoFrame{
 					Data:   []byte("foobar"),
 					Offset: 10,
@@ -67,6 +85,8 @@ var _ = Describe("Crypto Stream", func() {
 				}
 				Expect(str.HandleCryptoFrame(f2)).To(Succeed())
 				Expect(str.HandleCryptoFrame(f1)).To(Succeed())
+				Expect(str.GetCryptoData()).To(HaveLen(3))
+				Expect(str.GetCryptoData()).To(HaveLen(3))
 				Expect(str.Finish()).To(Succeed())
 				Expect(str.HandleCryptoFrame(f2)).To(Succeed())
 			})


### PR DESCRIPTION
Closes #4614. Part of #3663.

```
name          old time/op    new time/op    delta
Handshake-16     612µs ± 2%     609µs ± 3%    ~     (p=0.172 n=14+15)

name          old alloc/op   new alloc/op   delta
Handshake-16     244kB ± 0%     243kB ± 0%  -0.43%  (p=0.000 n=13+14)

name          old allocs/op  new allocs/op  delta
Handshake-16     2.50k ± 0%     2.50k ± 0%  -0.16%  (p=0.002 n=15+15)
```