### PR TITLE
simplify handling of packet unpacking errors

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -537,7 +537,9 @@ func TestConnectionServerInvalidPackets(t *testing.T) {
 			Token:            []byte("foobar"),
 		}}, make([]byte, 16) /* Retry integrity tag */)
 		tracer.EXPECT().DroppedPacket(logging.PacketTypeRetry, protocol.InvalidPacketNumber, p.Size(), logging.PacketDropUnexpectedPacket)
-		require.False(t, tc.conn.handlePacketImpl(p))
+		wasProcessed, err := tc.conn.handlePacketImpl(p)
+		require.NoError(t, err)
+		require.False(t, wasProcessed)
 	})
 
 	t.Run("version negotiation", func(t *testing.T) {
@@ -551,7 +553,9 @@ func TestConnectionServerInvalidPackets(t *testing.T) {
 			[]Version{Version1},
 		)
 		tracer.EXPECT().DroppedPacket(logging.PacketTypeVersionNegotiation, protocol.InvalidPacketNumber, protocol.ByteCount(len(b)), logging.PacketDropUnexpectedPacket)
-		require.False(t, tc.conn.handlePacketImpl(receivedPacket{data: b, buffer: getPacketBuffer()}))
+		wasProcessed, err := tc.conn.handlePacketImpl(receivedPacket{data: b, buffer: getPacketBuffer()})
+		require.NoError(t, err)
+		require.False(t, wasProcessed)
 	})
 
 	t.Run("unsupported version", func(t *testing.T) {
@@ -564,7 +568,9 @@ func TestConnectionServerInvalidPackets(t *testing.T) {
 			PacketNumberLen: protocol.PacketNumberLen2,
 		}, nil)
 		tracer.EXPECT().DroppedPacket(logging.PacketTypeNotDetermined, protocol.InvalidPacketNumber, p.Size(), logging.PacketDropUnsupportedVersion)
-		require.False(t, tc.conn.handlePacketImpl(p))
+		wasProcessed, err := tc.conn.handlePacketImpl(p)
+		require.NoError(t, err)
+		require.False(t, wasProcessed)
 	})
 
 	t.Run("invalid header", func(t *testing.T) {
@@ -578,7 +584,9 @@ func TestConnectionServerInvalidPackets(t *testing.T) {
 		}, nil)
 		p.data[0] ^= 0x40 // unset the QUIC bit
 		tracer.EXPECT().DroppedPacket(logging.PacketTypeNotDetermined, protocol.InvalidPacketNumber, p.Size(), logging.PacketDropHeaderParseError)
-		require.False(t, tc.conn.handlePacketImpl(p))
+		wasProcessed, err := tc.conn.handlePacketImpl(p)
+		require.NoError(t, err)
+		require.False(t, wasProcessed)
 	})
 }
 
@@ -592,7 +600,9 @@ func TestConnectionClientDrop0RTT(t *testing.T) {
 		PacketNumberLen: protocol.PacketNumberLen2,
 	}, nil)
 	tracer.EXPECT().DroppedPacket(logging.PacketType0RTT, protocol.InvalidPacketNumber, p.Size(), logging.PacketDropUnexpectedPacket)
