### PR TITLE
migrate HTTP/3 integration tests away from Ginkgo

### DIFF
--- a/integrationtests/self/http_datagram_test.go
+++ b/integrationtests/self/http_datagram_test.go
@@ -1,0 +1,309 @@
+package self_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPSettings(t *testing.T) {
+	mux := http.NewServeMux()
+	port := startHTTPServer(t, mux)
+
+	t.Run("server settings", func(t *testing.T) {
+		tlsConf := tlsClientConfigWithoutServerName.Clone()
+		tlsConf.NextProtos = []string{http3.NextProtoH3}
+		conn, err := quic.DialAddr(
+			context.Background(),
+			fmt.Sprintf("localhost:%d", port),
+			tlsConf,
+			getQuicConfig(nil),
+		)
+		require.NoError(t, err)
+		defer conn.CloseWithError(0, "")
+		var tr http3.Transport
+		cc := tr.NewClientConn(conn)
+
+		select {
+		case <-cc.ReceivedSettings():
+		case <-time.After(time.Second):
+			t.Fatal("didn't receive HTTP/3 settings")
+		}
+
+		settings := cc.Settings()
+		require.True(t, settings.EnableExtendedConnect)
+		require.False(t, settings.EnableDatagrams)
+		require.Empty(t, settings.Other)
+	})
+
+	t.Run("client settings", func(t *testing.T) {
+		connChan := make(chan http3.Connection, 1)
+		mux.HandleFunc("/settings", func(w http.ResponseWriter, r *http.Request) {
+			conn := w.(http3.Hijacker).Connection()
+			connChan <- conn
+			w.WriteHeader(http.StatusOK)
+		})
+
+		tr := &http3.Transport{
+			TLSClientConfig: getTLSClientConfigWithoutServerName(),
+			QUICConfig: getQuicConfig(&quic.Config{
+				MaxIdleTimeout:  10 * time.Second,
+				EnableDatagrams: true,
+			}),
+			EnableDatagrams:    true,
+			AdditionalSettings: map[uint64]uint64{1337: 42},
+		}
+		defer tr.Close()
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/settings", port), nil)
+		require.NoError(t, err)
+
+		_, err = tr.RoundTrip(req)
+		require.NoError(t, err)
+		var conn http3.Connection
+		select {
+		case conn = <-connChan:
+		case <-time.After(time.Second):
+			t.Fatal("didn't receive HTTP/3 connection")
+		}
+
+		select {
+		case <-conn.ReceivedSettings():
+		case <-time.After(time.Second):
+			t.Fatal("didn't receive HTTP/3 settings")
+		}
+		settings := conn.Settings()
+		require.NotNil(t, settings)
+		require.True(t, settings.EnableDatagrams)
+		require.False(t, settings.EnableExtendedConnect)
+		require.Equal(t, uint64(42), settings.Other[1337])
+	})
+}
+
+func dialAndOpenHTTPDatagramStream(t *testing.T, addr string) http3.RequestStream {
+	t.Helper()
+
+	u, err := url.Parse(addr)
+	require.NoError(t, err)
+
+	tlsConf := getTLSClientConfigWithoutServerName()
+	tlsConf.NextProtos = []string{http3.NextProtoH3}
+	conn, err := quic.DialAddr(context.Background(), u.Host, tlsConf, getQuicConfig(&quic.Config{EnableDatagrams: true}))
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.CloseWithError(0, "") })
+
+	tr := http3.Transport{EnableDatagrams: true}
+	t.Cleanup(func() { tr.Close() })
+	cc := tr.NewClientConn(conn)
+	t.Cleanup(func() { cc.CloseWithError(0, "") })
+	str, err := cc.OpenRequestStream(context.Background())
+	require.NoError(t, err)
+	req := &http.Request{
+		Method: http.MethodConnect,
+		Proto:  "datagrams",
+		Host:   u.Host,
+		URL:    u,
+	}
+	require.NoError(t, str.SendRequestHeader(req))
+
+	rsp, err := str.ReadResponse()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	return str
+}
+
+func TestHTTPDatagrams(t *testing.T) {
+	errChan := make(chan error, 1)
+	const num = 5
+	datagramChan := make(chan struct{}, num)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/datagrams", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		conn := w.(http3.Hijacker).Connection()
+		select {
+		case <-conn.ReceivedSettings():
+		case <-time.After(time.Second):
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if !conn.Settings().EnableDatagrams {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+
+		str := w.(http3.HTTPStreamer).HTTPStream()
+		go str.Read([]byte{0}) // need to continue reading from stream to observe state transitions
+
+		for {
+			if _, err := str.ReceiveDatagram(context.Background()); err != nil {
+				errChan <- err
+				return
+			}
+			datagramChan <- struct{}{}
+		}
+	})
+
+	port := startHTTPServer(t, mux, func(s *http3.Server) { s.EnableDatagrams = true })
+	str := dialAndOpenHTTPDatagramStream(t, fmt.Sprintf("https://localhost:%d/datagrams", port))
+
+	for i := 0; i < num; i++ {
+		b := make([]byte, 8)
+		binary.BigEndian.PutUint64(b, uint64(i))
+		require.NoError(t, str.SendDatagram(bytes.Repeat(b, 100)))
+	}
+	var count int
+loop:
+	for {
+		select {
+		case <-datagramChan:
+			count++
+			if count >= num*4/5 {
+				break loop
+			}
+		case err := <-errChan:
+			t.Fatalf("receiving datagrams failed: %s", err)
+		}
+	}
+	str.CancelWrite(42)
+
+	select {
+	case err := <-errChan:
+		var serr *quic.StreamError
+		require.ErrorAs(t, err, &serr)
+		require.Equal(t, quic.StreamErrorCode(42), serr.ErrorCode)
+	case <-time.After(time.Second):
+		t.Fatal("didn't receive error")
+	}
+}
+
+func TestHTTPDatagramClose(t *testing.T) {
+	errChan := make(chan error, 1)
+	datagramChan := make(chan []byte, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/datagrams", func(w http.ResponseWriter, r *http.Request) {
+		conn := w.(http3.Hijacker).Connection()
+		select {
+		case <-conn.ReceivedSettings():
+		case <-time.After(time.Second):
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if !conn.Settings().EnableDatagrams {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+
+		str := w.(http3.HTTPStreamer).HTTPStream()
+		go str.Read([]byte{0}) // need to continue reading from stream to observe state transitions
+
+		for {
+			data, err := str.ReceiveDatagram(context.Background())
+			if err != nil {
+				errChan <- err
+				return
+			}
+			datagramChan <- data
+		}
+	})
+
+	port := startHTTPServer(t, mux, func(s *http3.Server) { s.EnableDatagrams = true })
+	str := dialAndOpenHTTPDatagramStream(t, fmt.Sprintf("https://localhost:%d/datagrams", port))
+	go str.Read([]byte{0})
+
+	require.NoError(t, str.SendDatagram([]byte("foo")))
+	select {
+	case data := <-datagramChan:
+		require.Equal(t, []byte("foo"), data)
+	case <-time.After(time.Second):
+		t.Fatal("didn't receive datagram")
+	}
+	// signal that we're done sending
+	str.Close()
+
+	var resetErr error
+	select {
+	case resetErr = <-errChan:
+	case <-time.After(time.Second):
+		t.Fatal("didn't receive error")
+	}
+	require.Equal(t, io.EOF, resetErr)
+
+	// make sure we can't send anymore
+	require.Error(t, str.SendDatagram([]byte("foo")))
+}
+
+func TestHTTPDatagramStreamReset(t *testing.T) {
+	errChan := make(chan error, 1)
+	datagramChan := make(chan []byte, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/datagrams", func(w http.ResponseWriter, r *http.Request) {
+		conn := w.(http3.Hijacker).Connection()
+		select {
+		case <-conn.ReceivedSettings():
+		case <-time.After(time.Second):
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if !conn.Settings().EnableDatagrams {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+
+		str := w.(http3.HTTPStreamer).HTTPStream()
+		go str.Read([]byte{0}) // need to continue reading from stream to observe state transitions
+
+		for {
+			data, err := str.ReceiveDatagram(context.Background())
+			if err != nil {
+				errChan <- err
+				return
+			}
+			str.CancelRead(42)
+			datagramChan <- data
+		}
+	})
+
+	port := startHTTPServer(t, mux, func(s *http3.Server) { s.EnableDatagrams = true })
+	str := dialAndOpenHTTPDatagramStream(t, fmt.Sprintf("https://localhost:%d/datagrams", port))
+	go str.Read([]byte{0})
+
+	require.NoError(t, str.SendDatagram([]byte("foo")))
+	select {
+	case data := <-datagramChan:
+		require.Equal(t, []byte("foo"), data)
+	case <-time.After(time.Second):
+		t.Fatal("didn't receive datagram")
+	}
+
+	var resetErr error
+	select {
+	case resetErr = <-errChan:
+	case <-time.After(time.Second):
+		t.Fatal("didn't receive error")
+	}
+	require.Equal(t, &quic.StreamError{ErrorCode: 42, Remote: false}, resetErr)
+
+	var err error
+	require.Eventually(t, func() bool {
+		err = str.SendDatagram([]byte("foo"))
+		return err != nil
+	}, time.Second, 10*time.Millisecond)
+	// make sure we can't send anymore
+	require.Equal(t, &quic.StreamError{ErrorCode: 42, Remote: true}, err)
+}

--- a/integrationtests/self/http_shutdown_test.go
+++ b/integrationtests/self/http_shutdown_test.go
@@ -1,0 +1,127 @@
+package self_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPShutdown(t *testing.T) {
+	mux := http.NewServeMux()
+	var server *http3.Server
+	port := startHTTPServer(t, mux, func(s *http3.Server) { server = s })
+	client := newHTTP3Client(t)
+
+	mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
+		go func() {
+			require.NoError(t, server.Close())
+		}()
+		time.Sleep(50 * time.Millisecond) // make sure the server started shutting down
+	})
+
+	_, err := client.Get(fmt.Sprintf("https://localhost:%d/shutdown", port))
+	require.Error(t, err)
+	var appErr *http3.Error
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, http3.ErrCodeNoError, appErr.ErrorCode)
+}
+
+func TestGracefulShutdownShortRequest(t *testing.T) {
+	delay := scaleDuration(50 * time.Millisecond)
+
+	var server *http3.Server
+	mux := http.NewServeMux()
+	port := startHTTPServer(t, mux, func(s *http3.Server) { server = s })
+	errChan := make(chan error, 1)
+	mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
+		go func() {
+			defer close(errChan)
+			errChan <- server.Shutdown(context.Background())
+		}()
+		time.Sleep(delay)
+		w.Write([]byte("shutdown"))
+	})
+
+	client := newHTTP3Client(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*delay)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/shutdown", port), nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, []byte("shutdown"), body)
+	client.Transport.(*http3.Transport).Close() // manually close the client
+
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not complete")
+	}
+}
+
+func TestGracefulShutdownLongLivedRequest(t *testing.T) {
+	delay := scaleDuration(50 * time.Millisecond)
+	errChan := make(chan error, 1)
+	requestChan := make(chan time.Duration, 1)
+
+	var server *http3.Server
+	mux := http.NewServeMux()
+	port := startHTTPServer(t, mux, func(s *http3.Server) { server = s })
+	mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), delay)
+			defer cancel()
+			errChan <- server.Shutdown(ctx)
+		}()
+
+		// measure how long it takes until the request errors
+		for t := range time.NewTicker(delay / 10).C {
+			if _, err := w.Write([]byte(t.String())); err != nil {
+				requestChan <- time.Since(start)
+				return
+			}
+		}
+	})
+
+	start := time.Now()
+	resp, err := newHTTP3Client(t).Get(fmt.Sprintf("https://localhost:%d/shutdown", port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.Error(t, err)
+	var h3Err *http3.Error
+	require.ErrorAs(t, err, &h3Err)
+	require.Equal(t, http3.ErrCodeNoError, h3Err.ErrorCode)
+	took := time.Since(start)
+	require.InDelta(t, delay.Seconds(), took.Seconds(), (delay / 2).Seconds())
+
+	// make sure that shutdown returned due to context deadline
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not return due to context deadline")
+	}
+
+	select {
+	case requestDuration := <-requestChan:
+		require.InDelta(t, delay.Seconds(), requestDuration.Seconds(), (delay / 2).Seconds())
+	case <-time.After(time.Second):
+		t.Fatal("did not receive request duration")
+	}
+}

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -6,18 +6,18 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+	mrand "math/rand"
 	"net"
 	"net/http"
 	"net/http/httptrace"
 	"net/textproto"
