### PR TITLE
fix handling of corrupted coalesced 1-RTT packets

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -864,7 +864,9 @@ func (s *connection) handlePacketImpl(rp receivedPacket) bool {
 			if counter > 0 {
 				p.buffer.Split()
 			}
-			processed = s.handleShortHeaderPacket(p)
+			if wasProcessed := s.handleShortHeaderPacket(p); wasProcessed {
+				processed = true
+			}
 			break
 		}
 	}


### PR DESCRIPTION
When receiving an undecryptable packet, we're careful to not modify any internal state. This means:
* not modifying any timers
* not sending anything in response

We do this to prevent an attacker from modifying the state.

However, this logic had a bug when dealing with coalesced packets: If the 1-RTT packet is undecryptable, we'd ignore the fact that we were able to successfully decrypt the Initial / Handshake packets in the same coalesced packet.

As a consequence, we'd fail to send out an ACK for the initial packet:
<img width="1354" alt="image" src="https://github.com/user-attachments/assets/3d071bb9-cc41-4f31-a8e2-5e0879889fb2">
As you can see, the ACK for the server's Initial packet 1 is only sent on PTO expiration (it should have been sent immediately). This leads the server to believe that the RTT is >400ms.

This is especially relevant since some QUIC implementations use the lazy way to pad packets: add bytes (in most cases, 0s) at the end of a coalesced packet. This would be interpreted as a coalesced packet.