### PR TITLE
query MTU discoverer for increases after processing ACK frame

### DIFF
--- a/mtu_discoverer.go
+++ b/mtu_discoverer.go
@@ -88,7 +88,6 @@ const (
 
 type mtuFinder struct {
 	lastProbeTime time.Time
-	mtuIncreased  func(protocol.ByteCount)
 
 	rttStats *utils.RTTStats
 
@@ -107,15 +106,13 @@ var _ mtuDiscoverer = &mtuFinder{}
 func newMTUDiscoverer(
 	rttStats *utils.RTTStats,
 	start, max protocol.ByteCount,
-	mtuIncreased func(protocol.ByteCount),
 	tracer *logging.ConnectionTracer,
 ) *mtuFinder {
 	f := &mtuFinder{
-		inFlight:     protocol.InvalidByteCount,
-		min:          start,
-		rttStats:     rttStats,
-		mtuIncreased: mtuIncreased,
-		tracer:       tracer,
+		inFlight: protocol.InvalidByteCount,
+		min:      start,
+		rttStats: rttStats,
+		tracer:   tracer,
 	}
 	for i := range f.lost {
 		if i == 0 {
@@ -207,7 +204,6 @@ func (h *mtuFinderAckHandler) OnAcked(wire.Frame) {
 	if h.tracer != nil && h.tracer.UpdatedMTU != nil {
 		h.tracer.UpdatedMTU(size, h.done())
 	}
-	h.mtuIncreased(size)
 }
 
 func (h *mtuFinderAckHandler) OnLost(wire.Frame) {


### PR DESCRIPTION
Instead of passing a callback around, we can just explicitly ask the MTU discoverer for increases in the MTU estimate. We know that these will only happen when MTU probe packets are acknowledged.

No functional change expected.

This will make it easier to replace the MTU discoverer when migration the connection (#234).