### PR TITLE
remove unused nolint directives

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - nolintlint
     - prealloc
     - staticcheck
     - stylecheck

--- a/connection.go
+++ b/connection.go
@@ -1834,7 +1834,6 @@ func (s *connection) triggerSending(now time.Time) error {
 	s.pacingDeadline = time.Time{}
 
 	sendMode := s.sentPacketHandler.SendMode(now)
-	//nolint:exhaustive // No need to handle pacing limited here.
 	switch sendMode {
 	case ackhandler.SendAny:
 		return s.sendPackets(now)

--- a/integrationtests/self/handshake_context_test.go
+++ b/integrationtests/self/handshake_context_test.go
@@ -51,7 +51,7 @@ func TestConnContextOnServerSide(t *testing.T) {
 	tr := &quic.Transport{
 		Conn: newUPDConnLocalhost(t),
 		ConnContext: func(ctx context.Context) context.Context {
-			return context.WithValue(ctx, "foo", "bar") //nolint:staticcheck
+			return context.WithValue(ctx, "foo", "bar")
 		},
 	}
 	defer tr.Close()
@@ -182,7 +182,7 @@ func TestContextOnClientSide(t *testing.T) {
 		return &tlsServerConf.Certificates[0], nil
 	}
 
-	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), "foo", "bar")) //nolint:staticcheck
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), "foo", "bar"))
 	conn, err := quic.Dial(
 		ctx,
 		newUPDConnLocalhost(t),

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -597,7 +597,7 @@ func TestHTTPContextFromQUIC(t *testing.T) {
 	tr := &quic.Transport{
 		Conn: conn,
 		ConnContext: func(ctx context.Context) context.Context {
-			return context.WithValue(ctx, "foo", "bar") //nolint:staticcheck
+			return context.WithValue(ctx, "foo", "bar")
 		},
 	}
 	defer tr.Close()
@@ -650,7 +650,7 @@ func TestHTTPConnContext(t *testing.T) {
 		func(s *http3.Server) {
 			s.ConnContext = func(ctx context.Context, c quic.Connection) context.Context {
 				connCtxChan <- ctx
-				ctx = context.WithValue(ctx, "foo", "bar") //nolint:staticcheck
+				ctx = context.WithValue(ctx, "foo", "bar")
 				return ctx
 			}
 		},

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -37,7 +37,6 @@ func IsValidVersion(v Version) bool {
 }
 
 func (vn Version) String() string {
-	//nolint:exhaustive
 	switch vn {
 	case VersionUnknown:
 		return "unknown"

--- a/internal/wire/extended_header.go
+++ b/internal/wire/extended_header.go
@@ -61,7 +61,6 @@ func (h *ExtendedHeader) Append(b []byte, v protocol.Version) ([]byte, error) {
 
 	var packetType uint8
 	if v == protocol.Version2 {
-		//nolint:exhaustive
 		switch h.Type {
 		case protocol.PacketTypeInitial:
 			packetType = 0b01
@@ -73,7 +72,6 @@ func (h *ExtendedHeader) Append(b []byte, v protocol.Version) ([]byte, error) {
 			packetType = 0b00
 		}
 	} else {
-		//nolint:exhaustive
 		switch h.Type {
 		case protocol.PacketTypeInitial:
 			packetType = 0b00

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -255,7 +255,6 @@ func (e eventPacketBuffered) Name() string       { return "packet_buffered" }
 func (e eventPacketBuffered) IsNil() bool        { return false }
 
 func (e eventPacketBuffered) MarshalJSONObject(enc *gojay.Encoder) {
-	//nolint:gosimple
 	enc.ObjectKey("header", packetHeaderWithType{PacketType: e.PacketType, PacketNumber: protocol.InvalidPacketNumber})
 	enc.ObjectKey("raw", rawInfo{Length: e.PacketSize})
 	enc.StringKey("trigger", "keys_unavailable")


### PR DESCRIPTION
The PR removes unused `//nolint` comments that have no effect. It were found with the help of [`nolintlint`](https://golangci-lint.run/usage/linters/#nolintlint) linter.