### PR TITLE
timer: fix behavior for new go1.23 timer semantics

### DIFF
--- a/internal/utils/timer.go
+++ b/internal/utils/timer.go
@@ -32,7 +32,10 @@ func (t *Timer) Reset(deadline time.Time) {
 	// We need to drain the timer if the value from its channel was not read yet.
 	// See https://groups.google.com/forum/#!topic/golang-dev/c9UUfASVPoU
 	if !t.t.Stop() && !t.read {
-		<-t.t.C
+		select {
+		case <-t.t.C:
+		default:
+		}
 	}
 	if !deadline.IsZero() {
 		t.t.Reset(time.Until(deadline))


### PR DESCRIPTION
New unbuffered timer introduced in go1.23 breaks the existing implementation specifically the part where the timer channel will not have any stale reads after `timer.Stop` returns.  

To verify
1.run kubo 0.30.0-rc2 for 10 minutes. 
2. Now try stopping the daemon with ctrl+c. It'll fail(not exit) because a few goroutines are stuck on https://github.com/quic-go/quic-go/blob/master/internal/utils/timer.go#L35. You can put a print statement there to verify that's what's exactly happening. 

From reading all the documentation, I expected this to work as it is because if we haven't read from the timer channel `timer.Stop` should return true. But that's not the case(possibly a golang bug?).

It can happen that `timer.Stop` returns false and we haven't received anything from the timer channel. This happens when the timer is [executed](https://github.com/golang/go/blob/master/src/runtime/time.go#L971) concurrently with [timer.Stop](https://github.com/golang/go/blob/master/src/runtime/time.go#L334). 
This is specifically the section that leads to this behavior: https://github.com/golang/go/blob/master/src/runtime/time.go#L1033-L1050. 




