### PR TITLE
remove unneeded Connection.GetVersion method

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2306,17 +2306,8 @@ func (s *connection) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 	return s.datagramQueue.Receive(ctx)
 }
 
-func (s *connection) LocalAddr() net.Addr {
-	return s.conn.LocalAddr()
-}
-
-func (s *connection) RemoteAddr() net.Addr {
-	return s.conn.RemoteAddr()
-}
-
-func (s *connection) GetVersion() protocol.Version {
-	return s.version
-}
+func (s *connection) LocalAddr() net.Addr  { return s.conn.LocalAddr() }
+func (s *connection) RemoteAddr() net.Addr { return s.conn.RemoteAddr() }
 
 func (s *connection) NextConnection(ctx context.Context) (Connection, error) {
 	// The handshake might fail after the server rejected 0-RTT.

--- a/connection_test.go
+++ b/connection_test.go
@@ -419,11 +419,6 @@ var _ = Describe("Connection", func() {
 		})
 	})
 
-	It("tells its versions", func() {
-		conn.version = 4242
-		Expect(conn.GetVersion()).To(Equal(protocol.Version(4242)))
-	})
-
 	Context("closing", func() {
 		var (
 			runErr         chan error

--- a/integrationtests/versionnegotiation/handshake_test.go
+++ b/integrationtests/versionnegotiation/handshake_test.go
@@ -15,10 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type versioner interface {
-	GetVersion() protocol.Version
-}
-
 type result struct {
 	loggedVersions                 bool
 	receivedVersionNegotiation     bool
@@ -73,9 +69,9 @@ func TestServerSupportsMoreVersionsThanClient(t *testing.T) {
 
 	sconn, err := server.Accept(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, expectedVersion, sconn.(versioner).GetVersion())
+	require.Equal(t, expectedVersion, sconn.ConnectionState().Version)
 
-	require.Equal(t, expectedVersion, conn.(versioner).GetVersion())
+	require.Equal(t, expectedVersion, conn.ConnectionState().Version)
 	require.NoError(t, conn.CloseWithError(0, ""))
 
 	select {
@@ -129,9 +125,9 @@ func TestClientSupportsMoreVersionsThanServer(t *testing.T) {
 
 	sconn, err := server.Accept(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, expectedVersion, sconn.(versioner).GetVersion())
+	require.Equal(t, expectedVersion, sconn.ConnectionState().Version)
 
-	require.Equal(t, protocol.SupportedVersions[0], conn.(versioner).GetVersion())
+	require.Equal(t, protocol.SupportedVersions[0], conn.ConnectionState().Version)
 	require.NoError(t, conn.CloseWithError(0, ""))
 
 	select {


### PR DESCRIPTION
Instead, use `Connection.ConnectionState().Version`.