### PR TITLE
optimize packing of STREAM_DATA_BLOCKED frames

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -1131,7 +1131,7 @@ func TestConnectionHandshakeServer(t *testing.T) {
 	}
 
 	var foundSessionTicket, foundHandshakeDone, foundNewToken bool
-	frames, _ := tc.conn.framer.AppendControlFrames(nil, protocol.MaxByteCount, time.Now(), protocol.Version1)
+	frames, _, _ := tc.conn.framer.Append(nil, nil, protocol.MaxByteCount, time.Now(), protocol.Version1)
 	for _, frame := range frames {
 		switch f := frame.Frame.(type) {
 		case *wire.CryptoFrame:

--- a/framer.go
+++ b/framer.go
@@ -79,7 +79,19 @@ func (f *framer) QueueControlFrame(frame wire.Frame) {
 	f.controlFrames = append(f.controlFrames, frame)
 }
 
-func (f *framer) AppendControlFrames(
+func (f *framer) Append(
+	frames []ackhandler.Frame,
+	streamFrames []ackhandler.StreamFrame,
+	maxLen protocol.ByteCount,
+	now time.Time,
+	v protocol.Version,
+) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount) {
+	frames, l := f.appendControlFrames(frames, maxLen, now, v)
+	streamFrames, l2 := f.appendStreamFrames(streamFrames, maxLen-l, v)
+	return frames, streamFrames, l + l2
+}
+
+func (f *framer) appendControlFrames(
 	frames []ackhandler.Frame,
 	maxLen protocol.ByteCount,
 	now time.Time,
@@ -173,7 +185,7 @@ func (f *framer) RemoveActiveStream(id protocol.StreamID) {
 	f.mutex.Unlock()
 }
 
-func (f *framer) AppendStreamFrames(frames []ackhandler.StreamFrame, maxLen protocol.ByteCount, v protocol.Version) ([]ackhandler.StreamFrame, protocol.ByteCount) {
+func (f *framer) appendStreamFrames(frames []ackhandler.StreamFrame, maxLen protocol.ByteCount, v protocol.Version) ([]ackhandler.StreamFrame, protocol.ByteCount) {
 	startLen := len(frames)
 	var length protocol.ByteCount
 	f.mutex.Lock()

--- a/mock_frame_source_test.go
+++ b/mock_frame_source_test.go
@@ -42,80 +42,42 @@ func (m *MockFrameSource) EXPECT() *MockFrameSourceMockRecorder {
 	return m.recorder
 }
 
-// AppendControlFrames mocks base method.
-func (m *MockFrameSource) AppendControlFrames(arg0 []ackhandler.Frame, arg1 protocol.ByteCount, arg2 time.Time, arg3 protocol.Version) ([]ackhandler.Frame, protocol.ByteCount) {
+// Append mocks base method.
+func (m *MockFrameSource) Append(arg0 []ackhandler.Frame, arg1 []ackhandler.StreamFrame, arg2 protocol.ByteCount, arg3 time.Time, arg4 protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendControlFrames", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Append", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]ackhandler.Frame)
-	ret1, _ := ret[1].(protocol.ByteCount)
-	return ret0, ret1
+	ret1, _ := ret[1].([]ackhandler.StreamFrame)
+	ret2, _ := ret[2].(protocol.ByteCount)
+	return ret0, ret1, ret2
 }
 
-// AppendControlFrames indicates an expected call of AppendControlFrames.
-func (mr *MockFrameSourceMockRecorder) AppendControlFrames(arg0, arg1, arg2, arg3 any) *MockFrameSourceAppendControlFramesCall {
+// Append indicates an expected call of Append.
+func (mr *MockFrameSourceMockRecorder) Append(arg0, arg1, arg2, arg3, arg4 any) *MockFrameSourceAppendCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendControlFrames", reflect.TypeOf((*MockFrameSource)(nil).AppendControlFrames), arg0, arg1, arg2, arg3)
-	return &MockFrameSourceAppendControlFramesCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Append", reflect.TypeOf((*MockFrameSource)(nil).Append), arg0, arg1, arg2, arg3, arg4)
+	return &MockFrameSourceAppendCall{Call: call}
 }
 
-// MockFrameSourceAppendControlFramesCall wrap *gomock.Call
-type MockFrameSourceAppendControlFramesCall struct {
+// MockFrameSourceAppendCall wrap *gomock.Call
+type MockFrameSourceAppendCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockFrameSourceAppendControlFramesCall) Return(arg0 []ackhandler.Frame, arg1 protocol.ByteCount) *MockFrameSourceAppendControlFramesCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockFrameSourceAppendCall) Return(arg0 []ackhandler.Frame, arg1 []ackhandler.StreamFrame, arg2 protocol.ByteCount) *MockFrameSourceAppendCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFrameSourceAppendControlFramesCall) Do(f func([]ackhandler.Frame, protocol.ByteCount, time.Time, protocol.Version) ([]ackhandler.Frame, protocol.ByteCount)) *MockFrameSourceAppendControlFramesCall {
+func (c *MockFrameSourceAppendCall) Do(f func([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount, time.Time, protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount)) *MockFrameSourceAppendCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFrameSourceAppendControlFramesCall) DoAndReturn(f func([]ackhandler.Frame, protocol.ByteCount, time.Time, protocol.Version) ([]ackhandler.Frame, protocol.ByteCount)) *MockFrameSourceAppendControlFramesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// AppendStreamFrames mocks base method.
-func (m *MockFrameSource) AppendStreamFrames(arg0 []ackhandler.StreamFrame, arg1 protocol.ByteCount, arg2 protocol.Version) ([]ackhandler.StreamFrame, protocol.ByteCount) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendStreamFrames", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]ackhandler.StreamFrame)
-	ret1, _ := ret[1].(protocol.ByteCount)
-	return ret0, ret1
-}
-
-// AppendStreamFrames indicates an expected call of AppendStreamFrames.
-func (mr *MockFrameSourceMockRecorder) AppendStreamFrames(arg0, arg1, arg2 any) *MockFrameSourceAppendStreamFramesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendStreamFrames", reflect.TypeOf((*MockFrameSource)(nil).AppendStreamFrames), arg0, arg1, arg2)
-	return &MockFrameSourceAppendStreamFramesCall{Call: call}
-}
-
-// MockFrameSourceAppendStreamFramesCall wrap *gomock.Call
-type MockFrameSourceAppendStreamFramesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockFrameSourceAppendStreamFramesCall) Return(arg0 []ackhandler.StreamFrame, arg1 protocol.ByteCount) *MockFrameSourceAppendStreamFramesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockFrameSourceAppendStreamFramesCall) Do(f func([]ackhandler.StreamFrame, protocol.ByteCount, protocol.Version) ([]ackhandler.StreamFrame, protocol.ByteCount)) *MockFrameSourceAppendStreamFramesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFrameSourceAppendStreamFramesCall) DoAndReturn(f func([]ackhandler.StreamFrame, protocol.ByteCount, protocol.Version) ([]ackhandler.StreamFrame, protocol.ByteCount)) *MockFrameSourceAppendStreamFramesCall {
+func (c *MockFrameSourceAppendCall) DoAndReturn(f func([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount, time.Time, protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount)) *MockFrameSourceAppendCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mock_send_stream_internal_test.go
+++ b/mock_send_stream_internal_test.go
@@ -383,18 +383,19 @@ func (c *MockSendStreamIhasDataCall) DoAndReturn(f func() bool) *MockSendStreamI
 }
 
 // popStreamFrame mocks base method.
-func (m *MockSendStreamI) popStreamFrame(maxBytes protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, bool) {
+func (m *MockSendStreamI) popStreamFrame(arg0 protocol.ByteCount, arg1 protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "popStreamFrame", maxBytes, v)
+	ret := m.ctrl.Call(m, "popStreamFrame", arg0, arg1)
 	ret0, _ := ret[0].(ackhandler.StreamFrame)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	ret1, _ := ret[1].(*wire.StreamDataBlockedFrame)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
 }
 
 // popStreamFrame indicates an expected call of popStreamFrame.
-func (mr *MockSendStreamIMockRecorder) popStreamFrame(maxBytes, v any) *MockSendStreamIpopStreamFrameCall {
+func (mr *MockSendStreamIMockRecorder) popStreamFrame(arg0, arg1 any) *MockSendStreamIpopStreamFrameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popStreamFrame", reflect.TypeOf((*MockSendStreamI)(nil).popStreamFrame), maxBytes, v)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popStreamFrame", reflect.TypeOf((*MockSendStreamI)(nil).popStreamFrame), arg0, arg1)
 	return &MockSendStreamIpopStreamFrameCall{Call: call}
 }
 
