### PR TITLE
http3: add (deprecated) type aliases for RoundTripper and SingleDestinationRoundTripper

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -68,6 +68,10 @@ type ClientConn struct {
 
 var _ http.RoundTripper = &ClientConn{}
 
+// Deprecated: SingleDestinationRoundTripper was renamed to ClientConn.
+// It can be obtained by calling NewClientConn on a Transport.
+type SingleDestinationRoundTripper = ClientConn
+
 func newClientConn(
 	conn quic.Connection,
 	enableDatagrams bool,

--- a/http3/transport.go
+++ b/http3/transport.go
@@ -117,6 +117,9 @@ var (
 	_ io.Closer         = &Transport{}
 )
 
+// Deprecated: RoundTripper was renamed to Transport.
+type RoundTripper = Transport
+
 // ErrNoCachedConn is returned when Transport.OnlyCachedConn is set
 var ErrNoCachedConn = errors.New("http3: no cached connection was available")
 


### PR DESCRIPTION
The changes introduced in https://github.com/quic-go/quic-go/pull/4693 are disruptive.

Adding type aliases will make transitioning to the new types easier when users upgrade.