### PR TITLE
fix accounting for lost RESET_STREAM frames in the send stream

### DIFF
--- a/send_stream.go
+++ b/send_stream.go
@@ -592,6 +592,7 @@ func (s *sendStreamResetStreamHandler) OnAcked(wire.Frame) {
 func (s *sendStreamResetStreamHandler) OnLost(wire.Frame) {
 	s.mutex.Lock()
 	s.queuedResetStreamFrame = true
+	s.numOutstandingFrames--
 	s.mutex.Unlock()
 	s.sender.onHasStreamControlFrame(s.streamID, (*sendStream)(s))
 }

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -744,7 +744,7 @@ func TestSendStreamCancellationResetStreamRetransmission(t *testing.T) {
 	require.False(t, hasMore)
 	require.True(t, mockCtrl.Satisfied())
 
-	// lose the frame
+	// lose the RESET_STREAM frame
 	mockSender.EXPECT().onHasStreamControlFrame(streamID, str)
 	f1.Handler.OnLost(f1.Frame)
 	// get the retransmission
@@ -754,9 +754,8 @@ func TestSendStreamCancellationResetStreamRetransmission(t *testing.T) {
 	require.False(t, hasMore)
 	require.True(t, mockCtrl.Satisfied())
 
-	// acknowledge the frame
-	// TODO(#4803): this should complete the stream, if we correctly accounted for lost RESET_STREAM frames
-	// mockSender.EXPECT().onStreamCompleted(streamID)
+	// acknowledging the RESET_STREAM frame completes the stream
+	mockSender.EXPECT().onStreamCompleted(streamID)
 	f2.Handler.OnAcked(f2.Frame)
 }
 


### PR DESCRIPTION
Fixes #4803.

~~This PR won't be merged before #4799, as I want to have decent tests for this, and I'm not going to write any more Ginkgo tests.~~