### PR TITLE
http3: send GOAWAY when server is shutting down

### DIFF
--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/quic-go/quic-go"
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
-	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -329,7 +328,7 @@ var _ = Describe("Frames", func() {
 			frame, err := fp.ParseNext()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&goawayFrame{}))
-			Expect(frame.(*goawayFrame).StreamID).To(Equal(protocol.StreamID(100)))
+			Expect(frame.(*goawayFrame).StreamID).To(Equal(quic.StreamID(100)))
 		})
 
 		It("writes", func() {
@@ -339,7 +338,7 @@ var _ = Describe("Frames", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(BeAssignableToTypeOf(&goawayFrame{}))
-			Expect(frame.(*goawayFrame).StreamID).To(Equal(protocol.StreamID(200)))
+			Expect(frame.(*goawayFrame).StreamID).To(Equal(quic.StreamID(200)))
 		})
 	})
 })

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/quic-go/quic-go/internal/protocol"
 	"io"
 
 	"github.com/quic-go/quic-go"
@@ -316,6 +317,29 @@ var _ = Describe("Frames", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(frame).To(Equal(&dataFrame{Length: 6}))
 			Expect(called).To(BeTrue())
+		})
+	})
+
+	Context("goaway frames", func() {
+		It("parses", func() {
+			data := quicvarint.Append(nil, 0x7) // type byte
+			data = quicvarint.Append(data, uint64(quicvarint.Len(100)))
+			data = quicvarint.Append(data, 100)
+			fp := frameParser{r: bytes.NewReader(data)}
+			frame, err := fp.ParseNext()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame).To(BeAssignableToTypeOf(&goawayFrame{}))
+			Expect(frame.(*goawayFrame).StreamID).To(Equal(protocol.StreamID(100)))
+		})
+
+		It("writes", func() {
+			data := (&goawayFrame{StreamID: 200}).Append(nil)
+			fp := frameParser{r: bytes.NewReader(data)}
+			frame, err := fp.ParseNext()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(frame).To(BeAssignableToTypeOf(&goawayFrame{}))
+			Expect(frame.(*goawayFrame).StreamID).To(Equal(protocol.StreamID(200)))
 		})
 	})
 })

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/quic-go/quic-go/internal/protocol"
 	"io"
 
 	"github.com/quic-go/quic-go"
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
+	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/quicvarint"
 
 	. "github.com/onsi/ginkgo/v2"

--- a/http3/server.go
+++ b/http3/server.go
@@ -707,6 +707,7 @@ func (s *Server) Close() error {
 	if s.closeCtx == nil {
 		return nil
 	}
+	s.closeCancel()
 
 	var err error
 	for ln := range s.listeners {
@@ -727,6 +728,7 @@ func (s *Server) CloseGracefully(ctx context.Context) error {
 		s.mutex.Unlock()
 		return nil
 	}
+	s.closeCancel()
 	s.mutex.Unlock()
 
 	// fast check if there is no serve goroutine running

--- a/http3/server.go
+++ b/http3/server.go
@@ -509,7 +509,7 @@ func (s *Server) handleConn(conn quic.Connection) error {
 	}()
 
 	// first valid ID is zero, subtract 4, so goaway frame id starts at 0
-	var lastID = quic.StreamID(-4)
+	lastID := quic.StreamID(-4)
 
 	hconn := newConnection(
 		ctx,

--- a/http3/server.go
+++ b/http3/server.go
@@ -334,6 +334,10 @@ func (s *Server) serveListener(ln QUICEarlyListener) error {
 				if s.Logger != nil {
 					s.Logger.Debug("handling connection failed", "error", err)
 				}
+				// server closed
+				if s.closeCtx.Err() != nil {
+					conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
+				}
 			}
 		}()
 	}
@@ -554,8 +558,6 @@ func (s *Server) handleConn(conn quic.Connection) error {
 				case <-handlingDoneChan:
 				case <-s.closeCtx.Done():
 				}
-				// close the connection
-				conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
 				return http.ErrServerClosed
 			}
 

