### PR TITLE
use RandomNonce in the init to allow fipsonly

### DIFF
--- a/internal/handshake/retry.go
+++ b/internal/handshake/retry.go
@@ -25,7 +25,7 @@ func initAEAD(key [16]byte) cipher.AEAD {
 	if err != nil {
 		panic(err)
 	}
-	aead, err := cipher.NewGCM(aes)
+	aead, err := cipher.NewGCMWithRandomNonce(aes)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
In the next Go release, FIPS improvements will be included. One of these is the FIPS-only mode, which triggers a panic if non-FIPS-compliant code is used.

When using quic-go, during the initialization of the handshake/retry process, there is a non-FIPS-compliant operation that causes a panic in FIPS-only mode.

I’m aware there are other issues related to FIPS-only mode in the code. However, the goal of this PR is to provide users with the ability to disable quic-go in FIPS mode. Without this PR, since the issue occurs during initialization, it’s not possible to disable it.