### PR TITLE
interop: fix server setup for the HTTP/0.9 server

### DIFF
--- a/interop/http09/http_test.go
+++ b/interop/http09/http_test.go
@@ -27,9 +27,7 @@ var _ = Describe("HTTP 0.9 integration tests", func() {
 	})
 
 	BeforeEach(func() {
-		server := &Server{
-			Server: &http.Server{},
-		}
+		server := &Server{}
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
 		Expect(err).ToNot(HaveOccurred())
 		tr := &quic.Transport{Conn: conn}

--- a/interop/http09/server.go
+++ b/interop/http09/server.go
@@ -2,7 +2,6 @@ package http09
 
 import (
 	"context"
-	"errors"
 	"io"
 	"log"
 	"net/http"
@@ -33,15 +32,11 @@ func (w *responseWriter) WriteHeader(int) {}
 
 // Server is a HTTP/0.9 server listening for QUIC connections.
 type Server struct {
-	*http.Server
+	Handler *http.ServeMux
 }
 
-// ListenAndServe listens and serves HTTP/0.9 over QUIC.
+// ServeListener serves HTTP/0.9 on all connections accepted from a QUIC listener.
 func (s *Server) ServeListener(ln *quic.EarlyListener) error {
-	if s.Server == nil {
-		return errors.New("use of http3.Server without http.Server")
-	}
-
 	for {
 		conn, err := ln.Accept(context.Background())
 		if err != nil {


### PR DESCRIPTION
This broke in #4651.