### PR TITLE
ci: update golangci-lint to v1.64.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         go: [  "1.22.x", "1.23.x" ]
     env:
-      GOLANGCI_LINT_VERSION: v1.62.0
+      GOLANGCI_LINT_VERSION: v1.64.4
     name: golangci-lint (Go ${{ matrix.go }})
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This version adds support for Go 1.24.