### PR TITLE
http3: add client trace support

### DIFF
--- a/http3/conn.go
+++ b/http3/conn.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -123,7 +124,8 @@ func (c *connection) openRequestStream(
 		rsp.Trailer = hdr
 		return nil
 	})
-	return newRequestStream(hstr, requestWriter, reqDone, c.decoder, disableCompression, maxHeaderBytes, rsp), nil
+	trace := httptrace.ContextClientTrace(ctx)
+	return newRequestStream(hstr, requestWriter, reqDone, c.decoder, disableCompression, maxHeaderBytes, rsp, trace), nil
 }
 
 func (c *connection) decodeTrailers(r io.Reader, l, maxHeaderBytes uint64) (http.Header, error) {

--- a/http3/http_stream_test.go
+++ b/http3/http_stream_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/http/httptrace"
 
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
 	"github.com/quic-go/quic-go/internal/protocol"
@@ -165,6 +166,7 @@ var _ = Describe("Request Stream", func() {
 			true,
 			math.MaxUint64,
 			&http.Response{},
+			&httptrace.ClientTrace{},
 		)
 	})
 

--- a/http3/ip_addr.go
+++ b/http3/ip_addr.go
@@ -1,0 +1,48 @@
+package http3
+
+import (
+	"net"
+	"strings"
+)
+
+// An addrList represents a list of network endpoint addresses.
+// Copy from [net.addrList] and change type from [net.Addr] to [net.IPAddr]
+type addrList []net.IPAddr
+
+// isIPv4 reports whether addr contains an IPv4 address.
+func isIPv4(addr net.IPAddr) bool {
+	return addr.IP.To4() != nil
+}
+
+// isNotIPv4 reports whether addr does not contain an IPv4 address.
+func isNotIPv4(addr net.IPAddr) bool { return !isIPv4(addr) }
+
+// forResolve returns the most appropriate address in address for
+// a call to ResolveTCPAddr, ResolveUDPAddr, or ResolveIPAddr.
+// IPv4 is preferred, unless addr contains an IPv6 literal.
+func (addrs addrList) forResolve(network, addr string) net.IPAddr {
+	var want6 bool
+	switch network {
+	case "ip":
+		// IPv6 literal (addr does NOT contain a port)
+		want6 = strings.ContainsRune(addr, ':')
+	case "tcp", "udp":
+		// IPv6 literal. (addr contains a port, so look for '[')
+		want6 = strings.ContainsRune(addr, '[')
+	}
+	if want6 {
+		return addrs.first(isNotIPv4)
+	}
+	return addrs.first(isIPv4)
+}
+
+// first returns the first address which satisfies strategy, or if
+// none do, then the first address of any kind.
+func (addrs addrList) first(strategy func(net.IPAddr) bool) net.IPAddr {
+	for _, addr := range addrs {
+		if strategy(addr) {
+			return addr
+		}
+	}
+	return addrs[0]
+}

