### PR TITLE
trace drop of unknown-version packets when Version Negotiation is off

### DIFF
--- a/server.go
+++ b/server.go
@@ -426,6 +426,9 @@ func (s *baseServer) handlePacketImpl(p receivedPacket) bool /* is the buffer st
 	// send a Version Negotiation Packet if the client is speaking a different protocol version
 	if !protocol.IsSupportedVersion(s.config.Versions, v) {
 		if s.disableVersionNegotiation {
+			if s.tracer != nil && s.tracer.DroppedPacket != nil {
+				s.tracer.DroppedPacket(p.remoteAddr, logging.PacketTypeNotDetermined, p.Size(), logging.PacketDropUnexpectedVersion)
+			}
 			return false
 		}
 

--- a/server_test.go
+++ b/server_test.go
@@ -385,6 +385,7 @@ var _ = Describe("Server", func() {
 				raddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1337}
 				packet.remoteAddr = raddr
 				done := make(chan struct{})
+				tracer.EXPECT().DroppedPacket(raddr, logging.PacketTypeNotDetermined, packet.Size(), logging.PacketDropUnexpectedVersion)
 				serv.handlePacket(packet)
 				Consistently(done, 50*time.Millisecond).ShouldNot(BeClosed())
 			})


### PR DESCRIPTION
Discovered when working on #4969.