### PR TITLE
remove the Token field from the StatelessResetError

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -622,20 +622,17 @@ var _ = Describe("Connection", func() {
 		})
 
 		It("closes due to a stateless reset", func() {
-			token := protocol.StatelessResetToken{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 			runConn()
 			gomock.InOrder(
 				tracer.EXPECT().ClosedConnection(gomock.Any()).Do(func(e error) {
-					var srErr *StatelessResetError
-					Expect(errors.As(e, &srErr)).To(BeTrue())
-					Expect(srErr.Token).To(Equal(token))
+					Expect(errors.Is(e, &qerr.StatelessResetError{})).To(BeTrue())
 				}),
 				tracer.EXPECT().Close(),
 			)
 			streamManager.EXPECT().CloseWithError(gomock.Any())
 			connRunner.EXPECT().Remove(gomock.Any()).AnyTimes()
 			cryptoSetup.EXPECT().Close()
-			conn.destroy(&StatelessResetError{Token: token})
+			conn.destroy(&StatelessResetError{})
 		})
 	})
 

--- a/internal/qerr/errors.go
+++ b/internal/qerr/errors.go
@@ -114,14 +114,12 @@ func (e *VersionNegotiationError) Is(target error) bool {
 }
 
 // A StatelessResetError occurs when we receive a stateless reset.
-type StatelessResetError struct {
-	Token protocol.StatelessResetToken
-}
+type StatelessResetError struct{}
 
 var _ net.Error = &StatelessResetError{}
 
 func (e *StatelessResetError) Error() string {
-	return fmt.Sprintf("received a stateless reset with token %x", e.Token)
+	return "received a stateless reset"
 }
 
 func (e *StatelessResetError) Is(target error) bool {

--- a/internal/qerr/errors_test.go
+++ b/internal/qerr/errors_test.go
@@ -117,9 +117,7 @@ func TestVersionNegotiationErrorString(t *testing.T) {
 }
 
 func TestStatelessResetErrorString(t *testing.T) {
-	token := protocol.StatelessResetToken{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}
-	err := &StatelessResetError{Token: token}
-	require.Equal(t, "received a stateless reset with token 000102030405060708090a0b0c0d0e0f", err.Error())
+	require.Equal(t, "received a stateless reset", (&StatelessResetError{}).Error())
 }
 
 func TestStatelessResetErrorIsNetError(t *testing.T) {

--- a/qlog/connection_tracer_test.go
+++ b/qlog/connection_tracer_test.go
@@ -134,18 +134,15 @@ func TestHandshakeTimeouts(t *testing.T) {
 
 func TestReceivedStatelessResetPacket(t *testing.T) {
 	tracer, buf := newConnectionTracer()
-	tracer.ClosedConnection(&quic.StatelessResetError{
-		Token: protocol.StatelessResetToken{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
-	})
+	tracer.ClosedConnection(&quic.StatelessResetError{})
 	tracer.Close()
 	entry := exportAndParseSingle(t, buf)
 	require.WithinDuration(t, time.Now(), entry.Time, scaleDuration(10*time.Millisecond))
 	require.Equal(t, "transport:connection_closed", entry.Name)
 	ev := entry.Event
-	require.Len(t, ev, 3)
+	require.Len(t, ev, 2)
 	require.Equal(t, "remote", ev["owner"])
 	require.Equal(t, "stateless_reset", ev["trigger"])
-	require.Equal(t, "00112233445566778899aabbccddeeff", ev["stateless_reset_token"])
 }
 
 func TestVersionNegotiationFailure(t *testing.T) {

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -124,7 +124,6 @@ func (e eventConnectionClosed) MarshalJSONObject(enc *gojay.Encoder) {
 	case errors.As(e.e, &statelessResetErr):
 		enc.StringKey("owner", ownerRemote.String())
 		enc.StringKey("trigger", "stateless_reset")
-		enc.StringKey("stateless_reset_token", fmt.Sprintf("%x", statelessResetErr.Token))
 	case errors.As(e.e, &handshakeTimeoutErr):
 		enc.StringKey("owner", ownerLocal.String())
 		enc.StringKey("trigger", "handshake_timeout")

--- a/transport.go
+++ b/transport.go
@@ -489,7 +489,7 @@ func (t *Transport) maybeHandleStatelessReset(data []byte) bool {
 	token := *(*protocol.StatelessResetToken)(data[len(data)-16:])
 	if conn, ok := t.handlerMap.GetByResetToken(token); ok {
 		t.logger.Debugf("Received a stateless reset with token %#x. Closing connection.", token)
-		go conn.destroy(&StatelessResetError{Token: token})
+		go conn.destroy(&StatelessResetError{})
 		return true
 	}
 	return false

--- a/transport_test.go
+++ b/transport_test.go
@@ -265,7 +265,7 @@ var _ = Describe("Transport", func() {
 			phm.EXPECT().Get(connID),
 			phm.EXPECT().GetByResetToken(token).Return(conn, true),
 			conn.EXPECT().destroy(gomock.Any()).Do(func(err error) {
-				Expect(err).To(MatchError(&StatelessResetError{Token: token}))
+				Expect(err).To(MatchError(&StatelessResetError{}))
 				close(destroyed)
 			}),
 		)


### PR DESCRIPTION
There's nothing the application could possibly do with this value.