### PR TITLE
wire: don't allocate an empty data slice for empty STREAM frames

### DIFF
--- a/internal/wire/stream_frame.go
+++ b/internal/wire/stream_frame.go
@@ -58,7 +58,10 @@ func parseStreamFrame(b []byte, typ uint64, _ protocol.Version) (*StreamFrame, i
 
 	var frame *StreamFrame
 	if dataLen < protocol.MinStreamFrameBufferSize {
-		frame = &StreamFrame{Data: make([]byte, dataLen)}
+		frame = &StreamFrame{}
+		if dataLen > 0 {
+			frame.Data = make([]byte, dataLen)
+		}
 	} else {
 		frame = GetStreamFrame()
 		// The STREAM frame can't be larger than the StreamFrame we obtained from the buffer,
@@ -74,7 +77,7 @@ func parseStreamFrame(b []byte, typ uint64, _ protocol.Version) (*StreamFrame, i
 	frame.Fin = fin
 	frame.DataLenPresent = hasDataLen
 
-	if dataLen != 0 {
+	if dataLen > 0 {
 		copy(frame.Data, b)
 	}
 	if frame.Offset+frame.DataLen() > protocol.MaxByteCount {

--- a/internal/wire/stream_frame_test.go
+++ b/internal/wire/stream_frame_test.go
@@ -55,7 +55,7 @@ func TestParseStreamFrameAllowsEmpty(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, protocol.StreamID(0x1337), f.StreamID)
 	require.Equal(t, protocol.ByteCount(0x12345), f.Offset)
-	require.Empty(t, f.Data)
+	require.Nil(t, f.Data)
 	require.False(t, f.Fin)
 	require.Equal(t, len(data), l)
 }


### PR DESCRIPTION
Minor optimization, but it simplifies testing in some cases.