-	"net/url"
 	"os"
 	"strconv"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -26,9 +26,7 @@ import (
 	"github.com/quic-go/quic-go/http3"
 	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
+	"github.com/stretchr/testify/require"
 )
 
 type neverEnding byte
@@ -40,1122 +38,922 @@ func (b neverEnding) Read(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-const deadlineDelay = 250 * time.Millisecond
+func randomString(length int) string {
+	const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		n := mrand.Intn(len(alphabet))
+		b[i] = alphabet[n]
+	}
+	return string(b)
+}
 
-var _ = Describe("HTTP tests", func() {
-	var (
-		mux            *http.ServeMux
-		client         *http.Client
-		tr             *http3.Transport
-		server         *http3.Server
-		stoppedServing chan struct{}
-		port           int
-	)
+func startHTTPServer(t *testing.T, mux *http.ServeMux, opts ...func(*http3.Server)) (port int) {
+	t.Helper()
+	server := &http3.Server{
+		Handler:    mux,
+		TLSConfig:  getTLSConfig(),
+		QUICConfig: getQuicConfig(&quic.Config{Allow0RTT: true, EnableDatagrams: true}),
+	}
+	for _, opt := range opts {
+		opt(server)
+	}
 
-	BeforeEach(func() {
-		mux = http.NewServeMux()
-		mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			io.WriteString(w, "Hello, World!\n") // don't check the error here. Stream may be reset.
-		})
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
 
-		mux.HandleFunc("/prdata", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			sl := r.URL.Query().Get("len")
-			if sl != "" {
-				var err error
-				l, err := strconv.Atoi(sl)
-				Expect(err).NotTo(HaveOccurred())
-				w.Write(GeneratePRData(l)) // don't check the error here. Stream may be reset.
-			} else {
-				w.Write(PRData) // don't check the error here. Stream may be reset.
-			}
-		})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		server.Serve(conn)
+	}()
 
-		mux.HandleFunc("/prdatalong", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			w.Write(PRDataLong) // don't check the error here. Stream may be reset.
-		})
-
-		mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			body, err := io.ReadAll(r.Body)
-			Expect(err).NotTo(HaveOccurred())
-			w.Write(body) // don't check the error here. Stream may be reset.
-		})
-
-		mux.HandleFunc("/remoteAddr", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			w.Header().Set("X-RemoteAddr", r.RemoteAddr)
-			w.WriteHeader(http.StatusOK)
-		})
-
-		server = &http3.Server{
-			Handler:    mux,
-			TLSConfig:  getTLSConfig(),
-			QUICConfig: getQuicConfig(&quic.Config{Allow0RTT: true, EnableDatagrams: true}),
+	t.Cleanup(func() {
+		conn.Close()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("server didn't shut down")
 		}
-
-		addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:0")
-		Expect(err).NotTo(HaveOccurred())
-		conn, err := net.ListenUDP("udp", addr)
-		Expect(err).NotTo(HaveOccurred())
-		port = conn.LocalAddr().(*net.UDPAddr).Port
-
-		stoppedServing = make(chan struct{})
-
-		go func() {
-			defer GinkgoRecover()
-			server.Serve(conn)
-			close(stoppedServing)
-		}()
 	})
+	return conn.LocalAddr().(*net.UDPAddr).Port
+}
 
-	AfterEach(func() {
-		Expect(tr.Close()).NotTo(HaveOccurred())
-		Expect(server.Close()).NotTo(HaveOccurred())
-		Eventually(stoppedServing).Should(BeClosed())
+func newHTTP3Client(t *testing.T) *http.Client {
+	tr := &http3.Transport{
+		TLSClientConfig:    getTLSClientConfigWithoutServerName(),
+		QUICConfig:         getQuicConfig(&quic.Config{MaxIdleTimeout: 10 * time.Second}),
+		DisableCompression: true,
+	}
+	t.Cleanup(func() { tr.Close() })
+	return &http.Client{Transport: tr}
+}
+
+func TestHTTPGet(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "Hello, World!\n")
 	})
