### PR TITLE
http3: simplify ConfigureTLSConfig

### DIFF
--- a/http3/transport.go
+++ b/http3/transport.go
@@ -322,7 +322,7 @@ func (t *Transport) dial(ctx context.Context, hostname string) (quic.EarlyConnec
 		tlsConf.ServerName = sni
 	}
 	// Replace existing ALPNs by H3
-	tlsConf.NextProtos = []string{versionToALPN(t.QUICConfig.Versions[0])}
+	tlsConf.NextProtos = []string{NextProtoH3}
 
 	dial := t.Dial
 	if dial == nil {


### PR DESCRIPTION
Fixes #4980. Closes #5004.

The previous logic allowed for setting different ALPN values depending on the QUIC version in use. This was needed to set the draft ALPN value before publication of the RFC.