### PR TITLE
fix: incorrect invocation of TLSHandshakeDone in 0-RTT

### DIFF
--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -572,6 +572,7 @@ var _ = Describe("Client", func() {
 			)
 			str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })
 			str.EXPECT().Close()
+			conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 			str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
 			tr := &Transport{}
 			cc := tr.NewClientConn(conn)
@@ -601,6 +602,7 @@ var _ = Describe("Client", func() {
 			)
 			str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })
 			str.EXPECT().Close()
+			conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 			str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
 			tr := &Transport{}
 			cc := tr.NewClientConn(conn)
@@ -629,6 +631,7 @@ var _ = Describe("Client", func() {
 			)
 			str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })
 			str.EXPECT().Close()
+			conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 			str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
 			tr := &Transport{}
 			cc := tr.NewClientConn(conn)
@@ -668,6 +671,7 @@ var _ = Describe("Client", func() {
 			)
 			str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })
 			str.EXPECT().Close()
+			conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 			str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
 			tr := &Transport{}
 			cc := tr.NewClientConn(conn)
@@ -710,6 +714,7 @@ var _ = Describe("Client", func() {
 			)
 			str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })
 			str.EXPECT().Close()
+			conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 			str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
 			tr := &Transport{}
 			cc := tr.NewClientConn(conn)
@@ -823,6 +828,7 @@ var _ = Describe("Client", func() {
 				closed := make(chan struct{})
 				r := bytes.NewReader(b)
 				str.EXPECT().Close().Do(func() error { close(closed); return nil })
+				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(r.Read).AnyTimes()
 				tr := &Transport{}
 				cc := tr.NewClientConn(conn)
@@ -844,6 +850,7 @@ var _ = Describe("Client", func() {
 				str.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeMessageError))
 				closed := make(chan struct{})
 				str.EXPECT().Close().Do(func() error { close(closed); return nil })
+				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(r.Read).AnyTimes()
 				tr := &Transport{}
 				cc := tr.NewClientConn(conn)
@@ -861,6 +868,7 @@ var _ = Describe("Client", func() {
 				str.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeFrameError))
 				closed := make(chan struct{})
 				str.EXPECT().Close().Do(func() error { close(closed); return nil })
+				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(r.Read).AnyTimes()
 				_, err := cc.RoundTrip(req)
 				Expect(err).To(MatchError("http3: HEADERS frame too large: 1338 bytes (max: 1337)"))
@@ -942,6 +950,7 @@ var _ = Describe("Client", func() {
 
 				done := make(chan struct{})
 				str.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write)
+				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
 				str.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeRequestCanceled))
 				str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeRequestCanceled)).Do(func(quic.StreamErrorCode) { close(done) })
@@ -1013,6 +1022,7 @@ var _ = Describe("Client", func() {
 				gz.Close()
 				rw.Flush()
 				str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })
+				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				str.EXPECT().Close()
 
@@ -1039,6 +1049,7 @@ var _ = Describe("Client", func() {
 				rw.Write([]byte("not gzipped"))
 				rw.Flush()
 				str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })
+				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
 				str.EXPECT().Close()
 
@@ -1079,6 +1090,7 @@ var _ = Describe("Client", func() {
 				)
 				str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })
 				str.EXPECT().Close()
+				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
 				tr := &Transport{}
 				cc := tr.NewClientConn(conn)
@@ -1113,6 +1125,7 @@ var _ = Describe("Client", func() {
 				)
 				str.EXPECT().Write(gomock.Any()).AnyTimes().DoAndReturn(func(p []byte) (int, error) { return len(p), nil })
 				str.EXPECT().Close()
+				conn.EXPECT().ConnectionState().Return(quic.ConnectionState{})
 				str.EXPECT().Read(gomock.Any()).DoAndReturn(rspBuf.Read).AnyTimes()
 				tr := &Transport{}
 				cc := tr.NewClientConn(conn)

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -125,7 +125,8 @@ func (c *connection) openRequestStream(
 		return nil
 	})
 	trace := httptrace.ContextClientTrace(ctx)
-	return newRequestStream(hstr, requestWriter, reqDone, c.decoder, disableCompression, maxHeaderBytes, rsp, trace), nil
+	traceTLSOnce := contextTraceTLSOnce(ctx)
+	return newRequestStream(hstr, requestWriter, reqDone, c.decoder, disableCompression, maxHeaderBytes, rsp, trace, traceTLSOnce), nil
 }
 
 func (c *connection) decodeTrailers(r io.Reader, l, maxHeaderBytes uint64) (http.Header, error) {

--- a/integrationtests/self/http_trace_test.go
+++ b/integrationtests/self/http_trace_test.go
@@ -4,15 +4,62 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptrace"
 	"net/textproto"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
 	"github.com/stretchr/testify/require"
 )
