### PR TITLE
proxy: fix test timeout failures during cleanup

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ jobs:
         run: echo "GOARCH=386" >> $GITHUB_ENV
       - run: go version
       - name: Run tools tests
-        run: go test ${{ env.RACEFLAG }} -v -timeout 30s -shuffle=on ./integrationtests/tools
+        run: go test ${{ env.RACEFLAG }} -v -timeout 30s -shuffle=on ./integrationtests/tools/...
       - name: Run version negotiation tests
         run: go test ${{ env.RACEFLAG }} -v -timeout 30s -shuffle=on ./integrationtests/versionnegotiation ${{ env.QLOGFLAG }}
       - name: Run self tests, using QUIC v1


### PR DESCRIPTION
Several proxy tests timed out because it got stuck in the packet read loop after all tests have run. Avoid this by running the `conn.Close()` Cleanup call from `newUPDConnLocalhost` before the timeout handler.

Update CI to run these tests.

Fixes: 3e87ea3f50df ("proxy: add function to simulate NAT rebinding (#4922)")
Relates to: #5009