--- a/http3/server.go
+++ b/http3/server.go
@@ -512,7 +512,7 @@ func (s *Server) handleConn(conn quic.Connection) error {
 		wg.Wait()
 		s.mutex.RLock()
 		// close once when the server is closed and the connection count is zero
-		if s.closed && s.connCount.Add(-1) == 0 && s.doneChanClosed.CompareAndSwap(false, true) {
+		if s.connCount.Add(-1) == 0 && s.closed && s.doneChanClosed.CompareAndSwap(false, true) {
 			close(s.closeDoneChan)
 		}
 		s.mutex.RUnlock()

--- a/http3/server.go
+++ b/http3/server.go
@@ -558,6 +558,7 @@ func (s *Server) handleConn(conn quic.Connection) error {
 
 				select {
 				// some requests may be still running, wait for them to finish before returning
+				// do nothing let quic to deliver the data the peer
 				case <-handlingDoneChan:
 				case <-s.closeCtx.Done():
 					// close the connection after graceful period

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -76,7 +76,8 @@ var _ = Describe("Server", func() {
 			},
 		}
 		s.closeCtx, s.closeCancel = context.WithCancel(context.Background())
-		s.closeDoneChan = make(chan struct{})
+		s.graceCtx, s.graceCancel = context.WithCancel(s.closeCtx)
+		s.graceDoneChan = make(chan struct{})
 		origQuicListenAddr = quicListenAddr
 	})
 

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -75,6 +75,7 @@ var _ = Describe("Server", func() {
 				return context.WithValue(ctx, testConnContextKey("test"), c)
 			},
 		}
+		s.closeCtx, s.closeCancel = context.WithCancel(context.Background())
 		origQuicListenAddr = quicListenAddr
 	})
 
@@ -1198,7 +1199,7 @@ var _ = Describe("Server", func() {
 	})
 
 	It("closes gracefully", func() {
-		Expect(s.CloseGracefully(0)).To(Succeed())
+		Expect(s.CloseGracefully(context.Background())).To(Succeed())
 	})
 
 	It("errors when listening fails", func() {

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -359,7 +359,7 @@ var _ = Describe("Server", func() {
 				})
 				ctx := context.WithValue(context.Background(), quic.ConnectionTracingKey, id)
 				conn.EXPECT().Context().Return(ctx).AnyTimes()
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(frameTypeChan).Should(Receive(BeEquivalentTo(0x41)))
 				time.Sleep(scaleDuration(20 * time.Millisecond)) // don't EXPECT any calls to conn.CloseWithError
 			})
@@ -387,7 +387,7 @@ var _ = Describe("Server", func() {
 				})
 				ctx := context.WithValue(context.Background(), quic.ConnectionTracingKey, quic.ConnectionTracingID(1234))
 				conn.EXPECT().Context().Return(ctx).AnyTimes()
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(frameTypeChan).Should(Receive(BeEquivalentTo(0x41)))
 				time.Sleep(scaleDuration(20 * time.Millisecond)) // don't EXPECT any calls to conn.CloseWithError
 			})
@@ -415,7 +415,7 @@ var _ = Describe("Server", func() {
 				})
 				ctx := context.WithValue(context.Background(), quic.ConnectionTracingKey, quic.ConnectionTracingID(1234))
 				conn.EXPECT().Context().Return(ctx).AnyTimes()
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(frameTypeChan).Should(Receive(BeEquivalentTo(0x41)))
 				time.Sleep(scaleDuration(20 * time.Millisecond)) // don't EXPECT any calls to conn.CloseWithError
 			})
@@ -443,7 +443,7 @@ var _ = Describe("Server", func() {
 				})
 				ctx := context.WithValue(context.Background(), quic.ConnectionTracingKey, quic.ConnectionTracingID(1234))
 				conn.EXPECT().Context().Return(ctx).AnyTimes()
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(done).Should(BeClosed())
 				time.Sleep(scaleDuration(20 * time.Millisecond)) // don't EXPECT any calls to conn.CloseWithError
 			})
@@ -488,7 +488,7 @@ var _ = Describe("Server", func() {
 				})
 				ctx := context.WithValue(context.Background(), quic.ConnectionTracingKey, id)
 				conn.EXPECT().Context().Return(ctx).AnyTimes()
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(streamTypeChan).Should(Receive(BeEquivalentTo(0x54)))
 				time.Sleep(scaleDuration(20 * time.Millisecond)) // don't EXPECT any calls to conn.CloseWithError
 			})