-
-	BeforeEach(func() {
-		tr = &http3.Transport{
-			TLSClientConfig: getTLSClientConfigWithoutServerName(),
-			QUICConfig: getQuicConfig(&quic.Config{
-				MaxIdleTimeout: 10 * time.Second,
-			}),
-			DisableCompression: true,
-		}
-		client = &http.Client{Transport: tr}
+	mux.HandleFunc("/long", func(w http.ResponseWriter, r *http.Request) {
+		w.Write(PRDataLong)
 	})
+	port := startHTTPServer(t, mux)
 
-	It("closes the connection after idle timeout", func() {
-		server.IdleTimeout = 100 * time.Millisecond
-		_, err := client.Get(fmt.Sprintf("https://localhost:%d/hello", port))
-		Expect(err).ToNot(HaveOccurred())
+	cl := newHTTP3Client(t)
 
-		time.Sleep(150 * time.Millisecond)
-
-		_, err = client.Get(fmt.Sprintf("https://localhost:%d/hello", port))
-		Expect(err).ToNot(MatchError("idle timeout"))
-		server.IdleTimeout = 0
-	})
-
-	It("downloads a hello", func() {
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/hello", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 3*time.Second))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(string(body)).To(Equal("Hello, World!\n"))
-	})
-
-	It("sets content-length for small response", func() {
-		mux.HandleFunc("/small", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			w.Write([]byte("foo"))
-			w.Write([]byte("bar"))
-		})
-
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/small", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		Expect(resp.Header.Get("Content-Length")).To(Equal("6"))
-	})
-
-	It("re-establishes a QUIC connection after a dial error", func() {
-		var dialCounter int
-		testErr := errors.New("test error")
-		cl := http.Client{
-			Transport: &http3.Transport{
-				TLSClientConfig: getTLSClientConfig(),
-				Dial: func(ctx context.Context, addr string, tlsConf *tls.Config, conf *quic.Config) (quic.EarlyConnection, error) {
-					dialCounter++
-					if dialCounter == 1 { // make the first dial fail
-						return nil, testErr
-					}
-					return quic.DialAddrEarly(ctx, addr, tlsConf, conf)
-				},
-			},
-		}
-		defer cl.Transport.(io.Closer).Close()
-		_, err := cl.Get(fmt.Sprintf("https://localhost:%d/hello", port))
-		Expect(err).To(MatchError(testErr))
+	t.Run("small", func(t *testing.T) {
 		resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/hello", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 2 * time.Second})
+		require.NoError(t, err)
+		require.Equal(t, "Hello, World!\n", string(body))
 	})
 
-	It("detects stream errors when server panics when writing response", func() {
-		respChan := make(chan struct{})
-		mux.HandleFunc("/writing_and_panicking", func(w http.ResponseWriter, r *http.Request) {
-			// no recover here as it will interfere with the handler
-			w.Write([]byte("foobar"))
-			w.(http.Flusher).Flush()
-			// wait for the client to receive the response
-			<-respChan
-			panic(http.ErrAbortHandler)
-		})
-
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/writing_and_panicking", port))
-		close(respChan)
-		Expect(err).ToNot(HaveOccurred())
-		body, err := io.ReadAll(resp.Body)
-		Expect(err).To(HaveOccurred())
-		// the body will be a prefix of what's written
-		Expect(bytes.HasPrefix([]byte("foobar"), body)).To(BeTrue())
+	t.Run("big", func(t *testing.T) {
+		resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/long", port))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 10 * time.Second})
+		require.NoError(t, err)
+		require.Equal(t, PRDataLong, body)
 	})
+}
 
-	It("requests to different servers with the same udpconn", func() {
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/remoteAddr", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		addr1 := resp.Header.Get("X-RemoteAddr")
-		Expect(addr1).ToNot(Equal(""))
-		resp, err = client.Get(fmt.Sprintf("https://127.0.0.1:%d/remoteAddr", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		addr2 := resp.Header.Get("X-RemoteAddr")
-		Expect(addr2).ToNot(Equal(""))
-		Expect(addr1).To(Equal(addr2))
+func TestHTTPPost(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(w, r.Body)
 	})
+	port := startHTTPServer(t, mux)
 
-	It("downloads concurrently", func() {
-		group, ctx := errgroup.WithContext(context.Background())
-		for i := 0; i < 2; i++ {
-			group.Go(func() error {
-				defer GinkgoRecover()
-				req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/hello", port), nil)
-				Expect(err).ToNot(HaveOccurred())
-				resp, err := client.Do(req)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(200))
-				body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 3*time.Second))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(string(body)).To(Equal("Hello, World!\n"))
+	cl := newHTTP3Client(t)
 
-				return nil
-			})
-		}
-
-		err := group.Wait()
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("sets and gets request headers", func() {
-		handlerCalled := make(chan struct{})
-		mux.HandleFunc("/headers/request", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			Expect(r.Header.Get("foo")).To(Equal("bar"))
-			Expect(r.Header.Get("lorem")).To(Equal("ipsum"))
-			close(handlerCalled)
-		})
-
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/headers/request", port), nil)
-		Expect(err).ToNot(HaveOccurred())
-		req.Header.Set("foo", "bar")
-		req.Header.Set("lorem", "ipsum")
-		resp, err := client.Do(req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		Eventually(handlerCalled).Should(BeClosed())
-	})
-
-	It("sets and gets response headers", func() {
-		mux.HandleFunc("/headers/response", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			w.Header().Set("foo", "bar")
-			w.Header().Set("lorem", "ipsum")
-		})
-
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/headers/response", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		Expect(resp.Header.Get("foo")).To(Equal("bar"))
-		Expect(resp.Header.Get("lorem")).To(Equal("ipsum"))
-	})
-
-	It("downloads a small file", func() {
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/prdata", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 5*time.Second))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(body).To(Equal(PRData))
-	})
-
-	It("downloads a large file", func() {
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/prdatalong", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 20*time.Second))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.ContentLength).To(BeEquivalentTo(-1))
-		Expect(body).To(Equal(PRDataLong))
-	})
-
-	It("downloads many hellos", func() {
-		const num = 150
-
-		for i := 0; i < num; i++ {
-			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/hello", port))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(200))
-			body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 3*time.Second))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(body)).To(Equal("Hello, World!\n"))
-		}
-	})
-
-	It("downloads many files, if the response is not read", func() {
-		const num = 150
-
-		for i := 0; i < num; i++ {
-			resp, err := client.Get(fmt.Sprintf("https://localhost:%d/prdata", port))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(200))
-			Expect(resp.Body.Close()).To(Succeed())
-		}
-	})
-
-	It("posts a small message", func() {
-		resp, err := client.Post(
+	t.Run("small", func(t *testing.T) {
+		resp, err := cl.Post(
 			fmt.Sprintf("https://localhost:%d/echo", port),
 			"text/plain",
 			bytes.NewReader([]byte("Hello, world!")),
 		)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 5*time.Second))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(body).To(Equal([]byte("Hello, world!")))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 2 * time.Second})
+		require.NoError(t, err)
+		require.Equal(t, []byte("Hello, world!"), body)
 	})
 
-	It("uploads a file", func() {
-		resp, err := client.Post(
+	t.Run("big", func(t *testing.T) {
+		resp, err := cl.Post(
 			fmt.Sprintf("https://localhost:%d/echo", port),
 			"text/plain",
 			bytes.NewReader(PRData),
 		)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 5*time.Second))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(body).To(Equal(PRData))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 10 * time.Second})
+		require.NoError(t, err)
+		require.Equal(t, PRData, body)
 	})
+}
 
-	It("uses gzip compression", func() {
-		mux.HandleFunc("/gzipped/hello", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			Expect(r.Header.Get("Accept-Encoding")).To(Equal("gzip"))
-			w.Header().Set("Content-Encoding", "gzip")
-			w.Header().Set("foo", "bar")
+func TestHTTPMultipleRequests(t *testing.T) {
+	mux := http.NewServeMux()
+	port := startHTTPServer(t, mux)
 
-			gw := gzip.NewWriter(w)
-			defer gw.Close()
-			gw.Write([]byte("Hello, World!\n"))
+	t.Run("reading the response", func(t *testing.T) {
+		mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, "Hello, World!\n")
 		})
 
-		client.Transport.(*http3.Transport).DisableCompression = false
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/gzipped/hello", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		Expect(resp.Uncompressed).To(BeTrue())
-
-		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 3*time.Second))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(string(body)).To(Equal("Hello, World!\n"))
+		cl := newHTTP3Client(t)
+		var eg errgroup.Group
+		for i := 0; i < 200; i++ {
+			eg.Go(func() error {
+				resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/hello", port))
+				if err != nil {
+					return err
+				}
+				if resp.StatusCode != http.StatusOK {
+					return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+				}
+				body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 3 * time.Second})
+				if err != nil {
+					return err
+				}
+				if string(body) != "Hello, World!\n" {
+					return fmt.Errorf("unexpected body: %q", body)
+				}
+				return nil
+			})
+		}
+		require.NoError(t, eg.Wait())
 	})
 
