### PR TITLE
ci: control concurrency of the interop Docker image builder

### DIFF
--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -5,7 +5,11 @@ on:
       - master
     tags:
       - 'v*'
-  
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   interop:
     runs-on: ${{ fromJSON(vars['DOCKER_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}


### PR DESCRIPTION
This makes sure that only the latest commit is pushed to the Docker registry.