### PR TITLE
Fix tools.go

### DIFF
--- a/integrationtests/gomodvendor/go.mod
+++ b/integrationtests/gomodvendor/go.mod
@@ -8,6 +8,7 @@ toolchain go1.22.4
 require github.com/quic-go/quic-go v0.21.0
 
 require (
+	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
 	github.com/onsi/ginkgo/v2 v2.9.5 // indirect
@@ -17,7 +18,6 @@ require (
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect

--- a/tools.go
+++ b/tools.go
@@ -3,6 +3,6 @@
 package quic
 
 import (
-	_ "github.com/onsi/ginkgo/v2/ginkgo"
-	_ "go.uber.org/mock/mockgen"
+	_ "github.com/onsi/ginkgo/v2"
+	_ "go.uber.org/mock/mockgen/model"
 )


### PR DESCRIPTION
Hey folks, getting some annoying errors in my editor from this package:

![CleanShot 2025-01-20 at 22 22 40@2x](https://github.com/user-attachments/assets/1edbfd53-5b77-4024-92c5-5e473a166dcb)

Here's the full error:

> error while importing github.com/quic-go/quic-go: import "github.com/onsi/ginkgo/v2/ginkgo" is a program, not an importable package

This PR fixes this issue by importing paths that have .go files and aren't a main package.

This should be a no-op since it'll still download the tools via `go mod tidy`.