### PR TITLE
flowcontrol: fix timestamp used for receive window auto-tuning

### DIFF
--- a/internal/flowcontrol/base_flow_controller_test.go
+++ b/internal/flowcontrol/base_flow_controller_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Base Flow controller", func() {
 			bytesRemaining := receiveWindowSize - protocol.ByteCount(bytesConsumed)
 			readPosition := receiveWindow - bytesRemaining
 			controller.bytesRead = readPosition
-			offset := controller.getWindowUpdate()
+			offset := controller.getWindowUpdate(time.Now())
 			Expect(offset).To(Equal(readPosition + receiveWindowSize))
 			Expect(controller.receiveWindow).To(Equal(readPosition + receiveWindowSize))
 		})
@@ -122,7 +122,7 @@ var _ = Describe("Base Flow controller", func() {
 			bytesRemaining := receiveWindowSize - protocol.ByteCount(bytesConsumed)
 			readPosition := receiveWindow - bytesRemaining
 			controller.bytesRead = readPosition
-			offset := controller.getWindowUpdate()
+			offset := controller.getWindowUpdate(time.Now())
 			Expect(offset).To(BeZero())
 		})
 
@@ -141,7 +141,7 @@ var _ = Describe("Base Flow controller", func() {
 			}
 
 			It("doesn't increase the window size for a new stream", func() {
-				controller.maybeAdjustWindowSize()
+				controller.maybeAdjustWindowSize(time.Now())
 				Expect(controller.receiveWindowSize).To(Equal(oldWindowSize))
 			})
 
@@ -149,7 +149,7 @@ var _ = Describe("Base Flow controller", func() {
 				setRtt(0)
 				controller.startNewAutoTuningEpoch(time.Now())
 				controller.addBytesRead(400)
-				offset := controller.getWindowUpdate()
+				offset := controller.getWindowUpdate(time.Now())
 				Expect(offset).ToNot(BeZero()) // make sure a window update is sent
 				Expect(controller.receiveWindowSize).To(Equal(oldWindowSize))
 			})
@@ -164,7 +164,7 @@ var _ = Describe("Base Flow controller", func() {
 				controller.epochStartOffset = controller.bytesRead
 				controller.epochStartTime = time.Now().Add(-rtt * 4 * 2 / 3)
 				controller.addBytesRead(dataRead)
-				offset := controller.getWindowUpdate()
+				offset := controller.getWindowUpdate(time.Now())
 				Expect(offset).ToNot(BeZero())
 				// check that the window size was increased
 				newWindowSize := controller.receiveWindowSize
@@ -183,7 +183,7 @@ var _ = Describe("Base Flow controller", func() {
 				controller.epochStartOffset = controller.bytesRead
 				controller.epochStartTime = time.Now().Add(-rtt * 4 * 1 / 3)
 				controller.addBytesRead(dataRead)
-				offset := controller.getWindowUpdate()
+				offset := controller.getWindowUpdate(time.Now())
 				Expect(offset).ToNot(BeZero())
 				// check that the window size was not increased
 				newWindowSize := controller.receiveWindowSize
@@ -202,7 +202,7 @@ var _ = Describe("Base Flow controller", func() {
 				controller.epochStartOffset = controller.bytesRead
 				controller.epochStartTime = time.Now().Add(-rtt * 4 * 2 / 3)
 				controller.addBytesRead(dataRead)
-				offset := controller.getWindowUpdate()
+				offset := controller.getWindowUpdate(time.Now())
 				Expect(offset).ToNot(BeZero())
 				// check that the window size was not increased
 				Expect(controller.receiveWindowSize).To(Equal(oldWindowSize))
@@ -219,16 +219,16 @@ var _ = Describe("Base Flow controller", func() {
 				}
 				setRtt(scaleDuration(20 * time.Millisecond))
 				resetEpoch()
-				controller.maybeAdjustWindowSize()
+				controller.maybeAdjustWindowSize(time.Now())
 				Expect(controller.receiveWindowSize).To(Equal(2 * oldWindowSize)) // 2000
 				// because the lastWindowUpdateTime is updated by MaybeTriggerWindowUpdate(), we can just call maybeAdjustWindowSize() multiple times and get an increase of the window size every time
 				resetEpoch()
-				controller.maybeAdjustWindowSize()
+				controller.maybeAdjustWindowSize(time.Now())
 				Expect(controller.receiveWindowSize).To(Equal(2 * 2 * oldWindowSize)) // 4000
 				resetEpoch()
-				controller.maybeAdjustWindowSize()
+				controller.maybeAdjustWindowSize(time.Now())
 				Expect(controller.receiveWindowSize).To(Equal(controller.maxReceiveWindowSize)) // 5000
-				controller.maybeAdjustWindowSize()
+				controller.maybeAdjustWindowSize(time.Now())
 				Expect(controller.receiveWindowSize).To(Equal(controller.maxReceiveWindowSize)) // 5000
 			})
 		})

--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -67,10 +67,10 @@ func (c *connectionFlowController) AddBytesRead(n protocol.ByteCount) {
 	c.mutex.Unlock()
 }
 
-func (c *connectionFlowController) GetWindowUpdate(time.Time) protocol.ByteCount {
+func (c *connectionFlowController) GetWindowUpdate(now time.Time) protocol.ByteCount {
 	c.mutex.Lock()
 	oldWindowSize := c.receiveWindowSize
-	offset := c.baseFlowController.getWindowUpdate()
+	offset := c.baseFlowController.getWindowUpdate(now)
 	if c.logger.Debug() && oldWindowSize < c.receiveWindowSize {
 		c.logger.Debugf("Increasing receive flow control window for the connection to %d kB", c.receiveWindowSize/(1<<10))
 	}

--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -144,7 +144,7 @@ func (c *streamFlowController) GetWindowUpdate(now time.Time) protocol.ByteCount
 	// Don't use defer for unlocking the mutex here, GetWindowUpdate() is called frequently and defer shows up in the profiler
 	c.mutex.Lock()
 	oldWindowSize := c.receiveWindowSize
-	offset := c.baseFlowController.getWindowUpdate()
+	offset := c.baseFlowController.getWindowUpdate(now)
 	if c.receiveWindowSize > oldWindowSize { // auto-tuning enlarged the window size
 		c.logger.Debugf("Increasing receive flow control window for stream %d to %d kB", c.streamID, c.receiveWindowSize/(1<<10))
 		c.connection.EnsureMinimumWindowSize(protocol.ByteCount(float64(c.receiveWindowSize)*protocol.ConnectionFlowControlMultiplier), now)


### PR DESCRIPTION
Followup to #4731. Apparently we forgot to properly pass the timestamp everywhere.