--- a/http3/trace.go
+++ b/http3/trace.go
@@ -1,0 +1,105 @@
+package http3
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http/httptrace"
+	"net/textproto"
+	"time"
+
+	"github.com/quic-go/quic-go"
+)
+
+func traceGetConn(trace *httptrace.ClientTrace, hostPort string) {
+	if trace != nil && trace.GetConn != nil {
+		trace.GetConn(hostPort)
+	}
+}
+
+// fakeConn is a wrapper for quic.EarlyConnection
+// because the quic connection does not implement net.Conn.
+type fakeConn struct {
+	conn quic.EarlyConnection
+}
+
+func (c *fakeConn) Close() error                       { panic("connection operation prohibited") }
+func (c *fakeConn) Read(p []byte) (int, error)         { panic("connection operation prohibited") }
+func (c *fakeConn) Write(p []byte) (int, error)        { panic("connection operation prohibited") }
+func (c *fakeConn) SetDeadline(t time.Time) error      { panic("connection operation prohibited") }
+func (c *fakeConn) SetReadDeadline(t time.Time) error  { panic("connection operation prohibited") }
+func (c *fakeConn) SetWriteDeadline(t time.Time) error { panic("connection operation prohibited") }
+func (c *fakeConn) RemoteAddr() net.Addr               { return c.conn.RemoteAddr() }
+func (c *fakeConn) LocalAddr() net.Addr                { return c.conn.LocalAddr() }
+
+func traceGotConn(trace *httptrace.ClientTrace, conn quic.EarlyConnection, reused bool) {
+	if trace != nil && trace.GotConn != nil {
+		trace.GotConn(httptrace.GotConnInfo{
+			Conn:   &fakeConn{conn: conn},
+			Reused: reused,
+		})
+	}
+}
+
+func traceGotFirstResponseByte(trace *httptrace.ClientTrace) {
+	if trace != nil && trace.GotFirstResponseByte != nil {
+		trace.GotFirstResponseByte()
+	}
+}
+
+func traceGot1xxResponse(trace *httptrace.ClientTrace, code int, header textproto.MIMEHeader) {
+	if trace != nil && trace.Got1xxResponse != nil {
+		trace.Got1xxResponse(code, header)
+	}
+}
+
+func traceGot100Continue(trace *httptrace.ClientTrace) {
+	if trace != nil && trace.Got100Continue != nil {
+		trace.Got100Continue()
+	}
+}
+
+func traceHasWroteHeaderField(trace *httptrace.ClientTrace) bool {
+	return trace != nil && trace.WroteHeaderField != nil
+}
+
+func traceWroteHeaderField(trace *httptrace.ClientTrace, k, v string) {
+	if trace != nil && trace.WroteHeaderField != nil {
+		trace.WroteHeaderField(k, []string{v})
+	}
+}
+
+func traceWroteHeaders(trace *httptrace.ClientTrace) {
+	if trace != nil && trace.WroteHeaders != nil {
+		trace.WroteHeaders()
+	}
+}
+
+func traceWroteRequest(trace *httptrace.ClientTrace, err error) {
+	if trace != nil && trace.WroteRequest != nil {
+		trace.WroteRequest(httptrace.WroteRequestInfo{Err: err})
+	}
+}
+
+func traceConnectStart(trace *httptrace.ClientTrace, network, addr string) {
+	if trace != nil && trace.ConnectStart != nil {
+		trace.ConnectStart(network, addr)
+	}
+}
+
+func traceConnectDone(trace *httptrace.ClientTrace, network, addr string, err error) {
+	if trace != nil && trace.ConnectDone != nil {
+		trace.ConnectDone(network, addr, err)
+	}
+}
+
+func traceTLSHandshakeStart(trace *httptrace.ClientTrace) {
+	if trace != nil && trace.TLSHandshakeStart != nil {
+		trace.TLSHandshakeStart()
+	}
+}
+
+func traceTLSHandshakeDone(trace *httptrace.ClientTrace, state tls.ConnectionState, err error) {
+	if trace != nil && trace.TLSHandshakeDone != nil {
+		trace.TLSHandshakeDone(state, err)
+	}
+}

--- a/http3/transport.go
+++ b/http3/transport.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -197,7 +198,9 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
 		return nil, fmt.Errorf("http3: invalid method %q", req.Method)
 	}
 
+	trace := httptrace.ContextClientTrace(req.Context())
 	hostname := authorityAddr(hostnameFromURL(req.URL))
+	traceGetConn(trace, hostname)
 	cl, isReused, err := t.getClient(req.Context(), hostname, opt.OnlyCachedConn)
 	if err != nil {
 		return nil, err
@@ -213,6 +216,7 @@ func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
 		t.removeClient(hostname)
 		return nil, cl.dialErr
 	}
