### PR TITLE
remove hardcoded maximum keep-alive period

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1778,7 +1778,7 @@ func (s *connection) applyTransportParameters() {
 	if params.MaxIdleTimeout > 0 {
 		s.idleTimeout = min(s.idleTimeout, params.MaxIdleTimeout)
 	}
-	s.keepAliveInterval = min(s.config.KeepAlivePeriod, min(s.idleTimeout/2, protocol.MaxKeepAliveInterval))
+	s.keepAliveInterval = min(s.config.KeepAlivePeriod, s.idleTimeout/2)
 	s.streamsMap.UpdateLimits(params)
 	s.frameParser.SetAckDelayExponent(params.AckDelayExponent)
 	s.connFlowController.UpdateSendWindow(params.InitialMaxData)

--- a/connection_test.go
+++ b/connection_test.go
@@ -2162,19 +2162,6 @@ var _ = Describe("Connection", func() {
 			Eventually(sent).Should(BeClosed())
 		})
 
-		It("sends a PING after a maximum of protocol.MaxKeepAliveInterval", func() {
-			conn.config.MaxIdleTimeout = time.Hour
-			setRemoteIdleTimeout(time.Hour)
-			conn.lastPacketReceivedTime = time.Now().Add(-protocol.MaxKeepAliveInterval).Add(-time.Millisecond)
-			sent := make(chan struct{})
-			packer.EXPECT().PackCoalescedPacket(false, gomock.Any(), gomock.Any(), conn.version).Do(func(bool, protocol.ByteCount, time.Time, protocol.Version) (*coalescedPacket, error) {
-				close(sent)
-				return nil, nil
-			})
-			runConn()
-			Eventually(sent).Should(BeClosed())
-		})
-
 		It("doesn't send a PING packet if keep-alive is disabled", func() {
 			setRemoteIdleTimeout(5 * time.Second)
 			conn.config.KeepAlivePeriod = 0

--- a/internal/protocol/params.go
+++ b/internal/protocol/params.go
@@ -102,10 +102,6 @@ const DefaultIdleTimeout = 30 * time.Second
 // DefaultHandshakeIdleTimeout is the default idle timeout used before handshake completion.
 const DefaultHandshakeIdleTimeout = 5 * time.Second
 
-// MaxKeepAliveInterval is the maximum time until we send a packet to keep a connection alive.
-// It should be shorter than the time that NATs clear their mapping.
-const MaxKeepAliveInterval = 20 * time.Second
-
 // RetiredConnectionIDDeleteTimeout is the time we keep closed connections around in order to retransmit the CONNECTION_CLOSE.
 // after this time all information about the old connection will be deleted
 const RetiredConnectionIDDeleteTimeout = 5 * time.Second


### PR DESCRIPTION
The keep-alive period can be set using `Config.KeepAlivePeriod`. While very large values will likely make keep-alives ineffective (depending on the NATs in the path), there's no good reason to hard-code the value.

Found while working on #4823.