### PR TITLE
clean up MTU probe packet sending logic

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1908,8 +1908,8 @@ func (s *connection) sendPackets(now time.Time) error {
 		s.logShortHeaderPacket(p.DestConnID, p.Ack, p.Frames, p.StreamFrames, p.PacketNumber, p.PacketNumberLen, p.KeyPhase, ecn, buf.Len(), false)
 		s.registerPackedShortHeaderPacket(p, ecn, now)
 		s.sendQueue.Send(buf, 0, ecn)
-		// This is kind of a hack. We need to trigger sending again somehow.
-		s.pacingDeadline = deadlineSendImmediately
+		// There's (likely) more data to send. Loop around again.
+		s.scheduleSending()
 		return nil
 	}
 


### PR DESCRIPTION
As the comment said, using the pacing deadline was a hack. Instead, we can just schedule sending, and loop around the run loop one more time.