### PR TITLE
introduce a test helper function to create a new UDP socket on localhost

### DIFF
--- a/integrationtests/self/conn_id_test.go
+++ b/integrationtests/self/conn_id_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	mrand "math/rand"
-	"net"
 	"testing"
 
 	"github.com/quic-go/quic-go"
@@ -67,13 +66,8 @@ func testTransferWithConnectionIDs(
 	}
 
 	// setup server
-	addr, err := net.ResolveUDPAddr("udp", "localhost:0")
-	require.NoError(t, err)
-	conn, err := net.ListenUDP("udp", addr)
-	require.NoError(t, err)
-	t.Cleanup(func() { conn.Close() })
 	serverTr := &quic.Transport{
-		Conn:                  conn,
+		Conn:                  newUPDConnLocalhost(t),
 		ConnectionIDLength:    serverConnIDLen,
 		ConnectionIDGenerator: serverConnIDGenerator,
 	}
@@ -83,13 +77,8 @@ func testTransferWithConnectionIDs(
 	require.NoError(t, err)
 
 	// setup client
-	laddr, err := net.ResolveUDPAddr("udp", "localhost:0")
-	require.NoError(t, err)
-	clientConn, err := net.ListenUDP("udp", laddr)
-	require.NoError(t, err)
-	t.Cleanup(func() { clientConn.Close() })
 	clientTr := &quic.Transport{
-		Conn:                  clientConn,
+		Conn:                  newUPDConnLocalhost(t),
 		ConnectionIDLength:    clientConnIDLen,
 		ConnectionIDGenerator: clientConnIDGenerator,
 	}
@@ -98,7 +87,7 @@ func testTransferWithConnectionIDs(
 
 	cl, err := clientTr.Dial(
 		context.Background(),
-		&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: ln.Addr().(*net.UDPAddr).Port},
+		ln.Addr(),
 		getTLSClientConfig(),
 		getQuicConfig(nil),
 	)

--- a/integrationtests/self/deadline_test.go
+++ b/integrationtests/self/deadline_test.go
@@ -16,18 +16,13 @@ import (
 
 func setupDeadlineTest(t *testing.T) (serverStr, clientStr quic.Stream) {
 	t.Helper()
-	server, err := quic.ListenAddr("localhost:0", getTLSConfig(), getQuicConfig(nil))
+	server, err := quic.Listen(newUPDConnLocalhost(t), getTLSConfig(), getQuicConfig(nil))
 	require.NoError(t, err)
 	t.Cleanup(func() { server.Close() })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	conn, err := quic.DialAddr(
-		ctx,
-		fmt.Sprintf("localhost:%d", server.Addr().(*net.UDPAddr).Port),
-		getTLSClientConfig(),
-		getQuicConfig(nil),
-	)
+	conn, err := quic.Dial(ctx, newUPDConnLocalhost(t), server.Addr(), getTLSClientConfig(), getQuicConfig(nil))
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.CloseWithError(0, "") })
 	clientStr, err = conn.OpenStream()

--- a/integrationtests/self/early_data_test.go
+++ b/integrationtests/self/early_data_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestEarlyData(t *testing.T) {
 	const rtt = 80 * time.Millisecond
-	ln, err := quic.ListenAddrEarly("localhost:0", getTLSConfig(), getQuicConfig(nil))
+	ln, err := quic.ListenEarly(newUPDConnLocalhost(t), getTLSConfig(), getQuicConfig(nil))
 	require.NoError(t, err)
 	defer ln.Close()
 
@@ -38,12 +38,9 @@ func TestEarlyData(t *testing.T) {
 		connChan <- conn
 	}()
 
-	clientConn, err := quic.DialAddr(
-		context.Background(),
-		fmt.Sprintf("localhost:%d", proxy.LocalPort()),
-		getTLSClientConfig(),
-		getQuicConfig(nil),
-	)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	clientConn, err := quic.Dial(ctx, newUPDConnLocalhost(t), proxy.LocalAddr(), getTLSClientConfig(), getQuicConfig(nil))
 	require.NoError(t, err)
 
 	var serverConn quic.EarlyConnection

--- a/integrationtests/self/http_hotswap_test.go
+++ b/integrationtests/self/http_hotswap_test.go
@@ -78,9 +78,9 @@ func TestHTTP3ServerHotswap(t *testing.T) {
 	}
 
 	tlsConf := http3.ConfigureTLSConfig(getTLSConfig())
-	quicln, err := quic.ListenAddrEarly("0.0.0.0:0", tlsConf, getQuicConfig(nil))
+	quicLn, err := quic.ListenEarly(newUPDConnLocalhost(t), tlsConf, getQuicConfig(nil))
 	require.NoError(t, err)
-	ln := &listenerWrapper{QUICEarlyListener: quicln}
+	ln := &listenerWrapper{QUICEarlyListener: quicLn}
 	port := strconv.Itoa(ln.Addr().(*net.UDPAddr).Port)
 
 	rt := &http3.Transport{

--- a/integrationtests/self/mitm_test.go
+++ b/integrationtests/self/mitm_test.go
@@ -26,19 +26,15 @@ import (
 const mitmTestConnIDLen = 6
 
 func getTransportsForMITMTest(t *testing.T) (serverTransport, clientTransport *quic.Transport) {
-	serverUDPConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
 	serverTransport = &quic.Transport{
-		Conn:               serverUDPConn,
+		Conn:               newUPDConnLocalhost(t),
 		ConnectionIDLength: mitmTestConnIDLen,
 	}
 	addTracer(serverTransport)
 	t.Cleanup(func() { serverTransport.Close() })
 
-	clientUDPConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
 	clientTransport = &quic.Transport{
-		Conn:               clientUDPConn,
+		Conn:               newUPDConnLocalhost(t),
 		ConnectionIDLength: mitmTestConnIDLen,
 	}
 	addTracer(clientTransport)

--- a/integrationtests/self/mtu_test.go
+++ b/integrationtests/self/mtu_test.go
@@ -19,12 +19,8 @@ import (
 )
 
 func TestInitialPacketSize(t *testing.T) {
-	server, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	defer server.Close()
-	client, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	defer client.Close()
+	server := newUPDConnLocalhost(t)
+	client := newUPDConnLocalhost(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -49,8 +45,8 @@ func TestPathMTUDiscovery(t *testing.T) {
 	rtt := scaleDuration(5 * time.Millisecond)
 	const mtu = 1400
 
-	ln, err := quic.ListenAddr(
-		"localhost:0",
+	ln, err := quic.Listen(
+		newUPDConnLocalhost(t),
 		getTLSConfig(),
 		getQuicConfig(&quic.Config{
 			InitialPacketSize:       1234,
@@ -109,10 +105,7 @@ func TestPathMTUDiscovery(t *testing.T) {
 
 	// Make sure to use v4-only socket here.
 	// We can't reliably set the DF bit on dual-stack sockets on older versions of macOS (before Sequoia).
-	udpConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	defer udpConn.Close()
-	tr := &quic.Transport{Conn: udpConn}
+	tr := &quic.Transport{Conn: newUPDConnLocalhost(t)}
 	defer tr.Close()
 
 	var mtus []logging.ByteCount

--- a/integrationtests/self/multiplex_test.go
+++ b/integrationtests/self/multiplex_test.go
@@ -60,15 +60,12 @@ func dialAndReceiveData(tr *quic.Transport, addr net.Addr) error {
 }
 
 func TestMultiplexesConnectionsToSameServer(t *testing.T) {
-	server, err := quic.ListenAddr("localhost:0", getTLSConfig(), getQuicConfig(nil))
+	server, err := quic.Listen(newUPDConnLocalhost(t), getTLSConfig(), getQuicConfig(nil))
 	require.NoError(t, err)
 	defer server.Close()
 	go runMultiplexTestServer(t, server)
 
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	defer conn.Close()
-	tr := &quic.Transport{Conn: conn}
+	tr := &quic.Transport{Conn: newUPDConnLocalhost(t)}
 	addTracer(tr)
 	defer tr.Close()
 
@@ -92,21 +89,17 @@ func TestMultiplexesConnectionsToSameServer(t *testing.T) {
 }
 
 func TestMultiplexingToDifferentServers(t *testing.T) {
-	server1, err := quic.ListenAddr("localhost:0", getTLSConfig(), getQuicConfig(nil))
+	server1, err := quic.Listen(newUPDConnLocalhost(t), getTLSConfig(), getQuicConfig(nil))
 	require.NoError(t, err)
 	defer server1.Close()
 	go runMultiplexTestServer(t, server1)
 
-	server2, err := quic.ListenAddr("localhost:0", getTLSConfig(), getQuicConfig(nil))
+	server2, err := quic.Listen(newUPDConnLocalhost(t), getTLSConfig(), getQuicConfig(nil))
 	require.NoError(t, err)
 	defer server2.Close()
 	go runMultiplexTestServer(t, server2)
 
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	defer conn.Close()
-
-	tr := &quic.Transport{Conn: conn}
+	tr := &quic.Transport{Conn: newUPDConnLocalhost(t)}
 	addTracer(tr)
 	defer tr.Close()
 
@@ -130,10 +123,7 @@ func TestMultiplexingToDifferentServers(t *testing.T) {
 }
 
 func TestMultiplexingConnectToSelf(t *testing.T) {
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	defer conn.Close()
-	tr := &quic.Transport{Conn: conn}
+	tr := &quic.Transport{Conn: newUPDConnLocalhost(t)}
 	addTracer(tr)
 	defer tr.Close()
 
@@ -158,20 +148,14 @@ func TestMultiplexingServerAndClientOnSameConn(t *testing.T) {
 		t.Skip("This test requires setting of iptables rules on Linux, see https://stackoverflow.com/questions/23859164/linux-udp-socket-sendto-operation-not-permitted.")
 	}
 
-	conn1, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	defer conn1.Close()
-	tr1 := &quic.Transport{Conn: conn1}
+	tr1 := &quic.Transport{Conn: newUPDConnLocalhost(t)}
 	addTracer(tr1)
 	defer tr1.Close()
 	server1, err := tr1.Listen(getTLSConfig(), getQuicConfig(nil))
 	require.NoError(t, err)
 	defer server1.Close()
 
-	conn2, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	defer conn2.Close()
-	tr2 := &quic.Transport{Conn: conn2}
+	tr2 := &quic.Transport{Conn: newUPDConnLocalhost(t)}
 	addTracer(tr2)
 	defer tr2.Close()
 	server2, err := tr2.Listen(getTLSConfig(), getQuicConfig(nil))
@@ -203,17 +187,11 @@ func TestMultiplexingServerAndClientOnSameConn(t *testing.T) {
 }
 
 func TestMultiplexingNonQUICPackets(t *testing.T) {
-	conn1, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	defer conn1.Close()
-	tr1 := &quic.Transport{Conn: conn1}
+	tr1 := &quic.Transport{Conn: newUPDConnLocalhost(t)}
 	defer tr1.Close()
 	addTracer(tr1)
 
-	conn2, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
-	require.NoError(t, err)
-	defer conn2.Close()
-	tr2 := &quic.Transport{Conn: conn2}
+	tr2 := &quic.Transport{Conn: newUPDConnLocalhost(t)}
 	defer tr2.Close()
 	addTracer(tr2)
 

--- a/integrationtests/self/rtt_test.go
+++ b/integrationtests/self/rtt_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func runServerForRTTTest(t *testing.T) (net.Addr, <-chan error) {
-	ln, err := quic.ListenAddr(
-		"localhost:0",
+	ln, err := quic.Listen(
+		newUPDConnLocalhost(t),
 		getTLSConfig(),
 		getQuicConfig(nil),
 	)
@@ -74,9 +74,10 @@ func TestDownloadWithFixedRTT(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
-			conn, err := quic.DialAddr(
+			conn, err := quic.Dial(
 				ctx,
-				fmt.Sprintf("localhost:%d", proxy.LocalPort()),
+				newUPDConnLocalhost(t),
+				proxy.LocalAddr(),
 				getTLSClientConfig(),
 				getQuicConfig(nil),
 			)
@@ -119,9 +120,10 @@ func TestDownloadWithReordering(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
-			conn, err := quic.DialAddr(
+			conn, err := quic.Dial(
 				ctx,
-				fmt.Sprintf("localhost:%d", proxy.LocalPort()),
+				newUPDConnLocalhost(t),
+				proxy.LocalAddr(),
 				getTLSClientConfig(),
 				getQuicConfig(nil),
 			)

--- a/integrationtests/self/self_test.go
+++ b/integrationtests/self/self_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"os"
 	"runtime/pprof"
 	"strconv"
@@ -21,6 +22,8 @@ import (
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/wire"
 	"github.com/quic-go/quic-go/logging"
+
+	"github.com/stretchr/testify/require"
 )
 
 const alpn = tools.ALPN
@@ -148,6 +151,14 @@ func addTracer(tr *quic.Transport) {
 		tools.QlogTracer(os.Stdout),
 		origTracer,
 	)
+}
+
+func newUPDConnLocalhost(t testing.TB) *net.UDPConn {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return conn
 }
 
 func areHandshakesRunning() bool {

--- a/integrationtests/self/stateless_reset_test.go
+++ b/integrationtests/self/stateless_reset_test.go
@@ -69,19 +69,14 @@ func testStatelessReset(t *testing.T, connIDLen int) {
 	require.NoError(t, err)
 	defer proxy.Close()
 
-	addr, err := net.ResolveUDPAddr("udp", "localhost:0")
-	require.NoError(t, err)
-	udpConn, err := net.ListenUDP("udp", addr)
-	require.NoError(t, err)
-	defer udpConn.Close()
 	cl := &quic.Transport{
-		Conn:               udpConn,
+		Conn:               newUPDConnLocalhost(t),
 		ConnectionIDLength: connIDLen,
 	}
 	defer cl.Close()
 	conn, err := cl.Dial(
 		context.Background(),
-		&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: proxy.LocalPort()},
+		proxy.LocalAddr(),
 		getTLSClientConfig(),
 		getQuicConfig(&quic.Config{MaxIdleTimeout: 2 * time.Second}),
 	)


### PR DESCRIPTION
This should also reduce the flakiness on macOS due to https://github.com/golang/go/issues/67226, since in the vast majority of tests we're now listening on a (single-stack) `net.UPDConn` directly.