### PR TITLE
http3: fix errors.Is for the Error

### DIFF
--- a/http3/error.go
+++ b/http3/error.go
@@ -33,6 +33,11 @@ func (e *Error) Error() string {
 	return s
 }
 
+func (e *Error) Is(target error) bool {
+	t, ok := target.(*Error)
+	return ok && e.ErrorCode == t.ErrorCode && e.Remote == t.Remote
+}
+
 func maybeReplaceError(err error) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
This is the HTTP/3 equivalent to https://github.com/quic-go/quic-go/pull/4825.

#4876 contains tests for this. I'm not going to touch Ginkgo tests again to get this PR in.