### PR TITLE
ci: disable SA1029 staticcheck (context key check) in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,3 +45,7 @@ issues:
         - exhaustive
         - prealloc
         - unparam
+    - path: _test\.go
+      text: "SA1029:"
+      linters:
+        - staticcheck


### PR DESCRIPTION
It's used in #4799.