### PR TITLE
proxy: add source and destination address to delay and drop callbacks

### DIFF
--- a/integrationtests/self/close_test.go
+++ b/integrationtests/self/close_test.go
@@ -30,10 +30,10 @@ func TestConnectionCloseRetransmission(t *testing.T) {
 	proxy := &quicproxy.Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: server.Addr().(*net.UDPAddr),
-		DelayPacket: func(_ quicproxy.Direction, _ []byte) time.Duration {
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration {
 			return 5 * time.Millisecond // 10ms RTT
 		},
-		DropPacket: func(dir quicproxy.Direction, b []byte) bool {
+		DropPacket: func(dir quicproxy.Direction, _, _ net.Addr, b []byte) bool {
 			if drop := drop.Load(); drop && dir == quicproxy.DirectionOutgoing {
 				dropped <- b
 				return true

--- a/integrationtests/self/datagram_test.go
+++ b/integrationtests/self/datagram_test.go
@@ -140,7 +140,7 @@ func TestDatagramLoss(t *testing.T) {
 	proxy := &quicproxy.Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: server.Addr().(*net.UDPAddr),
-		DropPacket: func(dir quicproxy.Direction, packet []byte) bool {
+		DropPacket: func(dir quicproxy.Direction, _, _ net.Addr, packet []byte) bool {
 			if wire.IsLongHeaderPacket(packet[0]) { // don't drop Long Header packets
 				return false
 			}
@@ -159,7 +159,7 @@ func TestDatagramLoss(t *testing.T) {
 			}
 			return false
 		},
-		DelayPacket: func(_ quicproxy.Direction, _ []byte) time.Duration { return rtt / 2 },
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration { return rtt / 2 },
 	}
 	require.NoError(t, proxy.Start())
 	defer proxy.Close()

--- a/integrationtests/self/drop_test.go
+++ b/integrationtests/self/drop_test.go
@@ -36,8 +36,8 @@ func TestDropTests(t *testing.T) {
 			proxy := &quicproxy.Proxy{
 				Conn:        newUPDConnLocalhost(t),
 				ServerAddr:  ln.Addr().(*net.UDPAddr),
-				DelayPacket: func(quicproxy.Direction, []byte) time.Duration { return rtt / 2 },
-				DropPacket: func(d quicproxy.Direction, b []byte) bool {
+				DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration { return rtt / 2 },
+				DropPacket: func(d quicproxy.Direction, _, _ net.Addr, b []byte) bool {
 					if !d.Is(direction) {
 						return false
 					}

--- a/integrationtests/self/early_data_test.go
+++ b/integrationtests/self/early_data_test.go
@@ -22,7 +22,7 @@ func TestEarlyData(t *testing.T) {
 	proxy := &quicproxy.Proxy{
 		Conn:        newUPDConnLocalhost(t),
 		ServerAddr:  ln.Addr().(*net.UDPAddr),
-		DelayPacket: func(quicproxy.Direction, []byte) time.Duration { return rtt / 2 },
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration { return rtt / 2 },
 	}
 	require.NoError(t, proxy.Start())
 	defer proxy.Close()

--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -47,7 +47,7 @@ func startDropTestListenerAndProxy(t *testing.T, rtt, timeout time.Duration, dro
 		Conn:        newUPDConnLocalhost(t),
 		ServerAddr:  ln.Addr().(*net.UDPAddr),
 		DropPacket:  dropCallback,
-		DelayPacket: func(quicproxy.Direction, []byte) time.Duration { return rtt / 2 },
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration { return rtt / 2 },
 	}
 	require.NoError(t, proxy.Start())
 	t.Cleanup(func() { proxy.Close() })
@@ -172,7 +172,7 @@ func dropTestProtocolNobodySpeaks(t *testing.T, ln *quic.Listener, addr net.Addr
 
 func dropCallbackDropNthPacket(direction quicproxy.Direction, n int) quicproxy.DropCallback {
 	var incoming, outgoing atomic.Int32
-	return func(d quicproxy.Direction, packet []byte) bool {
+	return func(d quicproxy.Direction, _, _ net.Addr, packet []byte) bool {
 		var p int32
 		switch d {
 		case quicproxy.DirectionIncoming:
@@ -188,7 +188,7 @@ func dropCallbackDropOneThird(direction quicproxy.Direction) quicproxy.DropCallb
 	const maxSequentiallyDropped = 10
 	var mx sync.Mutex
 	var incoming, outgoing int
-	return func(d quicproxy.Direction, _ []byte) bool {
+	return func(d quicproxy.Direction, _, _ net.Addr, _ []byte) bool {
 		drop := mrand.Int63n(int64(3)) == 0
 
 		mx.Lock()

--- a/integrationtests/self/handshake_rtt_test.go
+++ b/integrationtests/self/handshake_rtt_test.go
@@ -20,7 +20,7 @@ func handshakeWithRTT(t *testing.T, serverAddr net.Addr, tlsConf *tls.Config, qu
 	proxy := quicproxy.Proxy{
 		Conn:        newUPDConnLocalhost(t),
 		ServerAddr:  serverAddr.(*net.UDPAddr),
-		DelayPacket: func(quicproxy.Direction, []byte) time.Duration { return rtt / 2 },
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration { return rtt / 2 },
 	}
 	require.NoError(t, proxy.Start())
 	t.Cleanup(func() { proxy.Close() })

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -362,7 +362,7 @@ func TestHandshakingConnectionsClosedOnServerShutdown(t *testing.T) {
 	proxy := quicproxy.Proxy{
 		Conn:        newUPDConnLocalhost(t),
 		ServerAddr:  ln.Addr().(*net.UDPAddr),
-		DelayPacket: func(quicproxy.Direction, []byte) time.Duration { return rtt / 2 },
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration { return rtt / 2 },
 	}
 	require.NoError(t, proxy.Start())
 	defer proxy.Close()
@@ -553,7 +553,7 @@ func TestInvalidToken(t *testing.T) {
 	proxy := quicproxy.Proxy{
 		Conn:        newUPDConnLocalhost(t),
 		ServerAddr:  server.Addr().(*net.UDPAddr),
-		DelayPacket: func(quicproxy.Direction, []byte) time.Duration { return rtt / 2 },
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration { return rtt / 2 },
 	}
 	require.NoError(t, proxy.Start())
 	defer proxy.Close()

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -851,7 +851,7 @@ func TestHTTP0RTT(t *testing.T) {
 	proxy := quicproxy.Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
-		DelayPacket: func(_ quicproxy.Direction, data []byte) time.Duration {
+		DelayPacket: func(_ quicproxy.Direction, _, _ net.Addr, data []byte) time.Duration {
 			if contains0RTTPacket(data) {
 				num0RTTPackets.Add(1)
 			}

--- a/integrationtests/self/mtu_test.go
+++ b/integrationtests/self/mtu_test.go
@@ -82,8 +82,8 @@ func TestPathMTUDiscovery(t *testing.T) {
 	proxy := &quicproxy.Proxy{
 		Conn:        newUPDConnLocalhost(t),
 		ServerAddr:  ln.Addr().(*net.UDPAddr),
-		DelayPacket: func(_ quicproxy.Direction, _ []byte) time.Duration { return rtt / 2 },
-		DropPacket: func(dir quicproxy.Direction, packet []byte) bool {
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration { return rtt / 2 },
+		DropPacket: func(dir quicproxy.Direction, _, _ net.Addr, packet []byte) bool {
 			if len(packet) > mtu {
 				return true
 			}

--- a/integrationtests/self/nat_rebinding_test.go
+++ b/integrationtests/self/nat_rebinding_test.go
@@ -44,7 +44,7 @@ func TestNATRebinding(t *testing.T) {
 	var mx sync.Mutex
 	var switchedPath bool
 	var dataTransferred int
-	proxy.DelayPacket = func(dir quicproxy.Direction, b []byte) time.Duration {
+	proxy.DelayPacket = func(dir quicproxy.Direction, _, _ net.Addr, b []byte) time.Duration {
 		mx.Lock()
 		defer mx.Unlock()
 

--- a/integrationtests/self/packetization_test.go
+++ b/integrationtests/self/packetization_test.go
@@ -37,7 +37,7 @@ func TestACKBundling(t *testing.T) {
 	proxy := quicproxy.Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: server.Addr().(*net.UDPAddr),
-		DelayPacket: func(_ quicproxy.Direction, _ []byte) time.Duration {
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration {
 			return 5 * time.Millisecond
 		},
 	}
@@ -166,7 +166,7 @@ func testConnAndStreamDataBlocked(t *testing.T, limitStream, limitConn bool) {
 	proxy := quicproxy.Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: ln.Addr().(*net.UDPAddr),
-		DelayPacket: func(_ quicproxy.Direction, _ []byte) time.Duration {
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration {
 			return rtt / 2
 		},
 	}

--- a/integrationtests/self/rtt_test.go
+++ b/integrationtests/self/rtt_test.go
@@ -68,7 +68,7 @@ func TestDownloadWithFixedRTT(t *testing.T) {
 			proxy := quicproxy.Proxy{
 				Conn:        newUPDConnLocalhost(t),
 				ServerAddr:  &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: addr.(*net.UDPAddr).Port},
-				DelayPacket: func(_ quicproxy.Direction, _ []byte) time.Duration { return rtt / 2 },
+				DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration { return rtt / 2 },
 			}
 			require.NoError(t, proxy.Start())
 			t.Cleanup(func() { proxy.Close() })
@@ -113,7 +113,7 @@ func TestDownloadWithReordering(t *testing.T) {
 			proxy := quicproxy.Proxy{
 				Conn:       newUPDConnLocalhost(t),
 				ServerAddr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: addr.(*net.UDPAddr).Port},
-				DelayPacket: func(_ quicproxy.Direction, _ []byte) time.Duration {
+				DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration {
 					return randomDuration(rtt/2, rtt*3/2) / 2
 				},
 			}

--- a/integrationtests/self/stateless_reset_test.go
+++ b/integrationtests/self/stateless_reset_test.go
@@ -60,7 +60,7 @@ func testStatelessReset(t *testing.T, connIDLen int) {
 	proxy := quicproxy.Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: ln.Addr().(*net.UDPAddr),
-		DropPacket: func(quicproxy.Direction, []byte) bool { return drop.Load() },
+		DropPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) bool { return drop.Load() },
 	}
 	require.NoError(t, proxy.Start())
 	defer proxy.Close()

--- a/integrationtests/self/timeout_test.go
+++ b/integrationtests/self/timeout_test.go
@@ -114,7 +114,7 @@ func TestIdleTimeout(t *testing.T) {
 	proxy := quicproxy.Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: server.Addr().(*net.UDPAddr),
-		DropPacket: func(_ quicproxy.Direction, _ []byte) bool { return drop.Load() },
+		DropPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) bool { return drop.Load() },
 	}
 	require.NoError(t, proxy.Start())
 	defer proxy.Close()
@@ -181,7 +181,7 @@ func TestKeepAlive(t *testing.T) {
 	proxy := quicproxy.Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: server.Addr().(*net.UDPAddr),
-		DropPacket: func(_ quicproxy.Direction, _ []byte) bool { return drop.Load() },
+		DropPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) bool { return drop.Load() },
 	}
 	require.NoError(t, proxy.Start())
 	defer proxy.Close()
@@ -323,7 +323,7 @@ func TestTimeoutAfterSendingPacket(t *testing.T) {
 	proxy := quicproxy.Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: server.Addr().(*net.UDPAddr),
-		DropPacket: func(_ quicproxy.Direction, _ []byte) bool { return drop.Load() },
+		DropPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) bool { return drop.Load() },
 	}
 	require.NoError(t, proxy.Start())
 	defer proxy.Close()

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -142,13 +142,16 @@ func TestDropIncomingPackets(t *testing.T) {
 	const numPackets = 6
 	serverAddr, serverReceivedPackets := runServer(t)
 	var counter atomic.Int32
+	var fromAddr, toAddr atomic.Pointer[net.Addr]
 	proxy := Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: serverAddr,
-		DropPacket: func(d Direction, _ []byte) bool {
+		DropPacket: func(d Direction, from, to net.Addr, _ []byte) bool {
 			if d != DirectionIncoming {
 				return false
 			}
+			fromAddr.Store(&from)
+			toAddr.Store(&to)
 			return counter.Add(1)%2 == 1
 		},
 	}
@@ -174,19 +177,25 @@ func TestDropIncomingPackets(t *testing.T) {
 		t.Fatalf("received unexpected packet")
 	case <-time.After(100 * time.Millisecond):
 	}
+
+	require.Equal(t, *fromAddr.Load(), clientConn.LocalAddr())
+	require.Equal(t, *toAddr.Load(), serverAddr)
 }
 
 func TestDropOutgoingPackets(t *testing.T) {
 	const numPackets = 6
 	serverAddr, serverReceivedPackets := runServer(t)
 	var counter atomic.Int32
+	var fromAddr, toAddr atomic.Pointer[net.Addr]
 	proxy := Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: serverAddr,
-		DropPacket: func(d Direction, _ []byte) bool {
+		DropPacket: func(d Direction, from, to net.Addr, _ []byte) bool {
 			if d != DirectionOutgoing {
 				return false
 			}
+			fromAddr.Store(&from)
+			toAddr.Store(&to)
 			return counter.Add(1)%2 == 1
 		},
 	}
@@ -225,6 +234,9 @@ func TestDropOutgoingPackets(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 	require.Len(t, serverReceivedPackets, numPackets)
+
+	require.Equal(t, *fromAddr.Load(), serverAddr)
+	require.Equal(t, *toAddr.Load(), clientConn.LocalAddr())
 }
 
 func TestDelayIncomingPackets(t *testing.T) {
@@ -235,7 +247,7 @@ func TestDelayIncomingPackets(t *testing.T) {
 	proxy := Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: serverAddr,
-		DelayPacket: func(d Direction, _ []byte) time.Duration {
+		DelayPacket: func(d Direction, _, _ net.Addr, _ []byte) time.Duration {
 			// delay packet 1 by 200 ms
 			// delay packet 2 by 400 ms
 			// ...
@@ -282,7 +294,7 @@ func TestPacketReordering(t *testing.T) {
 	proxy := Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: serverAddr,
-		DelayPacket: func(d Direction, _ []byte) time.Duration {
+		DelayPacket: func(d Direction, _, _ net.Addr, _ []byte) time.Duration {
 			// delay packet 1 by 600 ms
 			// delay packet 2 by 400 ms
 			// delay packet 3 by 200 ms
@@ -321,7 +333,7 @@ func TestConstantDelay(t *testing.T) { // no reordering expected here
 	proxy := Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: serverAddr,
-		DelayPacket: func(d Direction, _ []byte) time.Duration {
+		DelayPacket: func(d Direction, _, _ net.Addr, _ []byte) time.Duration {
 			if d == DirectionOutgoing {
 				return 0
 			}
@@ -359,7 +371,7 @@ func TestDelayOutgoingPackets(t *testing.T) {
 	proxy := Proxy{
 		Conn:       newUPDConnLocalhost(t),
 		ServerAddr: serverAddr,
-		DelayPacket: func(d Direction, _ []byte) time.Duration {
+		DelayPacket: func(d Direction, _, _ net.Addr, _ []byte) time.Duration {
 			// delay packet 1 by 200 ms
 			// delay packet 2 by 400 ms
 			// ...

--- a/integrationtests/versionnegotiation/rtt_test.go
+++ b/integrationtests/versionnegotiation/rtt_test.go
@@ -40,7 +40,7 @@ func TestVersionNegotiationFailure(t *testing.T) {
 	proxy := quicproxy.Proxy{
 		Conn:        proxyConn,
 		ServerAddr:  ln.Addr().(*net.UDPAddr),
-		DelayPacket: func(quicproxy.Direction, []byte) time.Duration { return rtt / 2 },
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration { return rtt / 2 },
 	}
 	require.NoError(t, proxy.Start())
 	defer proxy.Close()


### PR DESCRIPTION
This will help us test connection migration (#234).