### PR TITLE
http3: rename Server.CloseGracefully to Shutdown

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -747,10 +747,10 @@ func (s *Server) Close() error {
 	return err
 }
 
-// CloseGracefully shuts down the server gracefully.
+// Shutdown shuts down the server gracefully.
 // The server sends a GOAWAY frame first, then or for all running requests to complete.
-// CloseGracefully in combination with ListenAndServe() (instead of Serve()) may race if it is called before a UDP socket is established.
-func (s *Server) CloseGracefully(ctx context.Context) error {
+// Shutdown in combination with ListenAndServe() (instead of Serve()) may race if it is called before a UDP socket is established.
+func (s *Server) Shutdown(ctx context.Context) error {
 	s.mutex.Lock()
 	s.closed = true
 	// server is never used

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -1200,7 +1200,7 @@ var _ = Describe("Server", func() {
 	})
 
 	It("closes gracefully", func() {
-		Expect(s.CloseGracefully(context.Background())).To(Succeed())
+		Expect(s.Shutdown(context.Background())).To(Succeed())
 	})
 
 	It("errors when listening fails", func() {

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -1092,7 +1092,7 @@ var _ = Describe("HTTP tests", func() {
 			go func() {
 				defer GinkgoRecover()
 				defer close(done)
-				Expect(server.CloseGracefully(context.Background())).To(Succeed())
+				Expect(server.Shutdown(context.Background())).To(Succeed())
 				fmt.Println("close gracefully done")
 			}()
 			time.Sleep(delay)
@@ -1112,7 +1112,7 @@ var _ = Describe("HTTP tests", func() {
 		// manually close the client, since we don't support
 		client.Transport.(*http3.Transport).Close()
 
-		// make sure that CloseGracefully returned
+		// make sure that Shutdown returned
 		Eventually(done).Should(BeClosed())
 	})
 
@@ -1130,7 +1130,7 @@ var _ = Describe("HTTP tests", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), delay)
 				defer cancel()
 				defer close(shutdownDone)
-				Expect(server.CloseGracefully(ctx)).To(MatchError(context.DeadlineExceeded))
+				Expect(server.Shutdown(ctx)).To(MatchError(context.DeadlineExceeded))
 			}()
 			for t := range time.NewTicker(delay / 10).C {
 				if _, err := w.Write([]byte(t.String())); err != nil {
@@ -1155,7 +1155,7 @@ var _ = Describe("HTTP tests", func() {
 		Eventually(requestChan).Should(Receive(&requestDuration))
 		Expect(requestDuration).To(BeNumerically("~", delay, delay/2))
 
-		// make sure that CloseGracefully returned
+		// make sure that Shutdown returned
 		Eventually(shutdownDone).Should(BeClosed())
 	})
 })


### PR DESCRIPTION
This is more consistent with standard library naming for graceful shutdown methods for HTTP/1 and HTTP/2.