### PR TITLE
refactor connection timer logic

### DIFF
--- a/connection_timer_test.go
+++ b/connection_timer_test.go
@@ -47,14 +47,3 @@ func TestConnectionTimerReset(t *testing.T) {
 	timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), time.Time{}, time.Time{})
 	require.Equal(t, now.Add(time.Hour), timer.Deadline())
 }
-
-func TestConnectionTimerSendImmediately(t *testing.T) {
-	now := time.Now()
-	timer := newTimer()
-	timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), time.Time{}, time.Time{})
-	require.Equal(t, now.Add(time.Minute), timer.Deadline())
-	timer.SetRead()
-
-	timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), time.Time{}, deadlineSendImmediately)
-	require.Equal(t, deadlineSendImmediately, timer.Deadline())
-}


### PR DESCRIPTION
~~Depends on #4928.~~

Under certain circumstances, we would've set the connection to `deadlineSendImmediately`. While this technically is not wrong (since `deadlineSendImmediately` is in the past, and the timer would fire immediately), it is wasteful: we don't need to set a timer if we know that it will immediately fire.

Instead, we should just continue the run looping without even entering the `select` statement that would read from the timer channel.