### PR TITLE
wait for connection to shut down when the Dial context is cancelled

### DIFF
--- a/client.go
+++ b/client.go
@@ -245,6 +245,11 @@ func (c *client) dial(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		c.conn.destroy(nil)
+		// wait until the Go routine that called Connection.run() returns
+		select {
+		case <-errorChan:
+		case <-recreateChan:
+		}
 		return context.Cause(ctx)
 	case err := <-errorChan:
 		return err


### PR DESCRIPTION
This might be the reason for the occasional race conditions we're seeing in the integration tests.