### PR TITLE
wire: speed up parsing of headers with arbitrary length connection IDs

### DIFF
--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -313,3 +313,24 @@ func benchmarkParse(b *testing.B, inputs []benchmarkValue) {
 		}
 	}
 }
+
+func BenchmarkAppend(b *testing.B) {
+	b.Run("1-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(min(b.N, 1024), maxVarInt1)) })
+	b.Run("2-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(min(b.N, 1024), maxVarInt2)) })
+	b.Run("4-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(min(b.N, 1024), maxVarInt4)) })
+	b.Run("8-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(min(b.N, 1024), maxVarInt8)) })
+}
+
+func benchmarkAppend(b *testing.B, inputs []benchmarkValue) {
+	buf := make([]byte, 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf = buf[:0]
+		index := i % 1024
+		buf = Append(buf, inputs[index].v)
+
+		if !bytes.Equal(buf, inputs[index].b) {
+			b.Fatalf("expected to write %v, wrote %v", inputs[i].b, buf)
+		}
+	}
+}


### PR DESCRIPTION
This is significantly faster:
```
name                                          old time/op    new time/op    delta
ArbitraryHeaderParsing/dest_8/_src_10-16        53.8ns ± 2%    27.4ns ± 2%  -49.01%  (p=0.008 n=5+5)
ArbitraryHeaderParsing/dest_20_/_src_20-16      61.6ns ± 1%    33.3ns ± 3%  -46.00%  (p=0.008 n=5+5)
ArbitraryHeaderParsing/dest_100_/_src_150-16    90.0ns ± 3%    54.8ns ± 5%  -39.09%  (p=0.008 n=5+5)

name                                          old alloc/op   new alloc/op   delta
ArbitraryHeaderParsing/dest_8/_src_10-16         72.0B ± 0%     24.0B ± 0%  -66.67%  (p=0.008 n=5+5)
ArbitraryHeaderParsing/dest_20_/_src_20-16       96.0B ± 0%     48.0B ± 0%  -50.00%  (p=0.008 n=5+5)
ArbitraryHeaderParsing/dest_100_/_src_150-16      320B ± 0%      272B ± 0%  -15.00%  (p=0.008 n=5+5)

name                                          old allocs/op  new allocs/op  delta
ArbitraryHeaderParsing/dest_8/_src_10-16          3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
ArbitraryHeaderParsing/dest_20_/_src_20-16        3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
ArbitraryHeaderParsing/dest_100_/_src_150-16      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)