@@ -513,7 +513,7 @@ var _ = Describe("Server", func() {
 				})
 				ctx := context.WithValue(context.Background(), quic.ConnectionTracingKey, quic.ConnectionTracingID(1234))
 				conn.EXPECT().Context().Return(ctx).AnyTimes()
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(done).Should(BeClosed())
 				time.Sleep(scaleDuration(20 * time.Millisecond)) // don't EXPECT any calls to conn.CloseWithError
 			})
@@ -540,7 +540,7 @@ var _ = Describe("Server", func() {
 				})
 				ctx := context.WithValue(context.Background(), quic.ConnectionTracingKey, quic.ConnectionTracingID(1234))
 				conn.EXPECT().Context().Return(ctx).AnyTimes()
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(streamTypeChan).Should(Receive(BeEquivalentTo(0x54)))
 				time.Sleep(scaleDuration(20 * time.Millisecond)) // don't EXPECT any calls to conn.CloseWithError
 			})
@@ -588,7 +588,7 @@ var _ = Describe("Server", func() {
 				str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeNoError))
 				str.EXPECT().Close().Do(func() error { close(done); return nil })
 
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(done).Should(BeClosed())
 				hfs := decodeHeader(responseBuf)
 				Expect(hfs).To(HaveKeyWithValue(":status", []string{"200"}))
@@ -610,7 +610,7 @@ var _ = Describe("Server", func() {
 				var buf bytes.Buffer
 				str.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
 
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(handlerCalled).Should(BeClosed())
 
 				// The buffer is expected to contain:
@@ -646,7 +646,7 @@ var _ = Describe("Server", func() {
 				str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeFrameError))
 				str.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeFrameError)).Do(func(quic.StreamErrorCode) { close(done) })
 
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(done).Should(BeClosed())
 			})
 
@@ -662,7 +662,7 @@ var _ = Describe("Server", func() {
 				str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeRequestIncomplete))
 				str.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeRequestIncomplete)).Do(func(quic.StreamErrorCode) { close(done) })
 
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Consistently(handlerCalled).ShouldNot(BeClosed())
 			})
 
@@ -683,7 +683,7 @@ var _ = Describe("Server", func() {
 					close(done)
 					return nil
 				})
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(done).Should(BeClosed())
 			})
 
@@ -706,7 +706,7 @@ var _ = Describe("Server", func() {
 				str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeFrameError))
 				str.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeFrameError)).Do(func(quic.StreamErrorCode) { close(done) })
 
-				s.handleConn(context.Background(), conn)
+				s.handleConn(conn)
 				Eventually(done).Should(BeClosed())
 			})
 		})

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Server", func() {
 			},
 		}
 		s.closeCtx, s.closeCancel = context.WithCancel(context.Background())
+		s.closeDoneChan = make(chan struct{})
 		origQuicListenAddr = quicListenAddr
 	})
 

--- a/integrationtests/self/hotswap_test.go
+++ b/integrationtests/self/hotswap_test.go
@@ -46,7 +46,6 @@ type fakeClosingListener struct {
 }
 
 func (ln *fakeClosingListener) Accept(ctx context.Context) (quic.EarlyConnection, error) {
-	Expect(ctx).To(Equal(context.Background()))
 	return ln.listenerWrapper.Accept(ln.ctx)
 }
 

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -1102,8 +1102,8 @@ var _ = Describe("HTTP tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			close(serverDoneChan)
 		}()
