### PR TITLE
retransmit path probe packets

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2636,18 +2636,22 @@ func (s *connection) AddPath(t *Transport) (*Path, error) {
 	if err := t.init(false); err != nil {
 		return nil, err
 	}
-	return s.getPathManager().NewPath(t, func() {
-		runner := t.connRunner()
-		s.connIDGenerator.AddConnRunner(
-			t.id(),
-			connRunnerCallbacks{
-				AddConnectionID:    func(connID protocol.ConnectionID) { runner.Add(connID, s) },
-				RemoveConnectionID: runner.Remove,
-				RetireConnectionID: runner.Retire,
-				ReplaceWithClosed:  runner.ReplaceWithClosed,
-			},
-		)
-	}), nil
+	return s.getPathManager().NewPath(
+		t,
+		200*time.Millisecond, // initial RTT estimate
+		func() {
+			runner := t.connRunner()
+			s.connIDGenerator.AddConnRunner(
+				t.id(),
+				connRunnerCallbacks{
+					AddConnectionID:    func(connID protocol.ConnectionID) { runner.Add(connID, s) },
+					RemoveConnectionID: runner.Remove,
+					RetireConnectionID: runner.Retire,
+					ReplaceWithClosed:  runner.ReplaceWithClosed,
+				},
+			)
+		},
+	), nil
 }
 
 func (s *connection) NextConnection(ctx context.Context) (Connection, error) {


### PR DESCRIPTION
Fixes #4989. For #234.

New PATH_CHALLENGES are sent for as long as Path.Probe is active. The first retransmission is sent after 200ms, with an exponential backoff afterwards.