@@ -404,19 +405,19 @@ type MockSendStreamIpopStreamFrameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockSendStreamIpopStreamFrameCall) Return(frame ackhandler.StreamFrame, hasMore bool) *MockSendStreamIpopStreamFrameCall {
-	c.Call = c.Call.Return(frame, hasMore)
+func (c *MockSendStreamIpopStreamFrameCall) Return(arg0 ackhandler.StreamFrame, arg1 *wire.StreamDataBlockedFrame, hasMore bool) *MockSendStreamIpopStreamFrameCall {
+	c.Call = c.Call.Return(arg0, arg1, hasMore)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSendStreamIpopStreamFrameCall) Do(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, bool)) *MockSendStreamIpopStreamFrameCall {
+func (c *MockSendStreamIpopStreamFrameCall) Do(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool)) *MockSendStreamIpopStreamFrameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSendStreamIpopStreamFrameCall) DoAndReturn(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, bool)) *MockSendStreamIpopStreamFrameCall {
+func (c *MockSendStreamIpopStreamFrameCall) DoAndReturn(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool)) *MockSendStreamIpopStreamFrameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mock_stream_internal_test.go
+++ b/mock_stream_internal_test.go
@@ -610,18 +610,19 @@ func (c *MockStreamIhasDataCall) DoAndReturn(f func() bool) *MockStreamIhasDataC
 }
 
 // popStreamFrame mocks base method.