-		Eventually(clientDoneChan).Should(BeClosed())
-		Eventually(serverDoneChan).Should(BeClosed())
+		Eventually(clientDoneChan, "5s").Should(BeClosed())
+		Eventually(serverDoneChan, "5s").Should(BeClosed())
 	})
 
 	It("graceful shutdown successfully with timeout", func() {
@@ -1165,7 +1165,7 @@ var _ = Describe("HTTP tests", func() {
 			Expect(err).To(HaveOccurred())
 			close(serverDoneChan)
 		}()
-		Eventually(fastDoneChan).Should(BeClosed())
+		Eventually(fastDoneChan, "5s").Should(BeClosed())
 		Eventually(slowDoneChan, "20s").Should(BeClosed())
 		Eventually(serverDoneChan, "10s").Should(BeClosed())
 	})

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -1080,16 +1080,16 @@ var _ = Describe("HTTP tests", func() {
 
 		mux.HandleFunc("/fast", func(w http.ResponseWriter, r *http.Request) {
 			close(fastChan)
-			w.Write(PRData)
+			w.Write(PRDataLong)
 		})
 		mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
 			close(slowChan)
 			ticker := time.NewTicker(time.Second)
 			defer ticker.Stop()
-			chunkSize := len(PRData) / 20
-			for i := range 20 {
+			chunkSize := len(PRDataLong) / 10
+			for i := range 10 {
 				<-ticker.C
-				w.Write(PRData[i*chunkSize : (i+1)*chunkSize])
+				w.Write(PRDataLong[i*chunkSize : (i+1)*chunkSize])
 			}
 		})
 		// makes two requests, one fast and one slow, both are expected to finish successfully
@@ -1100,7 +1100,7 @@ var _ = Describe("HTTP tests", func() {
 			Expect(resp.StatusCode).To(Equal(200))
 			body, err := io.ReadAll(resp.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(body).To(Equal(PRData))
+			Expect(body).To(Equal(PRDataLong))
 			wg.Done()
 		}()
 		wg.Add(1)
@@ -1110,7 +1110,7 @@ var _ = Describe("HTTP tests", func() {
 			Expect(resp.StatusCode).To(Equal(200))
 			body, err := io.ReadAll(resp.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(body).To(Equal(PRData))
+			Expect(body).To(Equal(PRDataLong))
 			wg.Done()
 		}()
 
@@ -1135,16 +1135,16 @@ var _ = Describe("HTTP tests", func() {
 
 		mux.HandleFunc("/fast", func(w http.ResponseWriter, r *http.Request) {
 			close(fastChan)
-			w.Write(PRData)
+			w.Write(PRDataLong)
 		})
 		mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
 			close(slowChan)
 			ticker := time.NewTicker(time.Second)
 			defer ticker.Stop()
-			chunkSize := len(PRData) / 20
-			for i := range 20 {
+			chunkSize := len(PRDataLong) / 10
+			for i := range 10 {
 				<-ticker.C
-				w.Write(PRData[i*chunkSize : (i+1)*chunkSize])
+				w.Write(PRDataLong[i*chunkSize : (i+1)*chunkSize])
 			}
 		})
 		// makes two requests, one fast and one slow
@@ -1156,7 +1156,7 @@ var _ = Describe("HTTP tests", func() {
 			Expect(resp.StatusCode).To(Equal(200))
 			body, err := io.ReadAll(resp.Body)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(body).To(Equal(PRData))
+			Expect(body).To(Equal(PRDataLong))
 			wg.Done()
 		}()
 		wg.Add(1)
@@ -1167,7 +1167,7 @@ var _ = Describe("HTTP tests", func() {
 			Expect(resp.StatusCode).To(Equal(200))
 			body, err := io.ReadAll(resp.Body)
 			Expect(err).To(HaveOccurred())
-			Expect(bytes.HasPrefix(PRData, body)).To(BeTrue())
+			Expect(bytes.HasPrefix(PRDataLong, body)).To(BeTrue())
 			wg.Done()
 		}()
 
@@ -1183,5 +1183,4 @@ var _ = Describe("HTTP tests", func() {
 		}()
 		wg.Wait()
 	})
-
 })

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -1166,7 +1166,7 @@ var _ = Describe("HTTP tests", func() {
 			close(serverDoneChan)
 		}()
 		Eventually(fastDoneChan, "5s").Should(BeClosed())
-		Eventually(slowDoneChan, "20s").Should(BeClosed())
 		Eventually(serverDoneChan, "10s").Should(BeClosed())
+		Eventually(slowDoneChan, "40s").Should(BeClosed())
 	})
 })

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -1075,6 +1075,7 @@ var _ = Describe("HTTP tests", func() {
 		var (
 			fastChan = make(chan struct{})
 			slowChan = make(chan struct{})
+			wg       sync.WaitGroup
 		)
 
 		mux.HandleFunc("/fast", func(w http.ResponseWriter, r *http.Request) {
@@ -1085,14 +1086,13 @@ var _ = Describe("HTTP tests", func() {
 			close(slowChan)
 			ticker := time.NewTicker(time.Second)
 			defer ticker.Stop()
-			chunkSize := len(PRData) / 10
-			for i := range 10 {
+			chunkSize := len(PRData) / 20
+			for i := range 20 {
 				<-ticker.C
 				w.Write(PRData[i*chunkSize : (i+1)*chunkSize])
 			}
 		})
 		// makes two requests, one fast and one slow, both are expected to finish successfully
-		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
 			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/fast", port))
@@ -1130,6 +1130,7 @@ var _ = Describe("HTTP tests", func() {
 		var (
 			fastChan = make(chan struct{})
 			slowChan = make(chan struct{})
+			wg       sync.WaitGroup
 		)
 
 		mux.HandleFunc("/fast", func(w http.ResponseWriter, r *http.Request) {
@@ -1140,14 +1141,13 @@ var _ = Describe("HTTP tests", func() {
 			close(slowChan)
 			ticker := time.NewTicker(time.Second)
 			defer ticker.Stop()
-			chunkSize := len(PRData) / 10
-			for i := range 10 {
+			chunkSize := len(PRData) / 20
+			for i := range 20 {
 				<-ticker.C
 				w.Write(PRData[i*chunkSize : (i+1)*chunkSize])
 			}
 		})
 		// makes two requests, one fast and one slow
-		var wg sync.WaitGroup
 		wg.Add(1)
 		// fast one will be done successfully
 		go func() {

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -1069,16 +1070,118 @@ var _ = Describe("HTTP tests", func() {
 		})))
 	})
 
-	It("aborts requests on shutdown", func() {
-		mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			Expect(server.Close()).To(Succeed())
-		})
+	It("graceful shutdown successfully with no timeout", func() {
+		// server will begin shutdown after receiving two requests
+		var (
+			fastChan = make(chan struct{})
+			slowChan = make(chan struct{})
+		)
 
-		_, err := client.Get(fmt.Sprintf("https://localhost:%d/shutdown", port))
-		Expect(err).To(HaveOccurred())
-		var appErr *http3.Error
-		Expect(errors.As(err, &appErr)).To(BeTrue())
-		Expect(appErr.ErrorCode).To(Equal(http3.ErrCodeNoError))
+		mux.HandleFunc("/fast", func(w http.ResponseWriter, r *http.Request) {
+			close(fastChan)
+			w.Write(PRData)
+		})
+		mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+			close(slowChan)
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
+			chunkSize := len(PRData) / 10
+			for i := range 10 {
+				<-ticker.C
+				w.Write(PRData[i*chunkSize : (i+1)*chunkSize])
+			}
+		})
+		// makes two requests, one fast and one slow, both are expected to finish successfully
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/fast", port))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(200))
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(body).To(Equal(PRData))
+			wg.Done()
+		}()
+		wg.Add(1)
+		go func() {
+			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/slow", port))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(200))
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(body).To(Equal(PRData))
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			<-fastChan
+			<-slowChan
+			err := server.CloseGracefully(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			wg.Done()
+		}()
+		wg.Wait()
 	})
+
+	It("graceful shutdown successfully with timeout", func() {
+		// server will begin shutdown after receiving two requests
+		var (
+			fastChan = make(chan struct{})
+			slowChan = make(chan struct{})
+		)
+
+		mux.HandleFunc("/fast", func(w http.ResponseWriter, r *http.Request) {
+			close(fastChan)
+			w.Write(PRData)
+		})
+		mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+			close(slowChan)
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
+			chunkSize := len(PRData) / 10
+			for i := range 10 {
+				<-ticker.C
+				w.Write(PRData[i*chunkSize : (i+1)*chunkSize])
+			}
+		})
+		// makes two requests, one fast and one slow
+		var wg sync.WaitGroup
+		wg.Add(1)
+		// fast one will be done successfully
+		go func() {
+			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/fast", port))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(200))
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(body).To(Equal(PRData))
+			wg.Done()
+		}()
+		wg.Add(1)
+		// slow one will be interrupted while reading the body
+		go func() {
+			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/slow", port))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(200))
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).To(HaveOccurred())
+			Expect(bytes.HasPrefix(PRData, body)).To(BeTrue())
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			<-fastChan
+			<-slowChan
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			err := server.CloseGracefully(ctx)
+			Expect(err).To(HaveOccurred())
+			wg.Done()
+		}()
+		wg.Wait()
+	})
+
 })


### PR DESCRIPTION
Part of #153. Supersedes [4407](https://github.com/quic-go/quic-go/pull/4407). Only implements server goaway sending logic.