+
+type traceEvent struct {
+	Key  string
+	Args any
+}
+
+func newClientTrace(eventQueue chan traceEvent) *httptrace.ClientTrace {
+	return &httptrace.ClientTrace{
+		GetConn:              func(hostPort string) { eventQueue <- traceEvent{Key: "GetConn", Args: hostPort} },
+		GotConn:              func(info httptrace.GotConnInfo) { eventQueue <- traceEvent{Key: "GotConn", Args: info} },
+		GotFirstResponseByte: func() { eventQueue <- traceEvent{Key: "GotFirstResponseByte"} },
+		Got100Continue:       func() { eventQueue <- traceEvent{Key: "Got100Continue"} },
+		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
+			eventQueue <- traceEvent{Key: "Got1xxResponse", Args: code}
+			return nil
+		},
+		DNSStart: func(di httptrace.DNSStartInfo) { eventQueue <- traceEvent{Key: "DNSStart", Args: di} },
+		DNSDone:  func(di httptrace.DNSDoneInfo) { eventQueue <- traceEvent{Key: "DNSDone", Args: di} },
+		ConnectStart: func(network, addr string) {
+			eventQueue <- traceEvent{Key: "ConnectStart", Args: map[string]string{"network": network, "addr": addr}}
+		},
+		ConnectDone: func(network, addr string, err error) {
+			eventQueue <- traceEvent{Key: "ConnectDone", Args: map[string]any{"network": network, "addr": addr, "err": err}}
+		},
+		TLSHandshakeStart: func() {
+			eventQueue <- traceEvent{Key: "TLSHandshakeStart"}
+		},
+		TLSHandshakeDone: func(state tls.ConnectionState, err error) {
+			eventQueue <- traceEvent{Key: "TLSHandshakeDone", Args: map[string]any{"state": state, "err": err}}
+		},
+		WroteHeaderField: func(key string, value []string) {
+			if key != ":authority" {
+				return
+			}
+			eventQueue <- traceEvent{Key: "WroteHeaderField", Args: value[0]}
+		},
+		WroteHeaders:    func() { eventQueue <- traceEvent{Key: "WroteHeaders"} },
+		Wait100Continue: func() { eventQueue <- traceEvent{Key: "Wait100Continue"} },
+		WroteRequest:    func(i httptrace.WroteRequestInfo) { eventQueue <- traceEvent{Key: "WroteRequest", Args: i} },
+	}
+}
 
 func TestHTTPClientTrace(t *testing.T) {
 	mux := http.NewServeMux()
@@ -23,44 +70,10 @@ func TestHTTPClientTrace(t *testing.T) {
 	port := startHTTPServer(t, mux)
 
 	buf := make([]byte, 1)
-	type event struct {
-		Key  string
-		Args any
-	}
-	eventQueue := make(chan event, 100)
-	wait100Continue := false
-	trace := httptrace.ClientTrace{
-		GetConn:              func(hostPort string) { eventQueue <- event{Key: "GetConn", Args: hostPort} },
-		GotConn:              func(info httptrace.GotConnInfo) { eventQueue <- event{Key: "GotConn", Args: info} },
-		GotFirstResponseByte: func() { eventQueue <- event{Key: "GotFirstResponseByte"} },
-		Got100Continue:       func() { eventQueue <- event{Key: "Got100Continue"} },
-		Got1xxResponse: func(code int, header textproto.MIMEHeader) error {
-			eventQueue <- event{Key: "Got1xxResponse", Args: code}
-			return nil
-		},
-		DNSStart: func(di httptrace.DNSStartInfo) { eventQueue <- event{Key: "DNSStart", Args: di} },
-		DNSDone:  func(di httptrace.DNSDoneInfo) { eventQueue <- event{Key: "DNSDone", Args: di} },
-		ConnectStart: func(network, addr string) {
-			eventQueue <- event{Key: "ConnectStart", Args: map[string]string{"network": network, "addr": addr}}
-		},
-		ConnectDone: func(network, addr string, err error) {
-			eventQueue <- event{Key: "ConnectDone", Args: map[string]any{"network": network, "addr": addr, "err": err}}
-		},
-		TLSHandshakeStart: func() { eventQueue <- event{Key: "TLSHandshakeStart"} },
-		TLSHandshakeDone: func(state tls.ConnectionState, err error) {
-			eventQueue <- event{Key: "TLSHandshakeDone", Args: map[string]any{"state": state, "err": err}}
-		},
-		WroteHeaderField: func(key string, value []string) {
-			if key != ":authority" {
-				return
-			}
-			eventQueue <- event{Key: "WroteHeaderField", Args: value[0]}
-		},
-		WroteHeaders:    func() { eventQueue <- event{Key: "WroteHeaders"} },
-		Wait100Continue: func() { wait100Continue = true },
-		WroteRequest:    func(i httptrace.WroteRequestInfo) { eventQueue <- event{Key: "WroteRequest", Args: i} },
-	}
-	ctx := httptrace.WithClientTrace(context.Background(), &trace)
+
+	eventQueue := make(chan traceEvent, 100)
+	trace := newClientTrace(eventQueue)
+	ctx := httptrace.WithClientTrace(context.Background(), trace)
 
 	cl := newHTTP3Client(t)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/client-trace", port), nil)
@@ -125,6 +138,86 @@ func TestHTTPClientTrace(t *testing.T) {
 			"GetConn", "DNSStart", "DNSDone", "ConnectStart", "TLSHandshakeStart", "TLSHandshakeDone",
 			"ConnectDone", "GotConn", "WroteHeaderField", "WroteHeaders", "WroteRequest",
 			"GotFirstResponseByte", "Got1xxResponse", "Got100Continue",
-		}, events)
-	require.Falsef(t, wait100Continue, "wait 100 continue") // Note: not supported Expect: 100-continue
+		},
+		events,
+	)
+}
+
+func TestHTTPClientTrace0RTT(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/0rtt", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(strconv.FormatBool(!r.TLS.HandshakeComplete)))
+	})
+	port := startHTTPServer(t, mux)
+
+	var num0RTTPackets atomic.Uint32
+	proxy, err := quicproxy.NewQuicProxy("localhost:0", &quicproxy.Opts{
+		RemoteAddr: fmt.Sprintf("localhost:%d", port),
+		DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
+			if contains0RTTPacket(data) {
+				num0RTTPackets.Add(1)
+			}
+			return scaleDuration(25 * time.Millisecond)
+		},
+	})
+	require.NoError(t, err)
+	defer proxy.Close()
+
+	tlsConf := getTLSClientConfigWithoutServerName()
+	puts := make(chan string, 10)
+	tlsConf.ClientSessionCache = newClientSessionCache(tls.NewLRUClientSessionCache(10), nil, puts)
+	tr := &http3.Transport{
+		TLSClientConfig:    tlsConf,
+		QUICConfig:         getQuicConfig(&quic.Config{MaxIdleTimeout: 10 * time.Second}),
+		DisableCompression: true,
+	}
+	defer tr.Close()
+
+	req, err := http.NewRequest(http3.MethodGet0RTT, fmt.Sprintf("https://localhost:%d/0rtt", proxy.LocalPort()), nil)
+	require.NoError(t, err)
+	rsp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+	data, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "false", string(data))
+	require.Zero(t, num0RTTPackets.Load())
+
+	select {
+	case <-puts:
+	case <-time.After(time.Second):
+		t.Fatal("did not receive session ticket")
+	}
+
+	eventQueue := make(chan traceEvent, 100)
+	trace := newClientTrace(eventQueue)
+	ctx := httptrace.WithClientTrace(context.Background(), trace)
+	req = req.WithContext(ctx)
+
+	tr2 := &http3.Transport{
+		TLSClientConfig:    tr.TLSClientConfig,
+		QUICConfig:         tr.QUICConfig,
+		DisableCompression: true,
+	}
+	defer tr2.Close()
+	rsp, err = tr2.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, 200, rsp.StatusCode)
+	data, err = io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "true", string(data))
+	require.NotZero(t, num0RTTPackets.Load())
+	close(eventQueue)
+	events := make([]string, 0, len(eventQueue))
+	for e := range eventQueue {
+		events = append(events, e.Key)
+	}
+	require.Equal(t,
+		[]string{
+			"GetConn", "DNSStart", "DNSDone", "ConnectStart", "TLSHandshakeStart", "ConnectDone",
+			"GotConn", "WroteHeaderField", "WroteHeaders", "WroteRequest", "TLSHandshakeDone",
+			"GotFirstResponseByte",
+		},
+		events,
+	)
 }


### PR DESCRIPTION
In 0-RTT, the TLS handshake process proceeds simultaneously with the request, and therefore is called in the following sequence:
ConnectStart -> TLSHandshakeStart -> ConnectDone -> WroteRequest -> TLSHandshakeDone -> GotFirstResponseByte

fixed #4870 
