### PR TITLE
reliably queue MAX_DATA frames

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2282,6 +2282,8 @@ func (s *connection) queueControlFrame(f wire.Frame) {
 	s.scheduleSending()
 }
 
+func (s *connection) onHasConnectionData() { s.scheduleSending() }
+
 func (s *connection) onHasStreamData(id protocol.StreamID, str sendStreamI) {
 	s.framer.AddActiveStream(id, str)
 	s.scheduleSending()

--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -57,10 +57,12 @@ func (c *connectionFlowController) IncrementHighestReceived(increment protocol.B
 	return nil
 }
 
-func (c *connectionFlowController) AddBytesRead(n protocol.ByteCount) {
+func (c *connectionFlowController) AddBytesRead(n protocol.ByteCount) (hasWindowUpdate bool) {
 	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	c.baseFlowController.addBytesRead(n)
-	c.mutex.Unlock()
+	return c.baseFlowController.hasWindowUpdate()
 }
 
 func (c *connectionFlowController) GetWindowUpdate(now time.Time) protocol.ByteCount {

--- a/internal/flowcontrol/connection_flow_controller_test.go
+++ b/internal/flowcontrol/connection_flow_controller_test.go
@@ -19,8 +19,9 @@ func TestConnectionFlowControlWindowUpdate(t *testing.T) {
 		&utils.RTTStats{},
 		utils.DefaultLogger,
 	)
+	require.False(t, fc.AddBytesRead(1))
 	require.Zero(t, fc.GetWindowUpdate(time.Now()))
-	fc.AddBytesRead(100)
+	require.True(t, fc.AddBytesRead(99))
 	require.Equal(t, protocol.ByteCount(200), fc.GetWindowUpdate(time.Now()))
 }
 

--- a/internal/flowcontrol/interface.go
+++ b/internal/flowcontrol/interface.go
@@ -18,7 +18,7 @@ type flowController interface {
 // A StreamFlowController is a flow controller for a QUIC stream.
 type StreamFlowController interface {
 	flowController
-	AddBytesRead(protocol.ByteCount) (shouldQueueWindowUpdate bool)
+	AddBytesRead(protocol.ByteCount) (hasStreamWindowUpdate, hasConnWindowUpdate bool)
 	// UpdateHighestReceived is called when a new highest offset is received
 	// final has to be to true if this is the final offset of the stream,
 	// as contained in a STREAM frame with FIN bit, and the RESET_STREAM frame
@@ -32,7 +32,7 @@ type StreamFlowController interface {
 // The ConnectionFlowController is the flow controller for the connection.
 type ConnectionFlowController interface {
 	flowController
-	AddBytesRead(protocol.ByteCount)
+	AddBytesRead(protocol.ByteCount) (hasWindowUpdate bool)
 	Reset() error
 	IsNewlyBlocked() (bool, protocol.ByteCount)
 }

--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -98,12 +98,12 @@ func (c *streamFlowController) UpdateHighestReceived(offset protocol.ByteCount, 
 	return c.connection.IncrementHighestReceived(increment, now)
 }
 
-func (c *streamFlowController) AddBytesRead(n protocol.ByteCount) (shouldQueueWindowUpdate bool) {
+func (c *streamFlowController) AddBytesRead(n protocol.ByteCount) (hasStreamWindowUpdate, hasConnWindowUpdate bool) {
 	c.mutex.Lock()
 	c.baseFlowController.addBytesRead(n)
-	shouldQueueWindowUpdate = c.shouldQueueWindowUpdate()
+	hasStreamWindowUpdate = c.shouldQueueWindowUpdate()
 	c.mutex.Unlock()
-	c.connection.AddBytesRead(n)
+	hasConnWindowUpdate = c.connection.AddBytesRead(n)
 	return
 }
 

--- a/internal/mocks/connection_flow_controller.go
+++ b/internal/mocks/connection_flow_controller.go
@@ -42,9 +42,11 @@ func (m *MockConnectionFlowController) EXPECT() *MockConnectionFlowControllerMoc
 }
 
 // AddBytesRead mocks base method.
-func (m *MockConnectionFlowController) AddBytesRead(arg0 protocol.ByteCount) {
+func (m *MockConnectionFlowController) AddBytesRead(arg0 protocol.ByteCount) bool {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddBytesRead", arg0)
+	ret := m.ctrl.Call(m, "AddBytesRead", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
 }
 
 // AddBytesRead indicates an expected call of AddBytesRead.
@@ -60,19 +62,19 @@ type MockConnectionFlowControllerAddBytesReadCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockConnectionFlowControllerAddBytesReadCall) Return() *MockConnectionFlowControllerAddBytesReadCall {
-	c.Call = c.Call.Return()
+func (c *MockConnectionFlowControllerAddBytesReadCall) Return(hasWindowUpdate bool) *MockConnectionFlowControllerAddBytesReadCall {
+	c.Call = c.Call.Return(hasWindowUpdate)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockConnectionFlowControllerAddBytesReadCall) Do(f func(protocol.ByteCount)) *MockConnectionFlowControllerAddBytesReadCall {
+func (c *MockConnectionFlowControllerAddBytesReadCall) Do(f func(protocol.ByteCount) bool) *MockConnectionFlowControllerAddBytesReadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockConnectionFlowControllerAddBytesReadCall) DoAndReturn(f func(protocol.ByteCount)) *MockConnectionFlowControllerAddBytesReadCall {
+func (c *MockConnectionFlowControllerAddBytesReadCall) DoAndReturn(f func(protocol.ByteCount) bool) *MockConnectionFlowControllerAddBytesReadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/mocks/stream_flow_controller.go
+++ b/internal/mocks/stream_flow_controller.go
@@ -78,11 +78,12 @@ func (c *MockStreamFlowControllerAbandonCall) DoAndReturn(f func()) *MockStreamF
 }
 
 // AddBytesRead mocks base method.
-func (m *MockStreamFlowController) AddBytesRead(arg0 protocol.ByteCount) bool {
+func (m *MockStreamFlowController) AddBytesRead(arg0 protocol.ByteCount) (bool, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddBytesRead", arg0)
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
 // AddBytesRead indicates an expected call of AddBytesRead.
@@ -98,19 +99,19 @@ type MockStreamFlowControllerAddBytesReadCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStreamFlowControllerAddBytesReadCall) Return(shouldQueueWindowUpdate bool) *MockStreamFlowControllerAddBytesReadCall {
-	c.Call = c.Call.Return(shouldQueueWindowUpdate)
+func (c *MockStreamFlowControllerAddBytesReadCall) Return(hasStreamWindowUpdate, hasConnWindowUpdate bool) *MockStreamFlowControllerAddBytesReadCall {
+	c.Call = c.Call.Return(hasStreamWindowUpdate, hasConnWindowUpdate)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStreamFlowControllerAddBytesReadCall) Do(f func(protocol.ByteCount) bool) *MockStreamFlowControllerAddBytesReadCall {
+func (c *MockStreamFlowControllerAddBytesReadCall) Do(f func(protocol.ByteCount) (bool, bool)) *MockStreamFlowControllerAddBytesReadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStreamFlowControllerAddBytesReadCall) DoAndReturn(f func(protocol.ByteCount) bool) *MockStreamFlowControllerAddBytesReadCall {
+func (c *MockStreamFlowControllerAddBytesReadCall) DoAndReturn(f func(protocol.ByteCount) (bool, bool)) *MockStreamFlowControllerAddBytesReadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mock_stream_sender_test.go
+++ b/mock_stream_sender_test.go
@@ -40,6 +40,42 @@ func (m *MockStreamSender) EXPECT() *MockStreamSenderMockRecorder {
 	return m.recorder
 }
 
+// onHasConnectionData mocks base method.
+func (m *MockStreamSender) onHasConnectionData() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "onHasConnectionData")
+}
+
+// onHasConnectionData indicates an expected call of onHasConnectionData.
+func (mr *MockStreamSenderMockRecorder) onHasConnectionData() *MockStreamSenderonHasConnectionDataCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "onHasConnectionData", reflect.TypeOf((*MockStreamSender)(nil).onHasConnectionData))
+	return &MockStreamSenderonHasConnectionDataCall{Call: call}
+}
+
+// MockStreamSenderonHasConnectionDataCall wrap *gomock.Call
+type MockStreamSenderonHasConnectionDataCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStreamSenderonHasConnectionDataCall) Return() *MockStreamSenderonHasConnectionDataCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStreamSenderonHasConnectionDataCall) Do(f func()) *MockStreamSenderonHasConnectionDataCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStreamSenderonHasConnectionDataCall) DoAndReturn(f func()) *MockStreamSenderonHasConnectionDataCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // onHasStreamControlFrame mocks base method.
 func (m *MockStreamSender) onHasStreamControlFrame(arg0 protocol.StreamID, arg1 streamControlFrameGetter) {
 	m.ctrl.T.Helper()

--- a/stream.go
+++ b/stream.go
@@ -24,6 +24,7 @@ var errDeadline net.Error = &deadlineError{}
 
 // The streamSender is notified by the stream about various events.
 type streamSender interface {
+	onHasConnectionData()
 	onHasStreamData(protocol.StreamID, sendStreamI)
 	onHasStreamControlFrame(protocol.StreamID, streamControlFrameGetter)
 	// must be called without holding the mutex that is acquired by closeForShutdown


### PR DESCRIPTION
We need to make sure that a MAX_DATA frame actually triggers the packing of a new packet (with which it can then be sent out). Otherwise, reading from a stream might get the MAX_DATA frame queued, but if no packet is sent, it's never sent out to the peer, potentially leading to a deadlock of the connection.