-func (m *MockStreamI) popStreamFrame(maxBytes protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, bool) {
+func (m *MockStreamI) popStreamFrame(arg0 protocol.ByteCount, arg1 protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "popStreamFrame", maxBytes, v)
+	ret := m.ctrl.Call(m, "popStreamFrame", arg0, arg1)
 	ret0, _ := ret[0].(ackhandler.StreamFrame)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	ret1, _ := ret[1].(*wire.StreamDataBlockedFrame)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
 }
 
 // popStreamFrame indicates an expected call of popStreamFrame.
-func (mr *MockStreamIMockRecorder) popStreamFrame(maxBytes, v any) *MockStreamIpopStreamFrameCall {
+func (mr *MockStreamIMockRecorder) popStreamFrame(arg0, arg1 any) *MockStreamIpopStreamFrameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popStreamFrame", reflect.TypeOf((*MockStreamI)(nil).popStreamFrame), maxBytes, v)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "popStreamFrame", reflect.TypeOf((*MockStreamI)(nil).popStreamFrame), arg0, arg1)
 	return &MockStreamIpopStreamFrameCall{Call: call}
 }
 
@@ -631,19 +632,19 @@ type MockStreamIpopStreamFrameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStreamIpopStreamFrameCall) Return(arg0 ackhandler.StreamFrame, arg1 bool) *MockStreamIpopStreamFrameCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockStreamIpopStreamFrameCall) Return(arg0 ackhandler.StreamFrame, arg1 *wire.StreamDataBlockedFrame, hasMore bool) *MockStreamIpopStreamFrameCall {
+	c.Call = c.Call.Return(arg0, arg1, hasMore)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStreamIpopStreamFrameCall) Do(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, bool)) *MockStreamIpopStreamFrameCall {
+func (c *MockStreamIpopStreamFrameCall) Do(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool)) *MockStreamIpopStreamFrameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStreamIpopStreamFrameCall) DoAndReturn(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, bool)) *MockStreamIpopStreamFrameCall {
+func (c *MockStreamIpopStreamFrameCall) DoAndReturn(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool)) *MockStreamIpopStreamFrameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/stream.go
+++ b/stream.go
@@ -57,7 +57,7 @@ type streamI interface {
 	// for sending
 	hasData() bool
 	handleStopSendingFrame(*wire.StopSendingFrame)
-	popStreamFrame(maxBytes protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, bool)
+	popStreamFrame(protocol.ByteCount, protocol.Version) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasMore bool)
 	updateSendWindow(protocol.ByteCount)
 }
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -69,7 +69,7 @@ func TestStreamCompletion(t *testing.T) {
 		require.NoError(t, str.Close())
 		mockFC.EXPECT().SendWindowSize().Return(protocol.MaxByteCount)
 		mockFC.EXPECT().AddBytesSent(protocol.ByteCount(6))
-		f, _ := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+		f, _, _ := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
 		require.NotNil(t, f.Frame)
 		require.True(t, f.Frame.Fin)
 		f.Handler.OnAcked(f.Frame)


### PR DESCRIPTION
Part of #4771.

With this PR, we make sure that STREAM_DATA_BLOCKED frame end up in the same packet that contains the STREAM frame.

This will simplify debugging: It's not immediately obvious that sending that particular STREAM frame caused the stream to become flow control blocked.

To fully resolve the issue, we need the same change for connection-level flow control. Code-wise, this will look very different though.