### PR TITLE
Increase ctx timeout in TestDatagramLoss

### DIFF
--- a/integrationtests/self/datagram_test.go
+++ b/integrationtests/self/datagram_test.go
@@ -164,7 +164,7 @@ func TestDatagramLoss(t *testing.T) {
 	require.NoError(t, proxy.Start())
 	defer proxy.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), scaleDuration(numDatagrams*time.Millisecond))
+	ctx, cancel := context.WithTimeout(context.Background(), scaleDuration(2 * numDatagrams * time.Millisecond))
 	defer cancel()
 	clientConn, err := quic.Dial(
 		ctx,


### PR DESCRIPTION
This PR attempts to fix the flaky testcase [mentioned in this issue](https://github.com/quic-go/quic-go/issues/4784). 

Captured packets showed that outgoing packets did reach the client side. So I think simply increasing context timeout should help the client drain and receive these packets.