### PR TITLE
implement closing of paths probed for connection migration

### DIFF
--- a/path_manager.go
+++ b/path_manager.go
@@ -12,6 +12,8 @@ import (
 
 type pathID int64
 
+const invalidPathID pathID = -1
+
 const maxPaths = 3
 
 type path struct {


### PR DESCRIPTION
This is needed to retire (and thereby get replacements for) connection IDs that were used for probing paths for connection migration, as mentioned in #4960.

Fixes #234. Fixes #3990.