-	It("handles context cancellations", func() {
-		mux.HandleFunc("/cancel", func(w http.ResponseWriter, r *http.Request) {
+	t.Run("not reading the response", func(t *testing.T) {
+		mux.HandleFunc("/prdata", func(w http.ResponseWriter, r *http.Request) {
+			w.Write(PRData)
+		})
+
+		cl := newHTTP3Client(t)
+		const num = 150
+
+		for i := 0; i < num; i++ {
+			resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/prdata", port))
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+		}
+	})
+}
+
+func TestContentLengthForSmallResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/small", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("foo"))
+		w.Write([]byte("bar"))
+	})
+	port := startHTTPServer(t, mux)
+
+	resp, err := newHTTP3Client(t).Get(fmt.Sprintf("https://localhost:%d/small", port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "6", resp.Header.Get("Content-Length"))
+}
+
+func TestHTTPHeaders(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/headers/response", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("foo", "bar")
+		w.Header().Set("lorem", "ipsum")
+		w.Header().Set("echo", r.Header.Get("echo"))
+	})
+	port := startHTTPServer(t, mux)
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/headers/response", port), nil)
+	require.NoError(t, err)
+	echoHdr := randomString(128)
+	req.Header.Set("echo", echoHdr)
+
+	resp, err := newHTTP3Client(t).Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "bar", resp.Header.Get("foo"))
+	require.Equal(t, "ipsum", resp.Header.Get("lorem"))
+	require.Equal(t, echoHdr, resp.Header.Get("echo"))
+}
+
+func TestHTTPTrailers(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/trailers", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Trailer", "AtEnd1, AtEnd2")
+		w.Header().Add("Trailer", "Never")
+		w.Header().Add("Trailer", "LAST")
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8") // normal header
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("AtEnd1", "value 1")
+		io.WriteString(w, "This HTTP response has both headers before this text and trailers at the end.\n")
+		w.(http.Flusher).Flush()
+		w.Header().Set("AtEnd2", "value 2")
+		io.WriteString(w, "More text\n")
+		w.(http.Flusher).Flush()
+		w.Header().Set("LAST", "value 3")
+		w.Header().Set(http.TrailerPrefix+"Unannounced", "Surprise!")
+		w.Header().Set("Late-Header", "No surprise!")
+	})
+
+	port := startHTTPServer(t, mux)
+
+	resp, err := newHTTP3Client(t).Get(fmt.Sprintf("https://localhost:%d/trailers", port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Empty(t, resp.Header.Get("Trailer"))
+	require.NotContains(t, resp.Header, "Atend1")
+	require.NotContains(t, resp.Header, "Atend2")
+	require.NotContains(t, resp.Header, "Never")
+	require.NotContains(t, resp.Header, "Last")
+	require.NotContains(t, resp.Header, "Late-Header")
+	require.Equal(t, http.Header(map[string][]string{
+		"Atend1": nil,
+		"Atend2": nil,
+		"Never":  nil,
+		"Last":   nil,
+	}), resp.Trailer)
+
+	body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 3 * time.Second})
+	require.NoError(t, err)
+	require.Equal(t, "This HTTP response has both headers before this text and trailers at the end.\nMore text\n", string(body))
+	for k := range resp.Header {
+		require.NotContains(t, k, http.TrailerPrefix)
+	}
+	require.Equal(t, http.Header(map[string][]string{
+		"Atend1":      {"value 1"},
+		"Atend2":      {"value 2"},
+		"Last":        {"value 3"},
+		"Unannounced": {"Surprise!"},
+	}), resp.Trailer)
+}
+
+func TestHTTPErrAbortHandler(t *testing.T) {
+	respChan := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/abort", func(w http.ResponseWriter, r *http.Request) {
+		// no recover here as it will interfere with the handler
+		w.Write([]byte("foobar"))
+		w.(http.Flusher).Flush()
+		// wait for the client to receive the response
+		<-respChan
+		panic(http.ErrAbortHandler)
+	})
+	port := startHTTPServer(t, mux)
+
+	resp, err := newHTTP3Client(t).Get(fmt.Sprintf("https://localhost:%d/abort", port))
+	close(respChan)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.Error(t, err)
+	var h3Err *http3.Error
+	require.True(t, errors.As(err, &h3Err))
+	require.Equal(t, http3.ErrCodeInternalError, h3Err.ErrorCode)
+	// the body will be a prefix of what's written
+	require.True(t, bytes.HasPrefix([]byte("foobar"), body))
+}
+
+func TestHTTPGzip(t *testing.T) {
+	mux := http.NewServeMux()
+	var acceptEncoding string
+	mux.HandleFunc("/hellogz", func(w http.ResponseWriter, r *http.Request) {
+		acceptEncoding = r.Header.Get("Accept-Encoding")
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("foo", "bar")
+
+		gw := gzip.NewWriter(w)
+		defer gw.Close()
+		_, err := gw.Write([]byte("Hello, World!\n"))
+		require.NoError(t, err)
+	})
+	port := startHTTPServer(t, mux)
+
+	cl := newHTTP3Client(t)
+	cl.Transport.(*http3.Transport).DisableCompression = false
+	resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/hellogz", port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.True(t, resp.Uncompressed)
+
+	body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 3 * time.Second})
+	require.NoError(t, err)
+	require.Equal(t, "Hello, World!\n", string(body))
+
+	// make sure the server received the Accept-Encoding header
+	require.Equal(t, "gzip", acceptEncoding)
+}
+
+func TestHTTPDifferentOrigins(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/remote-addr", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RemoteAddr", r.RemoteAddr)
+		w.WriteHeader(http.StatusOK)
+	})
+	port := startHTTPServer(t, mux)
+
+	cl := newHTTP3Client(t)
+	resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/remote-addr", port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	addr1 := resp.Header.Get("X-RemoteAddr")
+	require.NotEmpty(t, addr1)
+	resp, err = cl.Get(fmt.Sprintf("https://127.0.0.1:%d/remote-addr", port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	addr2 := resp.Header.Get("X-RemoteAddr")
+	require.NotEmpty(t, addr2)
+	require.Equal(t, addr1, addr2)
+}
+
+func TestHTTPServerIdleTimeout(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "Hello, World!\n")
+	})
+	port := startHTTPServer(t, mux, func(s *http3.Server) { s.IdleTimeout = 100 * time.Millisecond })
+
+	cl := newHTTP3Client(t)
+	_, err := cl.Get(fmt.Sprintf("https://localhost:%d/hello", port))
+	require.NoError(t, err)
+
+	time.Sleep(150 * time.Millisecond)
+
+	_, err = cl.Get(fmt.Sprintf("https://localhost:%d/hello", port))
+	require.Error(t, err)
+	var appErr *quic.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, quic.ApplicationErrorCode(http3.ErrCodeNoError), appErr.ErrorCode)
+}
+
+func TestHTTPReestablishConnectionAfterDialError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "Hello, World!\n")
+	})
+	port := startHTTPServer(t, mux)
+
+	var dialCounter int
+	testErr := errors.New("test error")
+	cl := http.Client{
+		Transport: &http3.Transport{
+			TLSClientConfig: getTLSClientConfig(),
+			Dial: func(ctx context.Context, addr string, tlsConf *tls.Config, conf *quic.Config) (quic.EarlyConnection, error) {
+				dialCounter++
+				if dialCounter == 1 { // make the first dial fail
+					return nil, testErr
+				}
+				return quic.DialAddrEarly(ctx, addr, tlsConf, conf)
+			},
+		},
+	}
+	defer cl.Transport.(io.Closer).Close()
+
+	_, err := cl.Get(fmt.Sprintf("https://localhost:%d/hello", port))
+	require.ErrorIs(t, err, testErr)
+	resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/hello", port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestHTTPClientRequestContextCancellation(t *testing.T) {
+	mux := http.NewServeMux()
+	port := startHTTPServer(t, mux)
+	cl := newHTTP3Client(t)
+
+	t.Run("before response", func(t *testing.T) {
+		mux.HandleFunc("/cancel-before", func(w http.ResponseWriter, r *http.Request) {
 			<-r.Context().Done()
 		})
 
-		ctx, cancel := context.WithCancel(context.Background())
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/cancel", port), nil)
-		Expect(err).ToNot(HaveOccurred())
-		time.AfterFunc(50*time.Millisecond, cancel)
-
-		_, err = client.Do(req)
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(MatchError(context.Canceled))
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/cancel-before", port), nil)
+		require.NoError(t, err)
+		_, err = cl.Do(req)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
-	It("cancels requests", func() {
-		handlerCalled := make(chan struct{})
-		mux.HandleFunc("/cancel", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			defer close(handlerCalled)
-			// TODO(4508): check for request context cancellations
+	t.Run("after response", func(t *testing.T) {
+		errChan := make(chan error, 1)
+		mux.HandleFunc("/cancel-after", func(w http.ResponseWriter, r *http.Request) {
+			// TODO(#4508): check for request context cancellations
 			for {
 				if _, err := w.Write([]byte("foobar")); err != nil {
-					var http3Err *http3.Error
-					Expect(errors.As(err, &http3Err)).To(BeTrue())
-					Expect(http3Err.ErrorCode).To(Equal(http3.ErrCode(0x10c)))
-					Expect(http3Err.Error()).To(Equal("H3_REQUEST_CANCELLED"))
+					errChan <- err
 					return
 				}
 			}
 		})
 
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/cancel", port), nil)
-		Expect(err).ToNot(HaveOccurred())
 		ctx, cancel := context.WithCancel(context.Background())
-		req = req.WithContext(ctx)
-		resp, err := client.Do(req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/cancel-after", port), nil)
+		require.NoError(t, err)
+		resp, err := cl.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 		cancel()
-		Eventually(handlerCalled).Should(BeClosed())
+
+		select {
+		case err := <-errChan:
+			require.Error(t, err)
+			var http3Err *http3.Error
+			require.True(t, errors.As(err, &http3Err))
+			require.Equal(t, http3.ErrCodeRequestCanceled, http3Err.ErrorCode)
+			require.True(t, http3Err.Remote)
+		case <-time.After(time.Second):
+			t.Fatal("handler was not called")
+		}
+
 		_, err = resp.Body.Read([]byte{0})
 		var http3Err *http3.Error
-		Expect(errors.As(err, &http3Err)).To(BeTrue())
-		Expect(http3Err.ErrorCode).To(Equal(http3.ErrCode(0x10c)))
-		Expect(http3Err.Error()).To(Equal("H3_REQUEST_CANCELLED (local)"))
+		require.True(t, errors.As(err, &http3Err))
+		require.Equal(t, http3.ErrCodeRequestCanceled, http3Err.ErrorCode)
+		require.False(t, http3Err.Remote)
 	})
+}
 
-	It("allows streamed HTTP requests", func() {
-		done := make(chan struct{})
-		mux.HandleFunc("/echoline", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			defer close(done)
-			w.WriteHeader(200)
-			w.(http.Flusher).Flush()
-			reader := bufio.NewReader(r.Body)
-			for {
-				msg, err := reader.ReadString('\n')
-				if err != nil {
-					return
-				}
-				_, err = w.Write([]byte(msg))
-				Expect(err).ToNot(HaveOccurred())
-				w.(http.Flusher).Flush()
-			}
-		})
+func TestHTTPDeadlines(t *testing.T) {
+	const deadlineDelay = 50 * time.Millisecond
 
-		r, w := io.Pipe()
-		req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("https://localhost:%d/echoline", port), r)
-		Expect(err).ToNot(HaveOccurred())
-		rsp, err := client.Do(req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(rsp.StatusCode).To(Equal(200))
+	mux := http.NewServeMux()
+	port := startHTTPServer(t, mux)
+	cl := newHTTP3Client(t)
 
-		reader := bufio.NewReader(rsp.Body)
-		for i := 0; i < 5; i++ {
-			msg := fmt.Sprintf("Hello world, %d!\n", i)
-			fmt.Fprint(w, msg)
-			msgRcvd, err := reader.ReadString('\n')
-			Expect(err).ToNot(HaveOccurred())
-			Expect(msgRcvd).To(Equal(msg))
+	t.Run("read deadline", func(t *testing.T) {
+		type result struct {
+			body []byte
+			err  error
 		}
-		Expect(req.Body.Close()).To(Succeed())
-		Eventually(done).Should(BeClosed())
-	})
 
-	It("allows taking over the stream", func() {
-		handlerCalled := make(chan struct{})
-		mux.HandleFunc("/httpstreamer", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			close(handlerCalled)
-			w.WriteHeader(http.StatusOK)
-
-			str := w.(http3.HTTPStreamer).HTTPStream()
-			str.Write([]byte("foobar"))
-
-			// Do this in a Go routine, so that the handler returns early.
-			// This way, we can also check that the HTTP/3 doesn't close the stream.
-			go func() {
-				defer GinkgoRecover()
-				_, err := io.Copy(str, str)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(str.Close()).To(Succeed())
-			}()
-		})
-
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/httpstreamer", port), nil)
-		Expect(err).ToNot(HaveOccurred())
-		tlsConf := getTLSClientConfigWithoutServerName()
-		tlsConf.NextProtos = []string{http3.NextProtoH3}
-		conn, err := quic.DialAddr(
-			context.Background(),
-			fmt.Sprintf("localhost:%d", port),
-			tlsConf,
-			getQuicConfig(nil),
-		)
-		Expect(err).ToNot(HaveOccurred())
-		defer conn.CloseWithError(0, "")
-		tr := http3.Transport{}
-		cc := tr.NewClientConn(conn)
-		str, err := cc.OpenRequestStream(context.Background())
-		Expect(err).ToNot(HaveOccurred())
-		Expect(str.SendRequestHeader(req)).To(Succeed())
-		// make sure the request is received (and not stuck in some buffer, for example)
-		Eventually(handlerCalled).Should(BeClosed())
-
-		rsp, err := str.ReadResponse()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(rsp.StatusCode).To(Equal(200))
-
-		b := make([]byte, 6)
-		_, err = io.ReadFull(str, b)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(b).To(Equal([]byte("foobar")))
-
-		data := GeneratePRData(8 * 1024)
-		_, err = str.Write(data)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(str.Close()).To(Succeed())
-		repl, err := io.ReadAll(str)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(repl).To(Equal(data))
-	})
-
-	It("serves QUIC connections", func() {
-		tlsConf := getTLSConfig()
-		tlsConf.NextProtos = []string{http3.NextProtoH3}
-		ln, err := quic.ListenAddr("localhost:0", tlsConf, getQuicConfig(nil))
-		Expect(err).ToNot(HaveOccurred())
-		defer ln.Close()
-		done := make(chan struct{})
-		go func() {
-			defer GinkgoRecover()
-			defer close(done)
-			conn, err := ln.Accept(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-			server.ServeQUICConn(conn) // returns once the client closes
-		}()
-
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/hello", ln.Addr().(*net.UDPAddr).Port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		client.Transport.(io.Closer).Close()
-		Eventually(done).Should(BeClosed())
-	})
-
-	It("supports read deadlines", func() {
+		resultChan := make(chan result, 1)
 		mux.HandleFunc("/read-deadline", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
 			rc := http.NewResponseController(w)
-			Expect(rc.SetReadDeadline(time.Now().Add(deadlineDelay))).To(Succeed())
-
+			require.NoError(t, rc.SetReadDeadline(time.Now().Add(deadlineDelay)))
 			body, err := io.ReadAll(r.Body)
-			Expect(err).To(MatchError(os.ErrDeadlineExceeded))
-			Expect(body).To(ContainSubstring("aa"))
-
+			resultChan <- result{body: body, err: err}
 			w.Write([]byte("ok"))
 		})
 
 		expectedEnd := time.Now().Add(deadlineDelay)
-		resp, err := client.Post(
+		resp, err := cl.Post(
 			fmt.Sprintf("https://localhost:%d/read-deadline", port),
 			"text/plain",
 			neverEnding('a'),
 		)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 
-		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 2*deadlineDelay))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(time.Now().After(expectedEnd)).To(BeTrue())
-		Expect(string(body)).To(Equal("ok"))
+		body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 2 * deadlineDelay})
+		require.NoError(t, err)
+		require.True(t, time.Now().After(expectedEnd))
+		require.Equal(t, "ok", string(body))
+
+		select {
+		case result := <-resultChan:
+			require.ErrorIs(t, result.err, os.ErrDeadlineExceeded)
+			require.Contains(t, string(result.body), "aa")
+		default:
+			t.Fatal("handler was not called")
+		}
 	})
 
-	It("supports write deadlines", func() {
+	t.Run("write deadline", func(t *testing.T) {
+		errChan := make(chan error, 1)
 		mux.HandleFunc("/write-deadline", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
 			rc := http.NewResponseController(w)
-			Expect(rc.SetWriteDeadline(time.Now().Add(deadlineDelay))).To(Succeed())
+			require.NoError(t, rc.SetWriteDeadline(time.Now().Add(deadlineDelay)))
 
 			_, err := io.Copy(w, neverEnding('a'))
-			Expect(err).To(MatchError(os.ErrDeadlineExceeded))
+			errChan <- err
 		})
 
 		expectedEnd := time.Now().Add(deadlineDelay)
 
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/write-deadline", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
+		resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/write-deadline", port))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
 
-		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 2*deadlineDelay))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(time.Now().After(expectedEnd)).To(BeTrue())
-		Expect(string(body)).To(ContainSubstring("aa"))
-	})
+		body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 2 * deadlineDelay})
+		require.NoError(t, err)
+		require.True(t, time.Now().After(expectedEnd))
+		require.Contains(t, string(body), "aa")
 
-	It("sets remote address", func() {
-		mux.HandleFunc("/remote-addr", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			_, ok := r.Context().Value(http3.RemoteAddrContextKey).(net.Addr)
-			Expect(ok).To(BeTrue())
-		})
-
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/remote-addr", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-	})
-
-	It("sets conn context", func() {
-		type ctxKey int
-		var tracingID quic.ConnectionTracingID
-		server.ConnContext = func(ctx context.Context, c quic.Connection) context.Context {
-			serv, ok := ctx.Value(http3.ServerContextKey).(*http3.Server)
-			Expect(ok).To(BeTrue())
-			Expect(serv).To(Equal(server))
-
-			ctx = context.WithValue(ctx, ctxKey(0), "Hello")
-			ctx = context.WithValue(ctx, ctxKey(1), c)
-			tracingID = c.Context().Value(quic.ConnectionTracingKey).(quic.ConnectionTracingID)
-			return ctx
+		select {
+		case err := <-errChan:
+			require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+		case <-time.After(2 * deadlineDelay):
+			t.Fatal("handler was not called")
 		}
-		mux.HandleFunc("/http3-conn-context", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			v, ok := r.Context().Value(ctxKey(0)).(string)
-			Expect(ok).To(BeTrue())
-			Expect(v).To(Equal("Hello"))
+	})
+}
 
-			c, ok := r.Context().Value(ctxKey(1)).(quic.Connection)
-			Expect(ok).To(BeTrue())
-			Expect(c).ToNot(BeNil())
+func TestHTTPServeQUICConn(t *testing.T) {
+	tlsConf := getTLSConfig()
+	tlsConf.NextProtos = []string{http3.NextProtoH3}
+	ln, err := quic.ListenAddr("localhost:0", tlsConf, getQuicConfig(nil))
+	require.NoError(t, err)
+	defer ln.Close()
 
-			serv, ok := r.Context().Value(http3.ServerContextKey).(*http3.Server)
-			Expect(ok).To(BeTrue())
-			Expect(serv).To(Equal(server))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "Hello, World!\n")
+	})
+	server := &http3.Server{
+		TLSConfig:  tlsConf,
+		QUICConfig: getQuicConfig(nil),
+		Handler:    mux,
+	}
+	errChan := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept(context.Background())
+		if err != nil {
+			errChan <- fmt.Errorf("failed to accept QUIC connection: %w", err)
+			return
+		}
+		errChan <- server.ServeQUICConn(conn) // returns once the client closes
+	}()
 
