### PR TITLE
fix calculation of idle timeout when the peer set max_idle_timeout to 0

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1768,8 +1768,9 @@ func (s *connection) applyTransportParameters() {
 	params := s.peerParams
 	// Our local idle timeout will always be > 0.
 	s.idleTimeout = s.config.MaxIdleTimeout
-	if s.idleTimeout > 0 && params.MaxIdleTimeout < s.idleTimeout {
-		s.idleTimeout = params.MaxIdleTimeout
+	// If the peer advertised an idle timeout, take the minimum of the values.
+	if params.MaxIdleTimeout > 0 {
+		s.idleTimeout = min(s.idleTimeout, params.MaxIdleTimeout)
 	}
 	s.keepAliveInterval = min(s.config.KeepAlivePeriod, min(s.idleTimeout/2, protocol.MaxKeepAliveInterval))
 	s.streamsMap.UpdateLimits(params)


### PR DESCRIPTION
Fixes #4644.

In that case, the idle timeout should be our local value, not 0.

@Blankwonder Could you take a look at this PR please?