+	traceGotConn(trace, cl.conn, isReused)
 	defer cl.useCount.Add(-1)
 	rsp, err := cl.rt.RoundTrip(req)
 	if err != nil {
@@ -313,19 +317,48 @@ func (t *Transport) dial(ctx context.Context, hostname string) (quic.EarlyConnec
 			t.transport = &quic.Transport{Conn: udpConn}
 		}
 		dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
-			udpAddr, err := net.ResolveUDPAddr("udp", addr)
+			network := "udp"
+			udpAddr, err := t.resolveUDPAddr(ctx, network, addr)
 			if err != nil {
 				return nil, err
 			}
-			return t.transport.DialEarly(ctx, udpAddr, tlsCfg, cfg)
+			trace := httptrace.ContextClientTrace(ctx)
+			traceConnectStart(trace, network, udpAddr.String())
+			traceTLSHandshakeStart(trace)
+			conn, err := t.transport.DialEarly(ctx, udpAddr, tlsCfg, cfg)
+			var state tls.ConnectionState
+			if conn != nil {
+				state = conn.ConnectionState().TLS
+			}
+			traceTLSHandshakeDone(trace, state, err)
+			traceConnectDone(trace, network, udpAddr.String(), err)
+			return conn, err
 		}
 	}
-
 	conn, err := dial(ctx, hostname, tlsConf, t.QUICConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 	return conn, t.newClient(conn), nil
+}
+
+func (t *Transport) resolveUDPAddr(ctx context.Context, network, addr string) (*net.UDPAddr, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	port, err := net.LookupPort(network, portStr)
+	if err != nil {
+		return nil, err
+	}
+	resolver := net.DefaultResolver
+	ipAddrs, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	addrs := addrList(ipAddrs)
+	ip := addrs.forResolve(network, addr)
+	return &net.UDPAddr{IP: ip.IP, Port: port, Zone: ip.Zone}, nil
 }
 
 func (t *Transport) removeClient(hostname string) {

--- a/integrationtests/self/http_trace_test.go
+++ b/integrationtests/self/http_trace_test.go
@@ -1,0 +1,130 @@
+package self_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptrace"
+	"net/textproto"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPClientTrace(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/client-trace", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusContinue)
+	})
+	port := startHTTPServer(t, mux)
+
+	buf := make([]byte, 1)
+	type event struct {
+		Key  string
+		Args any
+	}
+	eventQueue := make(chan event, 100)
+	wait100Continue := false
+	trace := httptrace.ClientTrace{
+		GetConn:              func(hostPort string) { eventQueue <- event{Key: "GetConn", Args: hostPort} },
+		GotConn:              func(info httptrace.GotConnInfo) { eventQueue <- event{Key: "GotConn", Args: info} },
+		GotFirstResponseByte: func() { eventQueue <- event{Key: "GotFirstResponseByte"} },
+		Got100Continue:       func() { eventQueue <- event{Key: "Got100Continue"} },
+		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
+			eventQueue <- event{Key: "Got1xxResponse", Args: code}
+			return nil
+		},
+		DNSStart: func(di httptrace.DNSStartInfo) { eventQueue <- event{Key: "DNSStart", Args: di} },
+		DNSDone:  func(di httptrace.DNSDoneInfo) { eventQueue <- event{Key: "DNSDone", Args: di} },
+		ConnectStart: func(network, addr string) {
+			eventQueue <- event{Key: "ConnectStart", Args: map[string]string{"network": network, "addr": addr}}
+		},
+		ConnectDone: func(network, addr string, err error) {
+			eventQueue <- event{Key: "ConnectDone", Args: map[string]any{"network": network, "addr": addr, "err": err}}
+		},
+		TLSHandshakeStart: func() { eventQueue <- event{Key: "TLSHandshakeStart"} },
+		TLSHandshakeDone: func(state tls.ConnectionState, err error) {
+			eventQueue <- event{Key: "TLSHandshakeDone", Args: map[string]any{"state": state, "err": err}}
+		},
+		WroteHeaderField: func(key string, value []string) {
+			if key != ":authority" {
+				return
+			}
+			eventQueue <- event{Key: "WroteHeaderField", Args: value[0]}
+		},
+		WroteHeaders:    func() { eventQueue <- event{Key: "WroteHeaders"} },
+		Wait100Continue: func() { wait100Continue = true },
+		WroteRequest:    func(i httptrace.WroteRequestInfo) { eventQueue <- event{Key: "WroteRequest", Args: i} },
+	}
+	ctx := httptrace.WithClientTrace(context.Background(), &trace)
+
+	cl := newHTTP3Client(t)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/client-trace", port), nil)
+	require.NoError(t, err)
+	resp, err := cl.Do(req)
+	close(eventQueue)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	events := make([]string, 0, len(eventQueue))
+	for e := range eventQueue {
+		events = append(events, e.Key)
+		switch e.Key {
+		case "GetConn":
+			require.Equal(t, fmt.Sprintf("localhost:%d", port), e.Args.(string))
+		case "GotConn":
+			info := e.Args.(httptrace.GotConnInfo)
+			require.Equal(t, fmt.Sprintf("127.0.0.1:%d", port), info.Conn.RemoteAddr().String())
+			host, _, err := net.SplitHostPort(info.Conn.LocalAddr().String())
+			require.NoError(t, err)
+			require.Contains(t, []string{"::", "0.0.0.0"}, host)
+			require.Panics(t, func() { info.Conn.Close() })
+			require.Panics(t, func() { info.Conn.Read(buf) })
+			require.Panics(t, func() { info.Conn.Write(buf) })
+			require.Panics(t, func() { info.Conn.SetDeadline(time.Now()) })
+			require.Panics(t, func() { info.Conn.SetReadDeadline(time.Now()) })
+			require.Panics(t, func() { info.Conn.SetWriteDeadline(time.Now()) })
+		case "Got1xxResponse":
+			require.Equal(t, 100, e.Args.(int))
+		case "DNSStart":
+			require.Equal(t, "localhost", e.Args.(httptrace.DNSStartInfo).Host)
+		case "DNSDone":
+			require.Condition(t, func() bool {
+				localhost := net.IPv4(127, 0, 0, 1)
+				localhostTo16 := localhost.To16()
+				for _, addr := range e.Args.(httptrace.DNSDoneInfo).Addrs {
+					if addr.IP.Equal(localhost) || addr.IP.Equal(localhostTo16) {
+						return true
+					}
+				}
+				return false
+			})
+		case "ConnectStart":
+			require.Equal(t, "udp", e.Args.(map[string]string)["network"])
+			require.Equal(t, fmt.Sprintf("127.0.0.1:%d", port), e.Args.(map[string]string)["addr"])
+		case "ConnectDone":
+			require.Equal(t, "udp", e.Args.(map[string]any)["network"])
+			require.Equal(t, fmt.Sprintf("127.0.0.1:%d", port), e.Args.(map[string]any)["addr"])
+			require.Nil(t, e.Args.(map[string]any)["err"])
+		case "TLSHandshakeDone":
+			require.Nil(t, e.Args.(map[string]any)["err"])
+			state := e.Args.(map[string]any)["state"].(tls.ConnectionState)
+			require.Equal(t, 1, len(state.PeerCertificates))
+			require.Equal(t, "localhost", state.PeerCertificates[0].DNSNames[0])
+		case "WroteHeaderField":
+			require.Equal(t, fmt.Sprintf("localhost:%d", port), e.Args.(string))
+		case "WroteRequest":
+			require.NoError(t, e.Args.(httptrace.WroteRequestInfo).Err)
+		}
+	}
+	require.Equal(t,
+		[]string{
+			"GetConn", "DNSStart", "DNSDone", "ConnectStart", "TLSHandshakeStart", "TLSHandshakeDone",
+			"ConnectDone", "GotConn", "WroteHeaderField", "WroteHeaders", "WroteRequest",
+			"GotFirstResponseByte", "Got1xxResponse", "Got100Continue",
+		}, events)
+	require.Falsef(t, wait100Continue, "wait 100 continue") // Note: not supported Expect: 100-continue
+}


### PR DESCRIPTION
Since the QUIC protocol's connection establishment involves TLS handshake, I think ConnectDone and TLSHandshakeStart hooks should be called after transport dial is completed, and TLSHandshakeDone after HandshakeComplete.

Notice: Wait100Continue not implemented as quic-go doesn't support handling 1xx responses. 

Fixes #4748. Fixes #3342.