### PR TITLE
http3: add HTTP Trailer support for servers

### DIFF
--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -251,15 +252,6 @@ func (w *responseWriter) promoteTrailer() {
 	}
 }
 
-func strSliceContains(ss []string, s string) bool {
-	for _, v := range ss {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
 func (w *responseWriter) declareTrailer(k string) {
 	k = http.CanonicalHeaderKey(k)
 	if !httpguts.ValidTrailerHeader(k) {
@@ -267,7 +259,8 @@ func (w *responseWriter) declareTrailer(k string) {
 		w.logger.Debug("ignoring invalid trailer", slog.String("header", k))
 		return
 	}
-	if !strSliceContains(w.trailers, k) {
+
+	if !slices.Contains(w.trailers, k) {
 		w.trailers = append(w.trailers, k)
 	}
 }

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -269,7 +269,7 @@ func (w *responseWriter) Flush() {
 	}
 }
 
-// declareTrailer will add the given to the trailer list, while also validating that the trailer has a
+// declareTrailer adds a trailer to the trailer list, while also validating that the trailer has a
 // valid name.
 func (w *responseWriter) declareTrailer(k string) {
 	if !httpguts.ValidTrailerHeader(k) {

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -273,7 +273,7 @@ func (w *responseWriter) Flush() {
 // valid name.
 func (w *responseWriter) declareTrailer(k string) {
 	if !httpguts.ValidTrailerHeader(k) {
-		// Forbidden by RFC 7230, section 4.1.2.
+		// Forbidden by RFC 9110, section 6.5.1.
 		w.logger.Debug("ignoring invalid trailer", slog.String("header", k))
 		return
 	}

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -206,17 +206,14 @@ func (w *responseWriter) writeHeader(status int) error {
 
 	// Handle trailer fields
 	if vals, ok := w.header["Trailer"]; ok {
-		trailers := make([]string, 0, len(vals))
 		for _, val := range vals {
 			for _, trailer := range strings.Split(val, ",") {
 				// We need to convert to the canonical header key value here because this will be called when using
 				// headers.Add or headers.Set.
 				trailer = textproto.CanonicalMIMEHeaderKey(strings.TrimSpace(trailer))
 				w.declareTrailer(trailer)
-				trailers = append(trailers, trailer)
 			}
 		}
-		w.header["Trailer"] = trailers
 	}
 
 	for k, v := range w.header {
@@ -250,12 +247,12 @@ func (w *responseWriter) FlushError() error {
 	return err
 }
 
-func (w *responseWriter) flushFinal() {
-	w.Flush()
-	if !w.trailerWritten {
-		if err := w.writeTrailers(); err != nil {
-			w.logger.Debug("could not write trailers", "error", err)
-		}
+func (w *responseWriter) flushTrailers() {
+	if w.trailerWritten {
+		return
+	}
+	if err := w.writeTrailers(); err != nil {
+		w.logger.Debug("could not write trailers", "error", err)
 	}
 }
 

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -246,10 +246,8 @@ func (w *responseWriter) FlushError() error {
 	if !w.headerComplete {
 		w.WriteHeader(http.StatusOK)
 	}
-	if _, err := w.doWrite(nil); err != nil {
-		return err
-	}
-	return nil
+	_, err := w.doWrite(nil)
+	return err
 }
 
 func (w *responseWriter) flushFinal() {

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -204,7 +204,6 @@ var _ = Describe("Response Writer", func() {
 
 		fields = decodeHeader(strBuf)
 		Expect(fields).To(HaveKeyWithValue("key", []string{"Value"}))
-
 	})
 
 	It("ignore non-announced trailer (without trailer prefix)", func() {
@@ -225,7 +224,6 @@ var _ = Describe("Response Writer", func() {
 		trailers := decodeHeader(strBuf)
 		Expect(trailers).To(HaveKeyWithValue("key", []string{"Value"}))
 		Expect(trailers).To(Not(HaveKeyWithValue("unknownkey", []string{"Value"})))
-
 	})
 
 	It("write non-announced trailer (with trailer prefix)", func() {

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/quic-go/qpack"
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
-	"golang.org/x/net/http2"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -231,7 +230,8 @@ var _ = Describe("Response Writer", func() {
 		rw.WriteHeader(200)
 		rw.Write([]byte("foobar"))
 		rw.Header().Set("Key", "Value")
-		rw.Header().Set(http2.TrailerPrefix+"Key2", "Value")
+		rw.Header().Set(http.TrailerPrefix+"Key2", "Value")
+		rw.Flush()
 
 		// Needs to call writeTrailers to simulate the end of the handler
 		Expect(rw.writeTrailers()).ToNot(HaveOccurred())

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Response Writer", func() {
 	})
 
 	decodeHeader := func(str io.Reader) map[string][]string {
-		rw.Flush()
+		rw.flushFinal()
 		fields := make(map[string][]string)
 		decoder := qpack.NewDecoder(nil)
 

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -30,7 +30,8 @@ var _ = Describe("Response Writer", func() {
 	})
 
 	decodeHeader := func(str io.Reader) map[string][]string {
-		rw.flushFinal()
+		rw.Flush()
+		rw.flushTrailers()
 		fields := make(map[string][]string)
 		decoder := qpack.NewDecoder(nil)
 

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/quic-go/qpack"
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
+	"golang.org/x/net/http2"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -183,5 +184,67 @@ var _ = Describe("Response Writer", func() {
 	It(`panics when writing invalid status`, func() {
 		Expect(func() { rw.WriteHeader(99) }).To(Panic())
 		Expect(func() { rw.WriteHeader(1000) }).To(Panic())
+	})
+
+	It("write announced trailer", func() {
+		rw.Header().Add("Trailer", "Key")
+		rw.WriteHeader(http.StatusTeapot)
+		n, err := rw.Write([]byte("foobar"))
+		Expect(n).To(Equal(6))
+		Expect(err).ToNot(HaveOccurred())
+		rw.Header().Set("Key", "Value")
+
+		// writeTrailers needs to be called after writing the full body
+		Expect(rw.writeTrailers()).ToNot(HaveOccurred())
+
+		fields := decodeHeader(strBuf)
+		Expect(fields).To(HaveKeyWithValue(":status", []string{"418"}))
+		Expect(fields).To(HaveKeyWithValue("trailer", []string{"Key"}))
+		Expect(getData(strBuf)).To(Equal([]byte("foobar")))
+
+		fields = decodeHeader(strBuf)
+		Expect(fields).To(HaveKeyWithValue("key", []string{"Value"}))
+
+	})
+
+	It("ignore non-announced trailer (without trailer prefix)", func() {
+		rw.Header().Set("Trailer", "Key")
+		rw.WriteHeader(200)
+		rw.Write([]byte("foobar"))
+		rw.Header().Set("UnknownKey", "Value")
+		rw.Header().Set("Key", "Value")
+
+		// Needs to call writeTrailers to simulate the end of the handler
+		Expect(rw.writeTrailers()).ToNot(HaveOccurred())
+		headers := decodeHeader(strBuf)
+		Expect(headers).To(HaveKeyWithValue(":status", []string{"200"}))
+		Expect(headers).To(HaveKeyWithValue("trailer", []string{"Key"}))
+
+		Expect(getData(strBuf)).To(Equal([]byte("foobar")))
+
+		trailers := decodeHeader(strBuf)
+		Expect(trailers).To(HaveKeyWithValue("key", []string{"Value"}))
+		Expect(trailers).To(Not(HaveKeyWithValue("unknownkey", []string{"Value"})))
+
+	})
+
+	It("write non-announced trailer (with trailer prefix)", func() {
+		rw.Header().Set("Trailer", "Key")
+		rw.WriteHeader(200)
+		rw.Write([]byte("foobar"))
+		rw.Header().Set("Key", "Value")
+		rw.Header().Set(http2.TrailerPrefix+"Key2", "Value")
+
+		// Needs to call writeTrailers to simulate the end of the handler
+		Expect(rw.writeTrailers()).ToNot(HaveOccurred())
+		headers := decodeHeader(strBuf)
+		Expect(headers).To(HaveKeyWithValue(":status", []string{"200"}))
+		Expect(headers).To(HaveKeyWithValue("trailer", []string{"Key"}))
+
+		Expect(getData(strBuf)).To(Equal([]byte("foobar")))
+
+		trailers := decodeHeader(strBuf)
+		Expect(trailers).To(HaveKeyWithValue("key", []string{"Value"}))
+		Expect(trailers).To(HaveKeyWithValue("key2", []string{"Value"}))
 	})
 })

--- a/http3/server.go
+++ b/http3/server.go
@@ -624,7 +624,8 @@ func (s *Server) handleRequest(conn *connection, str quic.Stream, datagrams *dat
 				r.header.Set("Content-Length", strconv.FormatInt(r.numWritten, 10))
 			}
 		}
-		r.flushFinal()
+		r.Flush()
+		r.flushTrailers()
 	}
 
 	// abort the stream when there is a panic

--- a/http3/server.go
+++ b/http3/server.go
@@ -610,6 +610,10 @@ func (s *Server) handleRequest(conn *connection, str quic.Stream, datagrams *dat
 			}
 		}()
 		handler.ServeHTTP(r, req)
+		if err := r.writeTrailers(); err != nil {
+			conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeGeneralProtocolError), "unexpected error writing headers")
+			return
+		}
 	}()
 
 	if r.wasStreamHijacked() {

--- a/http3/server.go
+++ b/http3/server.go
@@ -610,10 +610,6 @@ func (s *Server) handleRequest(conn *connection, str quic.Stream, datagrams *dat
 			}
 		}()
 		handler.ServeHTTP(r, req)
-		if err := r.writeTrailers(); err != nil {
-			conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeGeneralProtocolError), "unexpected error writing headers")
-			return
-		}
 	}()
 
 	if r.wasStreamHijacked() {

--- a/http3/server.go
+++ b/http3/server.go
@@ -624,7 +624,7 @@ func (s *Server) handleRequest(conn *connection, str quic.Stream, datagrams *dat
 				r.header.Set("Content-Length", strconv.FormatInt(r.numWritten, 10))
 			}
 		}
-		r.Flush()
+		r.flushFinal()
 	}
 
 	// abort the stream when there is a panic

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -1026,7 +1026,6 @@ var _ = Describe("HTTP tests", func() {
 			defer GinkgoRecover()
 			w.Header().Set("Trailer", "AtEnd1, AtEnd2")
 			w.Header().Add("Trailer", "LAST")
-
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8") // normal header
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("AtEnd1", "value 1")
@@ -1043,15 +1042,15 @@ var _ = Describe("HTTP tests", func() {
 		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/trailers", port))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(200))
-		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 3*time.Second))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(string(body)).To(Equal("This HTTP response has both headers before this text and trailers at the end.\nMore text\n"))
-		// note: canonical header casing is applied to the trailer names, so "LAST" is now "Last"
-		Expect(resp.Header.Values("Trailer")).To(Equal([]string{"Atend1", "Atend2", "Last"}))
+		Expect(resp.Header.Values("Trailer")).To(Equal([]string{"AtEnd1, AtEnd2", "LAST"}))
 		Expect(resp.Header).To(Not(HaveKey("Atend1")))
 		Expect(resp.Header).To(Not(HaveKey("Atend2")))
 		Expect(resp.Header).To(Not(HaveKey("Last")))
 		Expect(resp.Header).To(Not(HaveKey("Late-Header")))
+
+		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 3*time.Second))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(body)).To(Equal("This HTTP response has both headers before this text and trailers at the end.\nMore text\n"))
 		for k := range resp.Header {
 			Expect(k).To(Not(HavePrefix(http.TrailerPrefix)))
 		}

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -1033,6 +1033,8 @@ var _ = Describe("HTTP tests", func() {
 			io.WriteString(w, "This HTTP response has both headers before this text and trailers at the end.\n")
 			w.(http.Flusher).Flush()
 			w.Header().Set("AtEnd2", "value 2")
+			io.WriteString(w, "More text\n")
+			w.(http.Flusher).Flush()
 			w.Header().Set("LAST", "value 3")
 			w.Header().Set(http.TrailerPrefix+"Unannounced", "Surprise!")
 			w.Header().Set("Late-Header", "No surprise!")
@@ -1043,7 +1045,7 @@ var _ = Describe("HTTP tests", func() {
 		Expect(resp.StatusCode).To(Equal(200))
 		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 3*time.Second))
 		Expect(err).ToNot(HaveOccurred())
-		Expect(string(body)).To(Equal("This HTTP response has both headers before this text and trailers at the end.\n"))
+		Expect(string(body)).To(Equal("This HTTP response has both headers before this text and trailers at the end.\nMore text\n"))
 		// note: canonical header casing is applied to the trailer names, so "LAST" is now "Last"
 		Expect(resp.Header.Values("Trailer")).To(Equal([]string{"Atend1", "Atend2", "Last"}))
 		Expect(resp.Header).To(Not(HaveKey("Atend1")))


### PR DESCRIPTION
Closes #2344. Fixes #2266.

---

This is a continuation of the work done in https://github.com/quic-go/quic-go/pull/2344 and will resolve the server half of https://github.com/quic-go/quic-go/issues/2266. This adds support for writing trailers and a functional test which verifies the basic functionality of trailers for the quic-go http3 client and server. Because of that, this PR rely on #4581.