### PR TITLE
fix memory leak on connection ID rotation when closing connection

### DIFF
--- a/conn_id_manager_test.go
+++ b/conn_id_manager_test.go
@@ -242,4 +242,7 @@ func TestConnIDManagerClose(t *testing.T) {
 	require.Empty(t, removedTokens)
 	m.Close()
 	require.Equal(t, []protocol.StatelessResetToken{{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}}, removedTokens)
+
+	require.Panics(t, func() { m.Get() })
+	require.Panics(t, func() { m.SetStatelessResetToken(protocol.StatelessResetToken{}) })
 }

--- a/connection.go
+++ b/connection.go
@@ -1675,7 +1675,7 @@ func (s *connection) handleCloseError(closeErr *closeError) {
 	// when sending the CONNECTION_CLOSE frame.
 	// The connection ID manager removes the active stateless reset token from the packet
 	// handler map when it is closed, so we need to make sure that this happens last.
-	s.connIDManager.Close()
+	defer s.connIDManager.Close()
 
 	if s.tracer != nil && s.tracer.ClosedConnection != nil && !errors.As(e, &recreateErr) {
 		s.tracer.ClosedConnection(e)

--- a/connection.go
+++ b/connection.go
@@ -1667,10 +1667,15 @@ func (s *connection) handleCloseError(closeErr *closeError) {
 	}
 
 	s.streamsMap.CloseWithError(e)
-	s.connIDManager.Close()
 	if s.datagramQueue != nil {
 		s.datagramQueue.CloseWithError(e)
 	}
+
+	// In rare instances, the connection ID manager might switch to a new connection ID
+	// when sending the CONNECTION_CLOSE frame.
+	// The connection ID manager removes the active stateless reset token from the packet
+	// handler map when it is closed, so we need to make sure that this happens last.
+	s.connIDManager.Close()
 
 	if s.tracer != nil && s.tracer.ClosedConnection != nil && !errors.As(e, &recreateErr) {
 		s.tracer.ClosedConnection(e)


### PR DESCRIPTION
In rare instances, the connection ID manager might switch to a new connection ID when sending the packet containing the CONNECTION_CLOSE frame. The connection ID manager removes the active stateless reset token from the packet handler map when it is closed, so we need to make sure that this happens last, otherwise the packet handler will keep a pointer to the closed connection indefinitely.

Thanks to @MarcoPolo for debugging and reporting this issue.

Unfortunately, I don't see a good way to test this for now, since a fresh connection (as we use in tests), comes with a connection ID that doesn't have a stateless reset token. #4850 might make this easier to test at some point.