### PR TITLE
qlog: simplify QLOGDIR test by using t.Setenv and t.TempDir

### DIFF
--- a/qlog/qlog_dir_test.go
+++ b/qlog/qlog_dir_test.go
@@ -10,15 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createTmpDir(t *testing.T) string {
-	path, err := os.MkdirTemp("", "temp_test_dir")
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, os.RemoveAll(path)) })
-	return path
-}
-
 func TestQLOGDIRSet(t *testing.T) {
-	tmpDir := createTmpDir(t)
+	tmpDir := t.TempDir()
 
 	connID, _ := protocol.GenerateConnectionIDForInitial()
 	qlogDir := filepath.Join(tmpDir, "qlogs")

--- a/qlog/qlog_dir_test.go
+++ b/qlog/qlog_dir_test.go
@@ -3,47 +3,32 @@ package qlog
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/quic-go/quic-go/internal/protocol"
-	"github.com/quic-go/quic-go/logging"
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	originalQlogDirValue string
-	tempTestDirPath      string
-	ctx                  = context.Background()
-	perspective          = logging.PerspectiveClient
-)
-
-func setup(t *testing.T) {
-	originalQlogDirValue = os.Getenv("QLOGDIR")
-	var err error
-	tempTestDirPath, err = os.MkdirTemp("", "temp_test_dir")
+func createTmpDir(t *testing.T) string {
+	path, err := os.MkdirTemp("", "temp_test_dir")
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(path)) })
+	return path
 }
 
-func cleanup(t *testing.T) {
-	require.NoError(t, os.Setenv("QLOGDIR", originalQlogDirValue))
-	require.NoError(t, os.RemoveAll(tempTestDirPath))
-}
-
-func TestEnvironmentVariableIsSet(t *testing.T) {
-	setup(t)
-	defer cleanup(t)
+func TestQLOGDIRSet(t *testing.T) {
+	tmpDir := createTmpDir(t)
 
 	connID, _ := protocol.GenerateConnectionIDForInitial()
-	qlogDir := path.Join(tempTestDirPath, "qlogs")
-	err := os.Setenv("QLOGDIR", qlogDir)
-	require.NoError(t, err)
+	qlogDir := filepath.Join(tmpDir, "qlogs")
+	t.Setenv("QLOGDIR", qlogDir)
 
-	tracer := DefaultConnectionTracer(ctx, perspective, connID)
+	tracer := DefaultConnectionTracer(context.Background(), protocol.PerspectiveClient, connID)
 	require.NotNil(t, tracer)
 	tracer.Close()
 
-	_, err = os.Stat(qlogDir)
+	_, err := os.Stat(qlogDir)
 	qlogDirCreated := !os.IsNotExist(err)
 	require.True(t, qlogDirCreated)
 
@@ -52,14 +37,10 @@ func TestEnvironmentVariableIsSet(t *testing.T) {
 	require.Len(t, childs, 1)
 }
 
-func TestEnvironmentVariableIsNotSet(t *testing.T) {
-	setup(t)
-	defer cleanup(t)
-
+func TestQLOGDIRNotSet(t *testing.T) {
 	connID, _ := protocol.GenerateConnectionIDForInitial()
-	err := os.Setenv("QLOGDIR", "")
-	require.NoError(t, err)
+	t.Setenv("QLOGDIR", "")
 
-	tracer := DefaultConnectionTracer(ctx, perspective, connID)
+	tracer := DefaultConnectionTracer(context.Background(), protocol.PerspectiveClient, connID)
 	require.Nil(t, tracer)
 }


### PR DESCRIPTION
I wasn't aware of `t.Setenv` and `t.TempDir`. Very convenient functions.