### PR TITLE
migrate multiplexer tests away from Ginkgo

### DIFF
--- a/multiplexer.go
+++ b/multiplexer.go
@@ -67,7 +67,7 @@ func (m *connMultiplexer) RemoveConn(c indexableConn) error {
 
 	connIndex := m.index(c.LocalAddr())
 	if _, ok := m.conns[connIndex]; !ok {
-		return fmt.Errorf("cannote remove connection, connection is unknown")
+		return fmt.Errorf("cannote remove connection %s, connection is unknown", connIndex)
 	}
 
 	delete(m.conns, connIndex)

--- a/multiplexer_test.go
+++ b/multiplexer_test.go
@@ -2,25 +2,32 @@ package quic
 
 import (
 	"net"
+	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 )
 
-var _ = Describe("Multiplexer", func() {
-	It("adds new packet conns", func() {
-		conn1 := NewMockPacketConn(mockCtrl)
-		conn1.EXPECT().LocalAddr().Return(&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234})
-		getMultiplexer().AddConn(conn1)
-		conn2 := NewMockPacketConn(mockCtrl)
-		conn2.EXPECT().LocalAddr().Return(&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1235})
-		getMultiplexer().AddConn(conn2)
-	})
+type mockIndexableConn struct{ addr net.Addr }
 
-	It("panics when the same connection is added twice", func() {
-		conn := NewMockPacketConn(mockCtrl)
-		conn.EXPECT().LocalAddr().Return(&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 4321}).Times(2)
-		getMultiplexer().AddConn(conn)
-		Expect(func() { getMultiplexer().AddConn(conn) }).To(Panic())
-	})
-})
+var _ indexableConn = &mockIndexableConn{}
+
+func (m *mockIndexableConn) LocalAddr() net.Addr { return m.addr }
+
+func TestMultiplexerAddNewPacketConns(t *testing.T) {
+	conn1 := &mockIndexableConn{addr: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234}}
+	getMultiplexer().AddConn(conn1)
+	conn2 := &mockIndexableConn{addr: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1235}}
+	getMultiplexer().AddConn(conn2)
+
+	require.NoError(t, getMultiplexer().RemoveConn(conn1))
+	require.NoError(t, getMultiplexer().RemoveConn(conn2))
+}
+
+func TestMultiplexerPanicsOnDuplicateConn(t *testing.T) {
+	conn := &mockIndexableConn{addr: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 4321}}
+	getMultiplexer().AddConn(conn)
+	require.Panics(t, func() { getMultiplexer().AddConn(conn) })
+
+	require.NoError(t, getMultiplexer().RemoveConn(conn))
+	require.ErrorContains(t, getMultiplexer().RemoveConn(conn), "cannote remove connection")
+}


### PR DESCRIPTION
Part of #3652. Also fixes tests to properly clean up the multiplexer.