### PR TITLE
ackhandler: migrate ack-eliciting and send mode tests away from Ginkgo

### DIFF
--- a/internal/ackhandler/ack_eliciting_test.go
+++ b/internal/ackhandler/ack_eliciting_test.go
@@ -1,35 +1,28 @@
 package ackhandler
 
 import (
-	"reflect"
+	"testing"
 
 	"github.com/quic-go/quic-go/internal/wire"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 )
 
-var _ = Describe("ack-eliciting frames", func() {
-	for fl, el := range map[wire.Frame]bool{
+func TestAckElicitingFrames(t *testing.T) {
+	testCases := map[wire.Frame]bool{
 		&wire.AckFrame{}:             false,
 		&wire.ConnectionCloseFrame{}: false,
 		&wire.DataBlockedFrame{}:     true,
 		&wire.PingFrame{}:            true,
 		&wire.ResetStreamFrame{}:     true,
 		&wire.StreamFrame{}:          true,
+		&wire.DatagramFrame{}:        true,
 		&wire.MaxDataFrame{}:         true,
 		&wire.MaxStreamDataFrame{}:   true,
-	} {
-		f := fl
-		e := el
-		fName := reflect.ValueOf(f).Elem().Type().Name()
-
-		It("works for "+fName, func() {
-			Expect(IsFrameAckEliciting(f)).To(Equal(e))
-		})
-
-		It("HasAckElicitingFrames works for "+fName, func() {
-			Expect(HasAckElicitingFrames([]Frame{{Frame: f}})).To(Equal(e))
-		})
+		&wire.StopSendingFrame{}:     true,
 	}
-})
+
+	for f, expected := range testCases {
+		require.Equal(t, expected, IsFrameAckEliciting(f))
+		require.Equal(t, expected, HasAckElicitingFrames([]Frame{{Frame: f}}))
+	}
+}

--- a/internal/ackhandler/send_mode_test.go
+++ b/internal/ackhandler/send_mode_test.go
@@ -1,19 +1,18 @@
 package ackhandler
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-var _ = Describe("Send Mode", func() {
-	It("has a string representation", func() {
-		Expect(SendNone.String()).To(Equal("none"))
-		Expect(SendAny.String()).To(Equal("any"))
-		Expect(SendPacingLimited.String()).To(Equal("pacing limited"))
-		Expect(SendAck.String()).To(Equal("ack"))
-		Expect(SendPTOInitial.String()).To(Equal("pto (Initial)"))
-		Expect(SendPTOHandshake.String()).To(Equal("pto (Handshake)"))
-		Expect(SendPTOAppData.String()).To(Equal("pto (Application Data)"))
-		Expect(SendMode(123).String()).To(Equal("invalid send mode: 123"))
-	})
-})
+func TestSendModeStringer(t *testing.T) {
+	require.Equal(t, "none", SendNone.String())
+	require.Equal(t, "any", SendAny.String())
+	require.Equal(t, "pacing limited", SendPacingLimited.String())
+	require.Equal(t, "ack", SendAck.String())
+	require.Equal(t, "pto (Initial)", SendPTOInitial.String())
+	require.Equal(t, "pto (Handshake)", SendPTOHandshake.String())
+	require.Equal(t, "pto (Application Data)", SendPTOAppData.String())
+	require.Equal(t, "invalid send mode: 123", SendMode(123).String())
+}


### PR DESCRIPTION
Part of #3652.