-			id, ok := r.Context().Value(quic.ConnectionTracingKey).(quic.ConnectionTracingID)
-			Expect(ok).To(BeTrue())
-			Expect(id).To(Equal(tracingID))
-		})
+	cl := newHTTP3Client(t)
+	resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/hello", ln.Addr().(*net.UDPAddr).Port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/http3-conn-context", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	require.NoError(t, cl.Transport.(io.Closer).Close())
+	select {
+	case err := <-errChan:
+		require.Error(t, err)
+		require.ErrorContains(t, err, "accepting stream failed")
+	case <-time.After(time.Second):
+		t.Fatal("server didn't shut down")
+	}
+}
+
+func TestHTTPContextFromQUIC(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	defer conn.Close()
+	tr := &quic.Transport{
+		Conn: conn,
+		ConnContext: func(ctx context.Context) context.Context {
+			return context.WithValue(ctx, "foo", "bar") //nolint:staticcheck
+		},
+	}
+	defer tr.Close()
+	tlsConf := getTLSConfig()
+	tlsConf.NextProtos = []string{http3.NextProtoH3}
+	ln, err := tr.Listen(tlsConf, getQuicConfig(nil))
+	require.NoError(t, err)
+	defer ln.Close()
+
+	mux := http.NewServeMux()
+	ctxChan := make(chan context.Context, 1)
+	mux.HandleFunc("/quic-conn-context", func(w http.ResponseWriter, r *http.Request) {
+		ctxChan <- r.Context()
 	})
 
-	It("uses the QUIC connection context", func() {
-		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-		Expect(err).ToNot(HaveOccurred())
-		defer conn.Close()
-		tr := &quic.Transport{
-			Conn: conn,
-			ConnContext: func(ctx context.Context) context.Context {
-				//nolint:staticcheck
-				return context.WithValue(ctx, "foo", "bar")
-			},
-		}
-		defer tr.Close()
-		tlsConf := getTLSConfig()
-		tlsConf.NextProtos = []string{http3.NextProtoH3}
-		ln, err := tr.Listen(tlsConf, getQuicConfig(nil))
-		Expect(err).ToNot(HaveOccurred())
-		defer ln.Close()
+	server := &http3.Server{Handler: mux}
+	go func() {
+		c, err := ln.Accept(context.Background())
+		require.NoError(t, err)
+		server.ServeQUICConn(c)
+	}()
 
-		mux.HandleFunc("/quic-conn-context", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			v, ok := r.Context().Value("foo").(string)
-			Expect(ok).To(BeTrue())
-			Expect(v).To(Equal("bar"))
-		})
+	cl := newHTTP3Client(t)
+	resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/quic-conn-context", conn.LocalAddr().(*net.UDPAddr).Port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case ctx := <-ctxChan:
+		v, ok := ctx.Value("foo").(string)
+		require.True(t, ok)
+		require.Equal(t, "bar", v)
+	default:
+		t.Fatal("context not set")
+	}
+}
+
+func TestHTTPConnContext(t *testing.T) {
+	mux := http.NewServeMux()
+	requestCtxChan := make(chan context.Context, 1)
+	mux.HandleFunc("/context", func(w http.ResponseWriter, r *http.Request) {
+		requestCtxChan <- r.Context()
+	})
+
+	var server *http3.Server
+	connCtxChan := make(chan context.Context, 1)
+	port := startHTTPServer(t,
+		mux,
+		func(s *http3.Server) { server = s },
+		func(s *http3.Server) {
+			s.ConnContext = func(ctx context.Context, c quic.Connection) context.Context {
+				connCtxChan <- ctx
+				ctx = context.WithValue(ctx, "foo", "bar") //nolint:staticcheck
+				return ctx
+			}
+		},
+	)
+
+	resp, err := newHTTP3Client(t).Get(fmt.Sprintf("https://localhost:%d/context", port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tracingID quic.ConnectionTracingID
+	select {
+	case ctx := <-connCtxChan:
+		serv, ok := ctx.Value(http3.ServerContextKey).(*http3.Server)
+		require.True(t, ok)
+		require.Equal(t, server, serv)
+
+		id, ok := ctx.Value(quic.ConnectionTracingKey).(quic.ConnectionTracingID)
+		require.True(t, ok)
+		tracingID = id
+	default:
+		t.Fatal("handler was not called")
+	}
+
+	select {
+	case ctx := <-requestCtxChan:
+		v, ok := ctx.Value("foo").(string)
+		require.True(t, ok)
+		require.Equal(t, "bar", v)
+
+		serv, ok := ctx.Value(http3.ServerContextKey).(*http3.Server)
+		require.True(t, ok)
+		require.Equal(t, server, serv)
+
+		id, ok := ctx.Value(quic.ConnectionTracingKey).(quic.ConnectionTracingID)
+		require.True(t, ok)
+		require.Equal(t, tracingID, id)
+	default:
+		t.Fatal("handler was not called")
+	}
+}
+
+func TestHTTPRemoteAddrContextKey(t *testing.T) {
+	ctxChan := make(chan context.Context, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/remote-addr", func(w http.ResponseWriter, r *http.Request) {
+		ctxChan <- r.Context()
+	})
+
+	port := startHTTPServer(t, mux)
+
+	resp, err := newHTTP3Client(t).Get(fmt.Sprintf("https://localhost:%d/remote-addr", port))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case ctx := <-ctxChan:
+		_, ok := ctx.Value(http3.RemoteAddrContextKey).(net.Addr)
+		require.True(t, ok)
+		require.Equal(t, "127.0.0.1", ctx.Value(http3.RemoteAddrContextKey).(*net.UDPAddr).IP.String())
+	default:
+		t.Fatal("handler was not called")
+	}
+}
+
+func TestHTTPStreamedRequests(t *testing.T) {
+	errChan := make(chan error, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/echoline", func(w http.ResponseWriter, r *http.Request) {
+		defer close(errChan)
+		w.WriteHeader(200)
+		w.(http.Flusher).Flush()
+		reader := bufio.NewReader(r.Body)
+		for {
+			msg, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if _, err := w.Write([]byte(msg)); err != nil {
+				errChan <- err
+				return
+			}
+			w.(http.Flusher).Flush()
+		}
+	})
+
+	port := startHTTPServer(t, mux)
+
+	r, w := io.Pipe()
+	req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("https://localhost:%d/echoline", port), r)
+	require.NoError(t, err)
+	client := newHTTP3Client(t)
+	rsp, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+
+	reader := bufio.NewReader(rsp.Body)
+	for i := 0; i < 5; i++ {
+		msg := fmt.Sprintf("Hello world, %d!\n", i)
+		fmt.Fprint(w, msg)
+		msgRcvd, err := reader.ReadString('\n')
+		require.NoError(t, err)
+		require.Equal(t, msg, msgRcvd)
+	}
+	require.NoError(t, req.Body.Close())
+
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("handler did not complete")
+	}
+}
+
+func TestHTTP1xxResponse(t *testing.T) {
+	header1 := "</style.css>; rel=preload; as=style"
+	header2 := "</script.js>; rel=preload; as=script"
+	data := "1xx-test-data"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/103-early-data", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Link", header1)
+		w.Header().Add("Link", header2)
+		w.WriteHeader(http.StatusEarlyHints)
+		w.Write([]byte(data))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	port := startHTTPServer(t, mux)
+
+	var (
+		cnt    int
+		status int
+		hdr    textproto.MIMEHeader
+	)
+	ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
+		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
+			hdr = header
+			status = code
+			cnt++
+			return nil
+		},
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/103-early-data", port), nil)
+	require.NoError(t, err)
+	resp, err := newHTTP3Client(t).Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, data, string(body))
+	require.Equal(t, http.StatusEarlyHints, status)
+	require.Equal(t, []string{header1, header2}, hdr.Values("Link"))
+	require.Equal(t, 1, cnt)
+	require.Equal(t, []string{header1, header2}, resp.Header.Values("Link"))
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestHTTP1xxTerminalResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/101-switch-protocols", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("foo", "bar")
+		w.WriteHeader(http.StatusSwitchingProtocols)
+	})
+
+	port := startHTTPServer(t, mux)
+
+	var (
+		cnt    int
+		status int
+	)
+	ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
+		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
+			status = code
+			cnt++
+			return nil
+		},
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/101-switch-protocols", port), nil)
+	require.NoError(t, err)
+	resp, err := newHTTP3Client(t).Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	require.Equal(t, "bar", resp.Header.Get("Foo"))
+	require.Zero(t, status)
+	require.Zero(t, cnt)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestHTTP0RTT(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/0rtt", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(strconv.FormatBool(!r.TLS.HandshakeComplete)))
+	})
+	port := startHTTPServer(t, mux)
+
+	var num0RTTPackets atomic.Uint32
+	proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
+		RemoteAddr: fmt.Sprintf("localhost:%d", port),
+		DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
+			if contains0RTTPacket(data) {
+				num0RTTPackets.Add(1)
+			}
+			return scaleDuration(25 * time.Millisecond)
+		},
+	})
+	require.NoError(t, err)
+	defer proxy.Close()
+
+	tlsConf := getTLSClientConfigWithoutServerName()
+	puts := make(chan string, 10)
+	tlsConf.ClientSessionCache = newClientSessionCache(tls.NewLRUClientSessionCache(10), nil, puts)
+	tr := &http3.Transport{
+		TLSClientConfig:    tlsConf,
+		QUICConfig:         getQuicConfig(&quic.Config{MaxIdleTimeout: 10 * time.Second}),
+		DisableCompression: true,
+	}
+	defer tr.Close()
+
+	req, err := http.NewRequest(http3.MethodGet0RTT, fmt.Sprintf("https://localhost:%d/0rtt", proxy.LocalPort()), nil)
+	require.NoError(t, err)
+	rsp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+	data, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "false", string(data))
+	require.Zero(t, num0RTTPackets.Load())
+
+	select {
+	case <-puts:
+	case <-time.After(time.Second):
+		t.Fatal("did not receive session ticket")
+	}
+
+	tr2 := &http3.Transport{
+		TLSClientConfig:    tr.TLSClientConfig,
+		QUICConfig:         tr.QUICConfig,
+		DisableCompression: true,
+	}
+	defer tr2.Close()
+	rsp, err = tr2.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+	data, err = io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "true", string(data))
+	require.NotZero(t, num0RTTPackets.Load())
+}
+
+func TestHTTPStreamer(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/httpstreamer", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+
+		str := w.(http3.HTTPStreamer).HTTPStream()
+		str.Write([]byte("foobar"))
+
+		// Do this in a Go routine, so that the handler returns early.
+		// This way, we can also check that the HTTP/3 doesn't close the stream.
 		go func() {
-			defer GinkgoRecover()
-			c, err := ln.Accept(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-			server.ServeQUICConn(c)
+			defer str.Close()
+			_, _ = io.Copy(str, str)
 		}()
-
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/quic-conn-context", conn.LocalAddr().(*net.UDPAddr).Port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 	})
 
-	It("checks the server's settings", func() {
-		tlsConf := tlsClientConfigWithoutServerName.Clone()
-		tlsConf.NextProtos = []string{http3.NextProtoH3}
-		conn, err := quic.DialAddr(
-			context.Background(),
-			fmt.Sprintf("localhost:%d", port),
-			tlsConf,
-			getQuicConfig(nil),
-		)
-		Expect(err).ToNot(HaveOccurred())
-		defer conn.CloseWithError(0, "")
-		var tr http3.Transport
-		cc := tr.NewClientConn(conn)
-		Eventually(cc.ReceivedSettings(), 5*time.Second, 10*time.Millisecond).Should(BeClosed())
-		settings := cc.Settings()
-		Expect(settings.EnableExtendedConnect).To(BeTrue())
-		Expect(settings.EnableDatagrams).To(BeFalse())
-		Expect(settings.Other).To(BeEmpty())
-	})
+	port := startHTTPServer(t, mux)
 
-	It("receives the client's settings", func() {
-		settingsChan := make(chan *http3.Settings, 1)
-		mux.HandleFunc("/settings", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			conn := w.(http3.Hijacker).Connection()
-			Eventually(conn.ReceivedSettings(), 5*time.Second, 10*time.Millisecond).Should(BeClosed())
-			settingsChan <- conn.Settings()
-			w.WriteHeader(http.StatusOK)
-		})
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/httpstreamer", port), nil)
+	require.NoError(t, err)
+	tlsConf := getTLSClientConfigWithoutServerName()
+	tlsConf.NextProtos = []string{http3.NextProtoH3}
+	conn, err := quic.DialAddr(
+		context.Background(),
+		fmt.Sprintf("localhost:%d", port),
+		tlsConf,
+		getQuicConfig(nil),
+	)
+	require.NoError(t, err)
+	defer conn.CloseWithError(0, "")
+	tr := http3.Transport{}
+	cc := tr.NewClientConn(conn)
+	str, err := cc.OpenRequestStream(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, str.SendRequestHeader(req))
 
-		tr = &http3.Transport{
-			TLSClientConfig: getTLSClientConfigWithoutServerName(),
-			QUICConfig: getQuicConfig(&quic.Config{
-				MaxIdleTimeout:  10 * time.Second,
-				EnableDatagrams: true,
-			}),
-			EnableDatagrams:    true,
-			AdditionalSettings: map[uint64]uint64{1337: 42},
-		}
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/settings", port), nil)
-		Expect(err).ToNot(HaveOccurred())
+	rsp, err := str.ReadResponse()
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
 
-		_, err = tr.RoundTrip(req)
-		Expect(err).ToNot(HaveOccurred())
-		var settings *http3.Settings
-		Expect(settingsChan).To(Receive(&settings))
-		Expect(settings).ToNot(BeNil())
-		Expect(settings.EnableDatagrams).To(BeTrue())
-		Expect(settings.EnableExtendedConnect).To(BeFalse())
-		Expect(settings.Other).To(HaveKeyWithValue(uint64(1337), uint64(42)))
-	})
+	b := make([]byte, 6)
+	_, err = io.ReadFull(str, b)
+	require.NoError(t, err)
+	require.Equal(t, []byte("foobar"), b)
 
-	It("processes 1xx response", func() {
-		header1 := "</style.css>; rel=preload; as=style"
-		header2 := "</script.js>; rel=preload; as=script"
-		data := "1xx-test-data"
-		mux.HandleFunc("/103-early-data", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			w.Header().Add("Link", header1)
-			w.Header().Add("Link", header2)
-			w.WriteHeader(http.StatusEarlyHints)
-			n, err := w.Write([]byte(data))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(n).To(Equal(len(data)))
-			w.WriteHeader(http.StatusOK)
-		})
-
-		var (
-			cnt    int
-			status int
-			hdr    textproto.MIMEHeader
-		)
-		ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
-			Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
-				hdr = header
-				status = code
-				cnt++
-				return nil
-			},
-		})
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/103-early-data", port), nil)
-		Expect(err).ToNot(HaveOccurred())
-		resp, err := client.Do(req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		body, err := io.ReadAll(resp.Body)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(string(body)).To(Equal(data))
-		Expect(status).To(Equal(http.StatusEarlyHints))
-		Expect(hdr).To(HaveKeyWithValue("Link", []string{header1, header2}))
-		Expect(cnt).To(Equal(1))
-		Expect(resp.Header).To(HaveKeyWithValue("Link", []string{header1, header2}))
-		Expect(resp.Body.Close()).To(Succeed())
-	})
-
-	It("processes 1xx terminal response", func() {
-		mux.HandleFunc("/101-switch-protocols", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			w.Header().Add("foo", "bar")
-			w.WriteHeader(http.StatusSwitchingProtocols)
-		})
-
-		var (
-			cnt    int
-			status int
-		)
-		ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
-			Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
-				status = code
-				cnt++
-				return nil
-			},
-		})
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/101-switch-protocols", port), nil)
-		Expect(err).ToNot(HaveOccurred())
-		resp, err := client.Do(req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusSwitchingProtocols))
-		Expect(resp.Header).To(HaveKeyWithValue("Foo", []string{"bar"}))
-		Expect(status).To(Equal(0))
-		Expect(cnt).To(Equal(0))
-	})
-
-	Context("HTTP datagrams", func() {
-		openDatagramStream := func(h string) (_ http3.RequestStream, closeFn func()) {
-			tlsConf := getTLSClientConfigWithoutServerName()
-			tlsConf.NextProtos = []string{http3.NextProtoH3}
-			conn, err := quic.DialAddr(
-				context.Background(),
-				fmt.Sprintf("localhost:%d", port),
-				tlsConf,
-				getQuicConfig(&quic.Config{EnableDatagrams: true}),
-			)
-			Expect(err).ToNot(HaveOccurred())
-
-			tr := http3.Transport{EnableDatagrams: true}
-			cc := tr.NewClientConn(conn)
-			str, err := cc.OpenRequestStream(context.Background())
-			Expect(err).ToNot(HaveOccurred())
-			u, err := url.Parse(h)
-			Expect(err).ToNot(HaveOccurred())
-			req := &http.Request{
-				Method: http.MethodConnect,
-				Proto:  "datagrams",
-				Host:   u.Host,
-				URL:    u,
-			}
-			Expect(str.SendRequestHeader(req)).To(Succeed())
-
-			rsp, err := str.ReadResponse()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(rsp.StatusCode).To(Equal(http.StatusOK))
-			return str, func() { conn.CloseWithError(0, "") }
-		}
-
-		It("sends an receives HTTP datagrams", func() {
-			errChan := make(chan error, 1)
-			const num = 5
-			datagramChan := make(chan struct{}, num)
-			mux.HandleFunc("/datagrams", func(w http.ResponseWriter, r *http.Request) {
-				defer GinkgoRecover()
-				Expect(r.Method).To(Equal(http.MethodConnect))
-				conn := w.(http3.Hijacker).Connection()
-				Eventually(conn.ReceivedSettings()).Should(BeClosed())
-				Expect(conn.Settings().EnableDatagrams).To(BeTrue())
-				w.WriteHeader(http.StatusOK)
-
-				str := w.(http3.HTTPStreamer).HTTPStream()
-				go str.Read([]byte{0}) // need to continue reading from stream to observe state transitions
-
-				for {
-					if _, err := str.ReceiveDatagram(context.Background()); err != nil {
-						errChan <- err
-						return
-					}
-					datagramChan <- struct{}{}
-				}
-			})
-
-			str, closeFn := openDatagramStream(fmt.Sprintf("https://localhost:%d/datagrams", port))
-			defer closeFn()
-
-			for i := 0; i < num; i++ {
-				b := make([]byte, 8)
-				binary.BigEndian.PutUint64(b, uint64(i))
-				Expect(str.SendDatagram(bytes.Repeat(b, 100))).To(Succeed())
-			}
-			var count int
-		loop:
-			for {
-				select {
-				case <-datagramChan:
-					count++
-					if count >= num*4/5 {
-						break loop
-					}
-				case err := <-errChan:
-					Fail(fmt.Sprintf("receiving datagrams failed: %s", err))
-				}
-			}
-			str.CancelWrite(42)
-
-			var resetErr error
-			Eventually(errChan).Should(Receive(&resetErr))
-			Expect(resetErr.(*quic.StreamError).ErrorCode).To(BeEquivalentTo(42))
-		})
-
-		It("closes the send direction", func() {
-			errChan := make(chan error, 1)
-			datagramChan := make(chan []byte, 1)
-			mux.HandleFunc("/datagrams", func(w http.ResponseWriter, r *http.Request) {
-				defer GinkgoRecover()
-				conn := w.(http3.Hijacker).Connection()
-				Eventually(conn.ReceivedSettings()).Should(BeClosed())
-				Expect(conn.Settings().EnableDatagrams).To(BeTrue())
-				w.WriteHeader(http.StatusOK)
-
-				str := w.(http3.HTTPStreamer).HTTPStream()
-				go str.Read([]byte{0}) // need to continue reading from stream to observe state transitions
-
-				for {
-					data, err := str.ReceiveDatagram(context.Background())
-					if err != nil {
-						errChan <- err
-						return
-					}
-					datagramChan <- data
-				}
-			})
-
-			str, closeFn := openDatagramStream(fmt.Sprintf("https://localhost:%d/datagrams", port))
-			defer closeFn()
-			go str.Read([]byte{0})
-
-			Expect(str.SendDatagram([]byte("foo"))).To(Succeed())
-			Eventually(datagramChan).Should(Receive(Equal([]byte("foo"))))
-			// signal that we're done sending
-			str.Close()
-
-			var resetErr error
-			Eventually(errChan).Should(Receive(&resetErr))
-			Expect(resetErr).To(Equal(io.EOF))
-
-			// make sure we can't send anymore
-			Expect(str.SendDatagram([]byte("foo"))).ToNot(Succeed())
-		})
-
-		It("detecting a stream reset from the server", func() {
-			errChan := make(chan error, 1)
-			datagramChan := make(chan []byte, 1)
-			mux.HandleFunc("/datagrams", func(w http.ResponseWriter, r *http.Request) {
-				defer GinkgoRecover()
-				conn := w.(http3.Hijacker).Connection()
-				Eventually(conn.ReceivedSettings()).Should(BeClosed())
-				Expect(conn.Settings().EnableDatagrams).To(BeTrue())
-				w.WriteHeader(http.StatusOK)
-
-				str := w.(http3.HTTPStreamer).HTTPStream()
-				go str.Read([]byte{0}) // need to continue reading from stream to observe state transitions
-
-				for {
-					data, err := str.ReceiveDatagram(context.Background())
-					if err != nil {
-						errChan <- err
-						return
-					}
-					str.CancelRead(42)
-					datagramChan <- data
-				}
-			})
-
-			str, closeFn := openDatagramStream(fmt.Sprintf("https://localhost:%d/datagrams", port))
-			defer closeFn()
-			go str.Read([]byte{0})
-
-			Expect(str.SendDatagram([]byte("foo"))).To(Succeed())
-			Eventually(datagramChan).Should(Receive(Equal([]byte("foo"))))
-			// signal that we're done sending
-
-			var resetErr error
-			Eventually(errChan).Should(Receive(&resetErr))
-			Expect(resetErr).To(Equal(&quic.StreamError{ErrorCode: 42, Remote: false}))
-
-			// make sure we can't send anymore
-			Expect(str.SendDatagram([]byte("foo"))).To(Equal(&quic.StreamError{ErrorCode: 42, Remote: true}))
-		})
-	})
-
-	Context("0-RTT", func() {
-		runCountingProxy := func(serverPort int, rtt time.Duration) (*quicproxy.QuicProxy, *atomic.Uint32) {
-			var num0RTTPackets atomic.Uint32
-			proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
-				RemoteAddr: fmt.Sprintf("localhost:%d", serverPort),
-				DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
-					if contains0RTTPacket(data) {
-						num0RTTPackets.Add(1)
-					}
-					return rtt / 2
-				},
-			})
-			Expect(err).ToNot(HaveOccurred())
-			return proxy, &num0RTTPackets
-		}
-
-		It("sends 0-RTT GET requests", func() {
-			proxy, num0RTTPackets := runCountingProxy(port, scaleDuration(50*time.Millisecond))
-			defer proxy.Close()
-
-			tlsConf := getTLSClientConfigWithoutServerName()
-			puts := make(chan string, 10)
-			tlsConf.ClientSessionCache = newClientSessionCache(tls.NewLRUClientSessionCache(10), nil, puts)
-			tr := &http3.Transport{
-				TLSClientConfig: tlsConf,
-				QUICConfig: getQuicConfig(&quic.Config{
-					MaxIdleTimeout: 10 * time.Second,
-				}),
-				DisableCompression: true,
-			}
-			defer tr.Close()
-
-			mux.HandleFunc("/0rtt", func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte(strconv.FormatBool(!r.TLS.HandshakeComplete)))
-			})
-			req, err := http.NewRequest(http3.MethodGet0RTT, fmt.Sprintf("https://localhost:%d/0rtt", proxy.LocalPort()), nil)
-			Expect(err).ToNot(HaveOccurred())
-			rsp, err := tr.RoundTrip(req)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(rsp.StatusCode).To(BeEquivalentTo(200))
-			data, err := io.ReadAll(rsp.Body)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(data)).To(Equal("false"))
-			Expect(num0RTTPackets.Load()).To(BeZero())
-			Eventually(puts).Should(Receive())
-
-			tr2 := &http3.Transport{
-				TLSClientConfig:    tr.TLSClientConfig,
-				QUICConfig:         tr.QUICConfig,
-				DisableCompression: true,
-			}
-			defer tr2.Close()
-			rsp, err = tr2.RoundTrip(req)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(rsp.StatusCode).To(BeEquivalentTo(200))
-			data, err = io.ReadAll(rsp.Body)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(data)).To(Equal("true"))
-			Expect(num0RTTPackets.Load()).To(BeNumerically(">", 0))
-		})
-	})
-
-	It("sends and receives trailers", func() {
-		mux.HandleFunc("/trailers", func(w http.ResponseWriter, r *http.Request) {
-			defer GinkgoRecover()
-			w.Header().Set("Trailer", "AtEnd1, AtEnd2")
-			w.Header().Add("Trailer", "Never")
-			w.Header().Add("Trailer", "LAST")
-			w.Header().Set("Content-Type", "text/plain; charset=utf-8") // normal header
-			w.WriteHeader(http.StatusOK)
-			w.Header().Set("AtEnd1", "value 1")
-			io.WriteString(w, "This HTTP response has both headers before this text and trailers at the end.\n")
-			w.(http.Flusher).Flush()
-			w.Header().Set("AtEnd2", "value 2")
-			io.WriteString(w, "More text\n")
-			w.(http.Flusher).Flush()
-			w.Header().Set("LAST", "value 3")
-			w.Header().Set(http.TrailerPrefix+"Unannounced", "Surprise!")
-			w.Header().Set("Late-Header", "No surprise!")
-		})
-
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/trailers", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(200))
-		Expect(resp.Header.Get("Trailer")).To(Equal(""))
-		Expect(resp.Header).To(Not(HaveKey("Atend1")))
-		Expect(resp.Header).To(Not(HaveKey("Atend2")))
-		Expect(resp.Header).To(Not(HaveKey("Never")))
-		Expect(resp.Header).To(Not(HaveKey("Last")))
-		Expect(resp.Header).To(Not(HaveKey("Late-Header")))
-		Expect(resp.Trailer).To(Equal(http.Header(map[string][]string{
-			"Atend1": nil,
-			"Atend2": nil,
-			"Never":  nil,
-			"Last":   nil,
-		})))
-
-		body, err := io.ReadAll(gbytes.TimeoutReader(resp.Body, 3*time.Second))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(string(body)).To(Equal("This HTTP response has both headers before this text and trailers at the end.\nMore text\n"))
-		for k := range resp.Header {
-			Expect(k).To(Not(HavePrefix(http.TrailerPrefix)))
-		}
-		Expect(resp.Trailer).To(Equal(http.Header(map[string][]string{
-			"Atend1":      {"value 1"},
-			"Atend2":      {"value 2"},
-			"Last":        {"value 3"},
-			"Unannounced": {"Surprise!"},
-		})))
-	})
-
-	It("aborts requests on shutdown", func() {
-		mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
-			go func() {
-				defer GinkgoRecover()
-				Expect(server.Close()).To(Succeed())
-			}()
-			time.Sleep(scaleDuration(50 * time.Millisecond)) // make sure the server started shutting down
-		})
-
-		_, err := client.Get(fmt.Sprintf("https://localhost:%d/shutdown", port))
-		Expect(err).To(HaveOccurred())
-		var appErr *http3.Error
-		Expect(errors.As(err, &appErr)).To(BeTrue())
-		Expect(appErr.ErrorCode).To(Equal(http3.ErrCodeNoError))
-	})
-
-	It("allows existing requests to complete on graceful shutdown", func() {
-		delay := scaleDuration(100 * time.Millisecond)
-		done := make(chan struct{})
-
-		mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
-			go func() {
-				defer GinkgoRecover()
-				defer close(done)
-				Expect(server.Shutdown(context.Background())).To(Succeed())
-				fmt.Println("close gracefully done")
-			}()
-			time.Sleep(delay)
-			w.Write([]byte("shutdown"))
-		})
-
-		ctx, cancel := context.WithTimeout(context.Background(), 3*delay)
-		defer cancel()
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/shutdown", port), nil)
-		Expect(err).ToNot(HaveOccurred())
-		resp, err := client.Do(req)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		body, err := io.ReadAll(resp.Body)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(body).To(Equal([]byte("shutdown")))
-		// manually close the client, since we don't support
-		client.Transport.(*http3.Transport).Close()
-
-		// make sure that Shutdown returned
-		Eventually(done).Should(BeClosed())
-	})
-
-	It("aborts long-lived requests on graceful shutdown", func() {
-		delay := scaleDuration(100 * time.Millisecond)
-		shutdownDone := make(chan struct{})
-		requestChan := make(chan time.Duration, 1)
-
-		mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
-			start := time.Now()
-			w.WriteHeader(http.StatusOK)
-			w.(http.Flusher).Flush()
-			go func() {
-				defer GinkgoRecover()
-				ctx, cancel := context.WithTimeout(context.Background(), delay)
-				defer cancel()
-				defer close(shutdownDone)
-				Expect(server.Shutdown(ctx)).To(MatchError(context.DeadlineExceeded))
-			}()
-			for t := range time.NewTicker(delay / 10).C {
-				if _, err := w.Write([]byte(t.String())); err != nil {
-					requestChan <- time.Since(start)
-					return
-				}
-			}
-		})
-
-		start := time.Now()
-		resp, err := client.Get(fmt.Sprintf("https://localhost:%d/shutdown", port))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resp.StatusCode).To(Equal(http.StatusOK))
-		_, err = io.Copy(io.Discard, resp.Body)
-		Expect(err).To(HaveOccurred())
-		var h3Err *http3.Error
-		Expect(errors.As(err, &h3Err)).To(BeTrue())
-		Expect(h3Err.ErrorCode).To(Equal(http3.ErrCodeNoError))
-		took := time.Since(start)
-		Expect(took).To(BeNumerically("~", delay, delay/2))
-		var requestDuration time.Duration
-		Eventually(requestChan).Should(Receive(&requestDuration))
-		Expect(requestDuration).To(BeNumerically("~", delay, delay/2))
-
-		// make sure that Shutdown returned
-		Eventually(shutdownDone).Should(BeClosed())
-	})
-})
+	_, err = str.Write(PRData)
+	require.NoError(t, err)
+	require.NoError(t, str.Close())
+	repl, err := io.ReadAll(str)
+	require.NoError(t, err)
+	require.Equal(t, PRData, repl)
+}

--- a/integrationtests/self/zero_rtt_test.go
+++ b/integrationtests/self/zero_rtt_test.go
@@ -58,7 +58,9 @@ func contains0RTTPacket(data []byte) bool {
 			return false
 		}
 		hdr, _, rest, err := wire.ParsePacket(data)
-		Expect(err).ToNot(HaveOccurred())
+		if err != nil {
+			return false
+		}
 		if hdr.Type == protocol.PacketType0RTT {
 			return true
 		}


### PR DESCRIPTION
Splitting this out from #4736. This is a massive amount of work.
Part of #3652.