### PR TITLE
enable DPLPMTUD on macOS dual-stack sockets

### DIFF
--- a/integrationtests/self/mtu_test.go
+++ b/integrationtests/self/mtu_test.go
@@ -72,7 +72,7 @@ var _ = Describe("DPLPMTUD", func() {
 		defer proxy.Close()
 
 		// Make sure to use v4-only socket here.
-		// We can't reliably set the DF bit on dual-stack sockets on macOS.
+		// We can't reliably set the DF bit on dual-stack sockets on macOS before Sequoia (macOS 15).
 		udpConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
 		Expect(err).ToNot(HaveOccurred())
 		defer udpConn.Close()

--- a/sys_conn.go
+++ b/sys_conn.go
@@ -58,8 +58,8 @@ func wrapConn(pc net.PacketConn) (rawConn, error) {
 			return nil, err
 		}
 
+		// only set DF on UDP sockets
 		if _, ok := pc.LocalAddr().(*net.UDPAddr); ok {
-			// Only set DF on sockets that we expect to be able to handle that configuration.
 			var err error
 			supportsDF, err = setDF(rawConn)
 			if err != nil {

--- a/sys_conn_df_darwin.go
+++ b/sys_conn_df_darwin.go
@@ -13,19 +13,22 @@ import (
 )
 
 func setDF(rawConn syscall.RawConn) (bool, error) {
-	// Setting DF bit is only supported from macOS11
+	// Setting DF bit is only supported from macOS 11.
 	// https://github.com/chromium/chromium/blob/117.0.5881.2/net/socket/udp_socket_posix.cc#L555
-	if supportsDF, err := isAtLeastMacOS11(); !supportsDF || err != nil {
+	version, err := getMacOSVersion()
+	if err != nil || version < 11 {
 		return false, err
 	}
 
 	var controlErr error
+	var disableDF bool
 	if err := rawConn.Control(func(fd uintptr) {
 		addr, err := unix.Getsockname(int(fd))
 		if err != nil {
 			controlErr = fmt.Errorf("getsockname: %w", err)
 			return
 		}
+
 		// Dual-stack sockets are effectively IPv6 sockets (with IPV6_ONLY set to 0).
 		// On macOS, the DF bit on dual-stack sockets is controlled by the IPV6_DONTFRAG option.
 		// See https://datatracker.ietf.org/doc/draft-seemann-tsvwg-udp-fragmentation/ for details.
@@ -34,13 +37,28 @@ func setDF(rawConn syscall.RawConn) (bool, error) {
 			controlErr = unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_DONTFRAG, 1)
 		case *unix.SockaddrInet6:
 			controlErr = unix.SetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_DONTFRAG, 1)
+
+			// Setting the DF bit on dual-stack sockets works since macOS Sequoia.
+			// Disable DF on dual-stack sockets before Sequoia.
+			if version < 15 {
+				// check if this is a dual-stack socket by reading the IPV6_V6ONLY flag
+				v6only, err := unix.GetsockoptInt(int(fd), unix.IPPROTO_IPV6, unix.IPV6_V6ONLY)
+				if err != nil {
+					controlErr = fmt.Errorf("getting IPV6_V6ONLY: %w", err)
+					return
+				}
+				disableDF = v6only == 0
+			}
 		default:
 			controlErr = fmt.Errorf("unknown address type: %T", addr)
 		}
 	}); err != nil {
 		return false, err
 	}
-	return controlErr == nil, controlErr
+	if controlErr != nil {
+		return false, controlErr
+	}
+	return !disableDF, nil
 }
 
 func isSendMsgSizeErr(err error) bool {
@@ -49,22 +67,22 @@ func isSendMsgSizeErr(err error) bool {
 
 func isRecvMsgSizeErr(error) bool { return false }
 
-func isAtLeastMacOS11() (bool, error) {
+// for macOS versions, see
+// https://en.wikipedia.org/wiki/Darwin_(operating_system)#Darwin_20_onwards
+func getMacOSVersion() (int, error) {
 	uname := &unix.Utsname{}
-	err := unix.Uname(uname)
-	if err != nil {
-		return false, err
+	if err := unix.Uname(uname); err != nil {
+		return 0, err
 	}
 
 	release := string(uname.Release[:])
-	if idx := strings.Index(release, "."); idx != -1 {
-		version, err := strconv.Atoi(release[:idx])
-		if err != nil {
-			return false, err
-		}
-		// Darwin version 20 is macOS version 11
-		// https://en.wikipedia.org/wiki/Darwin_(operating_system)#Darwin_20_onwards
-		return version >= 20, nil
+	idx := strings.Index(release, ".")
+	if idx == -1 {
+		return 0, nil
 	}
-	return false, nil
+	version, err := strconv.Atoi(release[:idx])
+	if err != nil {
+		return 0, err
+	}
+	return version, nil
 }

--- a/sys_conn_df_darwin_test.go
+++ b/sys_conn_df_darwin_test.go
@@ -1,0 +1,95 @@
+package quic
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIPFragmentation(t *testing.T) {
+	sink, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
+	require.NoError(t, err)
+	t.Cleanup(func() { sink.Close() })
+	sinkPort := sink.LocalAddr().(*net.UDPAddr).Port
+
+	canSendIPv4 := func(conn *net.UDPConn) bool {
+		_, err := conn.WriteTo([]byte("hello"), &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: sinkPort})
+		return err == nil
+	}
+
+	canSendIPv6 := func(conn *net.UDPConn) bool {
+		_, err := conn.WriteTo([]byte("hello"), &net.UDPAddr{IP: net.IPv6loopback, Port: sinkPort})
+		return err == nil
+	}
+
+	t.Run("udp4", func(t *testing.T) {
+		conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+		require.NoError(t, err)
+		defer conn.Close()
+
+		require.True(t, canSendIPv4(conn))
+		require.False(t, canSendIPv6(conn))
+
+		raw, err := conn.SyscallConn()
+		require.NoError(t, err)
+		canDF, _ := setDF(raw)
+		require.True(t, canDF)
+	})
+
+	t.Run("udp6", func(t *testing.T) {
+		conn, err := net.ListenUDP("udp6", &net.UDPAddr{IP: net.IPv6loopback, Port: 0})
+		require.NoError(t, err)
+		defer conn.Close()
+
+		require.False(t, canSendIPv4(conn))
+		require.True(t, canSendIPv6(conn))
+
+		raw, err := conn.SyscallConn()
+		require.NoError(t, err)
+		canDF, _ := setDF(raw)
+		require.True(t, canDF)
+	})
+
+	t.Run("udp, dual-stack", func(t *testing.T) {
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
+		require.NoError(t, err)
+		defer conn.Close()
+
+		require.True(t, canSendIPv4(conn))
+		require.True(t, canSendIPv6(conn))
+
+		raw, err := conn.SyscallConn()
+		require.NoError(t, err)
+		canDF, _ := setDF(raw)
+		require.True(t, canDF)
+	})
+
+	t.Run("udp, listening on IPv4", func(t *testing.T) {
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+		require.NoError(t, err)
+		defer conn.Close()
+
+		require.True(t, canSendIPv4(conn))
+		require.False(t, canSendIPv6(conn))
+
+		raw, err := conn.SyscallConn()
+		require.NoError(t, err)
+		canDF, _ := setDF(raw)
+		require.True(t, canDF)
+	})
+
+	t.Run("udp, listening on IPv6", func(t *testing.T) {
+		conn, err := net.ListenUDP("udp6", &net.UDPAddr{IP: net.IPv6loopback, Port: 0})
+		require.NoError(t, err)
+		defer conn.Close()
+
+		require.False(t, canSendIPv4(conn))
+		require.True(t, canSendIPv6(conn))
+
+		raw, err := conn.SyscallConn()
+		require.NoError(t, err)
+		canDF, _ := setDF(raw)
+		require.True(t, canDF)
+	})
+}

--- a/sys_conn_df_darwin_test.go
+++ b/sys_conn_df_darwin_test.go
@@ -52,6 +52,10 @@ func TestIPFragmentation(t *testing.T) {
 	})
 
 	t.Run("udp, dual-stack", func(t *testing.T) {
+		if version, err := getMacOSVersion(); err != nil || version < macOSVersion15 {
+			t.Skipf("skipping on darwin %d", version-9)
+		}
+
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
 		require.NoError(t, err)
 		defer conn.Close()


### PR DESCRIPTION
My new draft in the TSV WG (https://datatracker.ietf.org/doc/draft-seemann-tsvwg-udp-fragmentation/) contains details on how IP fragmentation is handled on different platforms.