### PR TITLE
Copy EncryptedClientHelloKeys to new HTTP3 listener's tlsConfig

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -75,6 +75,7 @@ func ConfigureTLSConfig(tlsConf *tls.Config) *tls.Config {
 	// The tls.Config used to setup the quic.Listener needs to have the GetConfigForClient callback set.
 	// That way, we can get the QUIC version and set the correct ALPN value.
 	return &tls.Config{
+		EncryptedClientHelloKeys: tlsConf.EncryptedClientHelloKeys,
 		GetConfigForClient: func(ch *tls.ClientHelloInfo) (*tls.Config, error) {
 			// determine the ALPN from the QUIC version used
 			proto := NextProtoH3


### PR DESCRIPTION
The ECH keys need to be passed on to the listeners to be able to accept TLS handshakes that use ECH.

Fixes #4980

The problem had nothing to do with the parsing actually. Instead the http3 listener needs to have the tlsConf.EncryptedClientHelloKeys populated to be able to decrypt the incoming encrypted client hellos.
In the ConfigureTLSConfig() function, a new tls.Config is created and it doesn't keep the EncryptedClientHelloKeys currently. 