### PR TITLE
flowcontrol: fix start of the flow-control auto-tuning period

### DIFF
--- a/internal/flowcontrol/base_flow_controller.go
+++ b/internal/flowcontrol/base_flow_controller.go
@@ -66,11 +66,6 @@ func (c *baseFlowController) sendWindowSize() protocol.ByteCount {
 
 // needs to be called with locked mutex
 func (c *baseFlowController) addBytesRead(n protocol.ByteCount) {
-	// pretend we sent a WindowUpdate when reading the first byte
-	// this way auto-tuning of the window size already works for the first WindowUpdate
-	if c.bytesRead == 0 {
-		c.startNewAutoTuningEpoch(time.Now())
-	}
 	c.bytesRead += n
 }
 

--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -46,7 +46,12 @@ func (c *connectionFlowController) IncrementHighestReceived(increment protocol.B
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
+	// If this is the first frame received on this connection, start flow-control auto-tuning.
+	if c.highestReceived == 0 {
+		c.startNewAutoTuningEpoch(time.Now())
+	}
 	c.highestReceived += increment
+
 	if c.checkFlowControlViolation() {
 		return &qerr.TransportError{
 			ErrorCode:    qerr.FlowControlError,


### PR DESCRIPTION
The period should start when the first frame is received, not when the data is first read. This makes a difference when the first STREAM frame is received out of order.