### PR TITLE
add support for connection migration

### DIFF
--- a/conn_id_generator_test.go
+++ b/conn_id_generator_test.go
@@ -32,6 +32,7 @@ func testConnIDGeneratorIssueAndRetire(t *testing.T, hasInitialClientDestConnID 
 		initialClientDestConnID = &connID
 	}
 	g := newConnIDGenerator(
+		1,
 		protocol.ParseConnectionID([]byte{1, 1, 1, 1}),
 		initialClientDestConnID,
 		sr,
@@ -116,6 +117,7 @@ func testConnIDGeneratorRemoveAll(t *testing.T, hasInitialClientDestConnID bool)
 		removed []protocol.ConnectionID
 	)
 	g := newConnIDGenerator(
+		0,
 		protocol.ParseConnectionID([]byte{1, 1, 1, 1}),
 		initialClientDestConnID,
 		newStatelessResetter(&StatelessResetKey{1, 2, 3, 4}),
@@ -166,6 +168,7 @@ func testConnIDGeneratorReplaceWithClosed(t *testing.T, hasInitialClientDestConn
 		replacedWith []byte
 	)
 	g := newConnIDGenerator(
+		1,
 		protocol.ParseConnectionID([]byte{1, 1, 1, 1}),
 		initialClientDestConnID,
 		newStatelessResetter(&StatelessResetKey{1, 2, 3, 4}),
@@ -229,6 +232,7 @@ func TestConnIDGeneratorAddConnRunner(t *testing.T) {
 	var queuedFrames []wire.Frame
 
 	g := newConnIDGenerator(
+		1,
 		initialConnID,
 		&clientDestConnID,
 		sr,
@@ -240,7 +244,7 @@ func TestConnIDGeneratorAddConnRunner(t *testing.T) {
 	require.Len(t, tracker1.added, 2)
 
 	// add the second runner - it should get all existing connection IDs
-	g.AddConnRunner(runner2)
+	g.AddConnRunner(2, runner2)
 	require.Len(t, tracker1.added, 2) // unchanged
 	require.Len(t, tracker2.added, 4)
 	require.Contains(t, tracker2.added, initialConnID)

--- a/integrationtests/self/connection_migration_test.go
+++ b/integrationtests/self/connection_migration_test.go
@@ -1,0 +1,144 @@
+package self_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionMigration(t *testing.T) {
+	ln, err := quic.ListenAddr("localhost:0", tlsConfig, getQuicConfig(nil))
+	require.NoError(t, err)
+	defer ln.Close()
+
+	tr1 := &quic.Transport{Conn: newUDPConnLocalhost(t)}
+	defer tr1.Close()
+	tr2 := &quic.Transport{Conn: newUDPConnLocalhost(t)}
+	defer tr2.Close()
+
+	var packetsPath1, packetsPath2 atomic.Int64
+
+	const rtt = 5 * time.Millisecond
+	proxy := quicproxy.Proxy{
+		Conn:       newUDPConnLocalhost(t),
+		ServerAddr: ln.Addr().(*net.UDPAddr),
+		DelayPacket: func(dir quicproxy.Direction, from, to net.Addr, _ []byte) time.Duration {
+			var port int
+			switch dir {
+			case quicproxy.DirectionIncoming:
+				port = from.(*net.UDPAddr).Port
+			case quicproxy.DirectionOutgoing:
+				port = to.(*net.UDPAddr).Port
+			}
+			switch port {
+			case tr1.Conn.LocalAddr().(*net.UDPAddr).Port:
+				packetsPath1.Add(1)
+			case tr2.Conn.LocalAddr().(*net.UDPAddr).Port:
+				packetsPath2.Add(1)
+			default:
+				fmt.Println("address not found", from)
+			}
+			return rtt / 2
+		},
+	}
+	require.NoError(t, proxy.Start())
+	defer proxy.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := tr1.Dial(ctx, proxy.LocalAddr(), getTLSClientConfig(), getQuicConfig(nil))
+	require.NoError(t, err)
+	defer conn.CloseWithError(0, "")
+
+	sconn, err := ln.Accept(ctx)
+	require.NoError(t, err)
+	defer sconn.CloseWithError(0, "")
+
+	sendAndReceiveFile := func(t *testing.T) {
+		t.Helper()
+		str, err := conn.OpenUniStream()
+		require.NoError(t, err)
+
+		errChan := make(chan error, 1)
+		go func() {
+			defer close(errChan)
+			sstr, err := sconn.AcceptUniStream(ctx)
+			if err != nil {
+				errChan <- fmt.Errorf("accepting stream: %w", err)
+				return
+			}
+			data, err := io.ReadAll(sstr)
+			if err != nil {
+				errChan <- fmt.Errorf("reading stream data: %w", err)
+				return
+			}
+			if !bytes.Equal(data, PRData) {
+				errChan <- errors.New("unexpected data")
+			}
+		}()
+
+		_, err = str.Write(PRData)
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+
+		select {
+		case err := <-errChan:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for data")
+		}
+	}
+
+	sendAndReceiveFile(t) // stream 2
+	require.NotZero(t, packetsPath1.Load())
+	require.Zero(t, packetsPath2.Load())
+
+	// probing the path causes a few packets to be sent on path 2
+	path, err := conn.AddPath(tr2)
+	require.NoError(t, err)
+	require.ErrorIs(t, path.Switch(), quic.ErrPathNotValidated)
+	require.NoError(t, path.Probe(ctx))
+	require.Less(t, int(packetsPath2.Load()), 5)
+
+	// make sure that no more packets are sent on path 2 before switching to the path
+	c2 := packetsPath2.Load()
+	sendAndReceiveFile(t) // stream 6
+	require.Equal(t, packetsPath2.Load(), c2)
+
+	time.Sleep(3 * rtt) // wait for ACKs
+
+	// now switch and make sure that no packets are sent on path 1
+	require.NoError(t, path.Switch())
+	sendAndReceiveFile(t) // stream 10
+	c1 := packetsPath1.Load()
+	require.Equal(t, c1, packetsPath1.Load())
+	require.Greater(t, packetsPath2.Load(), c2)
+	require.Equal(t, tr2.Conn.LocalAddr(), conn.LocalAddr())
+
+	// switch back to the handshake path
+	time.Sleep(3 * rtt) // wait for ACKs
+	c1BeforeSwitch := packetsPath1.Load()
+	c2BeforeSwitch := packetsPath2.Load()
+	path2, err := conn.AddPath(tr1)
+	require.NoError(t, err)
+	require.NoError(t, path2.Probe(ctx))
+	time.Sleep(3 * rtt) // wait for ACKs
+	require.NoError(t, path2.Switch())
+	sendAndReceiveFile(t) // stream 14
+	require.Greater(t, packetsPath1.Load(), c1BeforeSwitch)
+	// some path probing might have happened
+	require.Less(t, int(packetsPath2.Load()-c2BeforeSwitch), 20)
+	require.Equal(t, tr1.Conn.LocalAddr(), conn.LocalAddr())
+}

--- a/interface.go
+++ b/interface.go
@@ -205,6 +205,8 @@ type Connection interface {
 	SendDatagram(payload []byte) error
 	// ReceiveDatagram gets a message received in a datagram, as specified in RFC 9221.
 	ReceiveDatagram(context.Context) ([]byte, error)
+
+	AddPath(*Transport) (*Path, error)
 }
 
 // An EarlyConnection is a connection that is handshaking.

--- a/internal/mocks/quic/early_conn.go
+++ b/internal/mocks/quic/early_conn.go
@@ -120,6 +120,45 @@ func (c *MockEarlyConnectionAcceptUniStreamCall) DoAndReturn(f func(context.Cont
 	return c
 }
 
+// AddPath mocks base method.
+func (m *MockEarlyConnection) AddPath(arg0 *quic.Transport) (*quic.Path, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddPath", arg0)
+	ret0, _ := ret[0].(*quic.Path)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddPath indicates an expected call of AddPath.
+func (mr *MockEarlyConnectionMockRecorder) AddPath(arg0 any) *MockEarlyConnectionAddPathCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPath", reflect.TypeOf((*MockEarlyConnection)(nil).AddPath), arg0)
+	return &MockEarlyConnectionAddPathCall{Call: call}
+}
+
+// MockEarlyConnectionAddPathCall wrap *gomock.Call
+type MockEarlyConnectionAddPathCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockEarlyConnectionAddPathCall) Return(arg0 *quic.Path, arg1 error) *MockEarlyConnectionAddPathCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockEarlyConnectionAddPathCall) Do(f func(*quic.Transport) (*quic.Path, error)) *MockEarlyConnectionAddPathCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockEarlyConnectionAddPathCall) DoAndReturn(f func(*quic.Transport) (*quic.Path, error)) *MockEarlyConnectionAddPathCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CloseWithError mocks base method.
 func (m *MockEarlyConnection) CloseWithError(arg0 quic.ApplicationErrorCode, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/mock_quic_conn_test.go
+++ b/mock_quic_conn_test.go
@@ -119,6 +119,45 @@ func (c *MockQUICConnAcceptUniStreamCall) DoAndReturn(f func(context.Context) (R
 	return c
 }
 
+// AddPath mocks base method.
+func (m *MockQUICConn) AddPath(arg0 *Transport) (*Path, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddPath", arg0)
+	ret0, _ := ret[0].(*Path)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddPath indicates an expected call of AddPath.
+func (mr *MockQUICConnMockRecorder) AddPath(arg0 any) *MockQUICConnAddPathCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPath", reflect.TypeOf((*MockQUICConn)(nil).AddPath), arg0)
+	return &MockQUICConnAddPathCall{Call: call}
+}
+
+// MockQUICConnAddPathCall wrap *gomock.Call
+type MockQUICConnAddPathCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockQUICConnAddPathCall) Return(arg0 *Path, arg1 error) *MockQUICConnAddPathCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockQUICConnAddPathCall) Do(f func(*Transport) (*Path, error)) *MockQUICConnAddPathCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockQUICConnAddPathCall) DoAndReturn(f func(*Transport) (*Path, error)) *MockQUICConnAddPathCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CloseWithError mocks base method.
 func (m *MockQUICConn) CloseWithError(arg0 ApplicationErrorCode, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/path_manager_outgoing.go
+++ b/path_manager_outgoing.go
@@ -1,0 +1,205 @@
+package quic
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/wire"
+)
+
+// ErrPathNotValidated is returned when trying to use a path before path probing has completed.
+var ErrPathNotValidated = errors.New("path not yet validated")
+
+var errPathDoesNotExist = errors.New("path does not exist")
+
+// Path is a network path.
+type Path struct {
+	id          pathID
+	pathManager *pathManagerOutgoing
+	tr          *Transport
+
+	enablePath     func()
+	startedProbing atomic.Bool
+}
+
+func (p *Path) Probe(ctx context.Context) error {
+	done := make(chan struct{})
+	p.pathManager.addPath(p, p.enablePath, done)
+
+	p.startedProbing.Store(true)
+	select {
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	case <-done:
+		return nil
+	}
+}
+
+// Switch switches the QUIC connection to this path.
+// It immediately stops sending on the old path, and sends on this new path.
+func (p *Path) Switch() error {
+	if err := p.pathManager.switchToPath(p.id); err != nil {
+		if errors.Is(err, errPathDoesNotExist) && !p.startedProbing.Load() {
+			return ErrPathNotValidated
+		}
+		return err
+	}
+	return nil
+}
+
+type pathOutgoing struct {
+	pathChallenge [8]byte
+	tr            *Transport
+	isValidated   bool
+	validated     chan<- struct{} // closed when the path the corresponding PATH_RESPONSE is received
+	enablePath    func()
+}
+
+type pathManagerOutgoing struct {
+	getConnID       func(pathID) (_ protocol.ConnectionID, ok bool)
+	retireConnID    func(pathID)
+	scheduleSending func()
+
+	mx             sync.Mutex
+	pathsToProbe   []pathID
+	paths          map[pathID]*pathOutgoing
+	nextPathID     pathID
+	pathToSwitchTo *pathOutgoing
+}
+
+func newPathManagerOutgoing(
+	getConnID func(pathID) (_ protocol.ConnectionID, ok bool),
+	retireConnID func(pathID),
+	scheduleSending func(),
+) *pathManagerOutgoing {
+	return &pathManagerOutgoing{
+		getConnID:       getConnID,
+		retireConnID:    retireConnID,
+		scheduleSending: scheduleSending,
+		paths:           make(map[pathID]*pathOutgoing, 4),
+	}
+}
+
+func (pm *pathManagerOutgoing) addPath(p *Path, enablePath func(), done chan<- struct{}) {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	pm.mx.Lock()
+	pm.paths[p.id] = &pathOutgoing{
+		pathChallenge: b,
+		tr:            p.tr,
+		validated:     done,
+		enablePath:    enablePath,
+	}
+	pm.pathsToProbe = append(pm.pathsToProbe, p.id)
+	pm.mx.Unlock()
+	pm.scheduleSending()
+}
+
+func (pm *pathManagerOutgoing) switchToPath(id pathID) error {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	p, ok := pm.paths[id]
+	if !ok {
+		return errPathDoesNotExist
+	}
+	if !p.isValidated {
+		return ErrPathNotValidated
+	}
+	pm.pathToSwitchTo = p
+	return nil
+}
+
+func (pm *pathManagerOutgoing) NewPath(t *Transport, enablePath func()) *Path {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	id := pm.nextPathID
+	pm.nextPathID++
+	return &Path{
+		pathManager: pm,
+		id:          id,
+		tr:          t,
+		enablePath:  enablePath,
+	}
+}
+
+func (pm *pathManagerOutgoing) NextPathToProbe() (_ protocol.ConnectionID, _ ackhandler.Frame, _ *Transport, hasPath bool) {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	var p *pathOutgoing
+	var id pathID
+	for {
+		if len(pm.pathsToProbe) == 0 {
+			return protocol.ConnectionID{}, ackhandler.Frame{}, nil, false
+		}
+
+		id = pm.pathsToProbe[0]
+		pm.pathsToProbe = pm.pathsToProbe[1:]
+
+		var ok bool
+		// if the path doesn't exist in the map, it might have been abandoned
+		p, ok = pm.paths[id]
+		if ok {
+			break
+		}
+	}
+
+	connID, ok := pm.getConnID(id)
+	if !ok {
+		return protocol.ConnectionID{}, ackhandler.Frame{}, nil, false
+	}
+
+	p.enablePath()
+	frame := ackhandler.Frame{
+		Frame:   &wire.PathChallengeFrame{Data: p.pathChallenge},
+		Handler: (*pathManagerOutgoingAckHandler)(pm),
+	}
+	return connID, frame, p.tr, true
+}
+
+func (pm *pathManagerOutgoing) HandlePathResponseFrame(f *wire.PathResponseFrame) {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	for _, p := range pm.paths {
+		if f.Data == p.pathChallenge {
+			// path validated
+			if !p.isValidated {
+				p.isValidated = true
+				close(p.validated)
+			}
+			// makes sure that duplicate PATH_RESPONSE frames are ignored
+			p.validated = nil
+			break
+		}
+	}
+}
+
+func (pm *pathManagerOutgoing) ShouldSwitchPath() (*Transport, bool) {
+	pm.mx.Lock()
+	defer pm.mx.Unlock()
+
+	if pm.pathToSwitchTo == nil {
+		return nil, false
+	}
+	p := pm.pathToSwitchTo
+	pm.pathToSwitchTo = nil
+	return p.tr, true
+}
+
+type pathManagerOutgoingAckHandler pathManagerOutgoing
+
+var _ ackhandler.FrameHandler = &pathManagerOutgoingAckHandler{}
+
+// OnAcked is called when the PATH_CHALLENGE is acked.
+// This doesn't validate the path, only receiving the PATH_RESPONSE does.
+func (pm *pathManagerOutgoingAckHandler) OnAcked(wire.Frame) {}
+
+func (pm *pathManagerOutgoingAckHandler) OnLost(wire.Frame) {}

--- a/path_manager_outgoing_test.go
+++ b/path_manager_outgoing_test.go
@@ -1,0 +1,99 @@
+package quic
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/wire"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathManagerOutgoing(t *testing.T) {
+	connIDs := []protocol.ConnectionID{
+		protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+		protocol.ParseConnectionID([]byte{2, 3, 4, 5, 6, 7, 8, 9}),
+	}
+	var retiredConnIDs []protocol.ConnectionID
+	pm := newPathManagerOutgoing(
+		func(id pathID) (protocol.ConnectionID, bool) { return connIDs[id], true },
+		func(id pathID) { retiredConnIDs = append(retiredConnIDs, connIDs[id]) },
+		func() {},
+	)
+
+	_, _, _, ok := pm.NextPathToProbe()
+	require.False(t, ok)
+
+	tr1 := &Transport{}
+	var enabled bool
+	p := pm.NewPath(tr1, func() { enabled = true })
+	require.ErrorIs(t, p.Switch(), ErrPathNotValidated)
+
+	errChan := make(chan error, 1)
+	go func() { errChan <- p.Probe(context.Background()) }()
+
+	// wait for the path to be queued for probing
+	time.Sleep(scaleDuration(5 * time.Millisecond))
+
+	require.False(t, enabled)
+	connID, f, tr, ok := pm.NextPathToProbe()
+	require.True(t, ok)
+	require.Equal(t, tr1, tr)
+	require.Equal(t, connIDs[0], connID)
+	require.IsType(t, &wire.PathChallengeFrame{}, f.Frame)
+	pc := f.Frame.(*wire.PathChallengeFrame)
+	require.True(t, enabled)
+
+	_, _, _, ok = pm.NextPathToProbe()
+	require.False(t, ok)
+
+	select {
+	case <-errChan:
+		t.Fatal("should still be probing")
+	default:
+	}
+
+	// acking the frame doesn't complete path validation...
+	f.Handler.OnAcked(f.Frame)
+	select {
+	case <-errChan:
+		t.Fatal("should still be probing")
+	default:
+	}
+
+	require.ErrorIs(t, p.Switch(), ErrPathNotValidated)
+	_, ok = pm.ShouldSwitchPath()
+	require.False(t, ok)
+
+	// ... neither does receiving a random PATH_RESPONSE...
+	pm.HandlePathResponseFrame(&wire.PathResponseFrame{Data: [8]byte{'f', 'o', 'o', 'f', 'o', 'o'}})
+	f.Handler.OnAcked(f.Frame) // doesn't do anything
+	f.Handler.OnLost(f.Frame)  // doesn't do anything
+	select {
+	case <-errChan:
+		t.Fatal("should still be probing")
+	default:
+	}
+
+	// ... only receiving the corresponding PATH_RESPONSE does
+	pm.HandlePathResponseFrame(&wire.PathResponseFrame{Data: pc.Data})
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	// receiving it multiple times is ok
+	pm.HandlePathResponseFrame(&wire.PathResponseFrame{Data: pc.Data})
+
+	// now switch to the other path
+	_, ok = pm.ShouldSwitchPath()
+	require.False(t, ok)
+	require.NoError(t, p.Switch())
+	switchToTransport, ok := pm.ShouldSwitchPath()
+	require.True(t, ok)
+	require.Equal(t, tr1, switchToTransport)
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -510,7 +510,7 @@ func testTransportDial(t *testing.T, early bool) {
 	newClientConnection = func(
 		_ context.Context,
 		_ sendConn,
-		_ connRunner,
+		_ *Transport,
 		_ protocol.ConnectionID,
 		_ protocol.ConnectionID,
 		_ ConnectionIDGenerator,
@@ -585,7 +585,7 @@ func TestTransportDialingVersionNegotiation(t *testing.T) {
 	newClientConnection = func(
 		_ context.Context,
 		_ sendConn,
-		_ connRunner,
+		_ *Transport,
 		_ protocol.ConnectionID,
 		_ protocol.ConnectionID,
 		_ ConnectionIDGenerator,


### PR DESCRIPTION
For #234. Still missing: closing of paths, which will be added in a follow-up PR.