### PR TITLE
http3: fix graceful server shutdown

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -763,7 +763,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	s.mutex.Unlock()
 
 	if s.connCount.Load() == 0 {
-		return nil
+		return s.Close()
 	}
 	select {
 	case <-s.connHandlingDone: // all connections were closed

--- a/http3/server.go
+++ b/http3/server.go
@@ -222,7 +222,6 @@ type Server struct {
 	graceCtx         context.Context    // canceled when the server is closed or gracefully closed
 	graceCancel      context.CancelFunc // cancels the graceCtx
 	connCount        atomic.Int64
-	connDoneOnce     atomic.Bool
 	connHandlingDone chan struct{}
 
 	altSvcHeader string
@@ -286,7 +285,7 @@ func (s *Server) init() {
 }
 
 func (s *Server) decreaseConnCount() {
-	if s.connCount.Add(-1) == 0 && s.graceCtx.Err() != nil && s.connDoneOnce.CompareAndSwap(false, true) {
+	if s.connCount.Add(-1) == 0 && s.graceCtx.Err() != nil {
 		close(s.connHandlingDone)
 	}
 }


### PR DESCRIPTION
Fix [6643](https://github.com/caddyserver/caddy/issues/6643#event-14725985001). Also close the underlying quic listeners when there is no quic connection to clean them up.