-	require.False(t, tc.conn.handlePacketImpl(p))
+	wasProcessed, err := tc.conn.handlePacketImpl(p)
+	require.NoError(t, err)
+	require.False(t, wasProcessed)
 }
 
 func TestConnectionUnpacking(t *testing.T) {
@@ -639,7 +649,9 @@ func TestConnectionUnpacking(t *testing.T) {
 	tracer.EXPECT().NegotiatedVersion(gomock.Any(), gomock.Any(), gomock.Any())
 	tracer.EXPECT().StartedConnection(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 	tracer.EXPECT().ReceivedLongHeaderPacket(gomock.Any(), gomock.Any(), logging.ECNCE, []logging.Frame{})
-	require.True(t, tc.conn.handlePacketImpl(packet))
+	wasProcessed, err := tc.conn.handlePacketImpl(packet)
+	require.NoError(t, err)
+	require.True(t, wasProcessed)
 	require.True(t, mockCtrl.Satisfied())
 
 	// receive a duplicate of this packet
@@ -651,7 +663,9 @@ func TestConnectionUnpacking(t *testing.T) {
 		data:            []byte{0}, // one PADDING frame
 	}, nil)
 	tracer.EXPECT().DroppedPacket(logging.PacketTypeInitial, protocol.PacketNumber(0x1337), protocol.ByteCount(len(packet.data)), logging.PacketDropDuplicate)
-	require.False(t, tc.conn.handlePacketImpl(packet))
+	wasProcessed, err = tc.conn.handlePacketImpl(packet)
+	require.NoError(t, err)
+	require.False(t, wasProcessed)
 	require.True(t, mockCtrl.Satisfied())
 
 	// receive a short header packet
@@ -666,7 +680,9 @@ func TestConnectionUnpacking(t *testing.T) {
 		protocol.PacketNumber(0x1337), protocol.PacketNumberLen2, protocol.KeyPhaseZero, []byte{0} /* PADDING */, nil,
 	)
 	tracer.EXPECT().ReceivedShortHeaderPacket(gomock.Any(), gomock.Any(), logging.ECT1, []logging.Frame{})
-	require.True(t, tc.conn.handlePacketImpl(packet))
+	wasProcessed, err = tc.conn.handlePacketImpl(packet)
+	require.NoError(t, err)
+	require.True(t, wasProcessed)
 }
 
 func TestConnectionUnpackCoalescedPacket(t *testing.T) {
@@ -753,7 +769,9 @@ func TestConnectionUnpackCoalescedPacket(t *testing.T) {
 		tracer.EXPECT().ReceivedLongHeaderPacket(gomock.Any(), gomock.Any(), logging.ECT1, []logging.Frame{&wire.PingFrame{}}),
 		tracer.EXPECT().DroppedPacket(logging.PacketTypeNotDetermined, protocol.InvalidPacketNumber, protocol.ByteCount(len(packet3.data)), logging.PacketDropUnknownConnectionID),
 	)
-	require.True(t, tc.conn.handlePacketImpl(packet))
+	wasProcessed, err := tc.conn.handlePacketImpl(packet)
+	require.NoError(t, err)
+	require.True(t, wasProcessed)
 }
 
 func TestConnectionUnpackFailuresFatal(t *testing.T) {
@@ -2472,13 +2490,17 @@ func TestConnectionVersionNegotiationInvalidPackets(t *testing.T) {
 		tc.srcConnID,
 		[]protocol.Version{1234, protocol.Version1},
 	)
-	require.False(t, tc.conn.handlePacketImpl(vnp))
+	wasProcessed, err := tc.conn.handlePacketImpl(vnp)
+	require.NoError(t, err)
+	require.False(t, wasProcessed)
 	require.True(t, mockCtrl.Satisfied())
 
 	// unparseable, since it's missing 2 bytes
 	tracer.EXPECT().DroppedPacket(logging.PacketTypeVersionNegotiation, gomock.Any(), gomock.Any(), logging.PacketDropHeaderParseError)
 	vnp.data = vnp.data[:len(vnp.data)-2]
-	require.False(t, tc.conn.handlePacketImpl(vnp))
+	wasProcessed, err = tc.conn.handlePacketImpl(vnp)
+	require.NoError(t, err)
+	require.False(t, wasProcessed)
 }
 
 func getRetryPacket(t *testing.T, src, dest, origDest protocol.ConnectionID, token []byte) receivedPacket {
@@ -2518,13 +2540,17 @@ func TestConnectionRetryDrops(t *testing.T) {
 	tracer.EXPECT().DroppedPacket(logging.PacketTypeRetry, gomock.Any(), gomock.Any(), logging.PacketDropPayloadDecryptError)
 	retry := getRetryPacket(t, newConnID, tc.srcConnID, tc.destConnID, []byte("foobar"))
 	retry.data[len(retry.data)-1]++
-	require.False(t, tc.conn.handlePacketImpl(retry))
+	wasProcessed, err := tc.conn.handlePacketImpl(retry)
+	require.NoError(t, err)
+	require.False(t, wasProcessed)
 	require.True(t, mockCtrl.Satisfied())
 
 	// receive a retry that doesn't change the connection ID
 	tracer.EXPECT().DroppedPacket(logging.PacketTypeRetry, gomock.Any(), gomock.Any(), logging.PacketDropUnexpectedPacket)
 	retry = getRetryPacket(t, tc.destConnID, tc.srcConnID, tc.destConnID, []byte("foobar"))
-	require.False(t, tc.conn.handlePacketImpl(retry))
+	wasProcessed, err = tc.conn.handlePacketImpl(retry)
+	require.NoError(t, err)
+	require.False(t, wasProcessed)
 }
 
 func TestConnectionRetryAfterReceivedPacket(t *testing.T) {
@@ -2549,16 +2575,20 @@ func TestConnectionRetryAfterReceivedPacket(t *testing.T) {
 			encryptionLevel: protocol.EncryptionInitial,
 		}, nil,
 	)
-	require.True(t, tc.conn.handlePacketImpl(receivedPacket{
+	wasProcessed, err := tc.conn.handlePacketImpl(receivedPacket{
 		data:    regular,
 		buffer:  getPacketBuffer(),
 		rcvTime: time.Now(),
-	}))
+	})
+	require.NoError(t, err)
+	require.True(t, wasProcessed)
 
 	// receive a retry
 	retry := getRetryPacket(t, tc.destConnID, tc.srcConnID, tc.destConnID, []byte("foobar"))
 	tracer.EXPECT().DroppedPacket(logging.PacketTypeRetry, gomock.Any(), gomock.Any(), logging.PacketDropUnexpectedPacket)
-	require.False(t, tc.conn.handlePacketImpl(retry))
+	wasProcessed, err = tc.conn.handlePacketImpl(retry)
+	require.NoError(t, err)
+	require.False(t, wasProcessed)
 }
 
 func TestConnectionConnectionIDChanges(t *testing.T) {


### PR DESCRIPTION
We should only use `closeLocal` in functions that are not called from the run loop. For functions called from the run loop, we should just use error return values.