### PR TITLE
quicvarint: refactor ifs into a switch statement

### DIFF
--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -125,17 +125,18 @@ func AppendWithLen(b []byte, i uint64, length int) []byte {
 	if l > length {
 		panic(fmt.Sprintf("cannot encode %d in %d bytes", i, length))
 	}
-	if length == 2 {
+	switch length {
+	case 2:
 		b = append(b, 0b01000000)
-	} else if length == 4 {
+	case 4:
 		b = append(b, 0b10000000)
-	} else if length == 8 {
+	case 8:
 		b = append(b, 0b11000000)
 	}
-	for j := 1; j < length-l; j++ {
+	for range length - l - 1 {
 		b = append(b, 0)
 	}
-	for j := 0; j < l; j++ {
+	for j := range l {
 		b = append(b, uint8(i>>(8*(l-1-j))))
 	}
 	return b

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -253,7 +253,28 @@ func benchmarkAppend(b *testing.B, inputs []benchmarkValue) {
 		buf = Append(buf, inputs[index].v)
 
 		if !bytes.Equal(buf, inputs[index].b) {
-			b.Fatalf("expected to write %v, wrote %v", inputs[i].b, buf)
+			b.Fatalf("expected to write %v, wrote %v", inputs[index].b, buf)
+		}
+	}
+}
+
+func BenchmarkAppendWithLen(b *testing.B) {
+	b.Run("1-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(min(b.N, 1024), maxVarInt1)) })
+	b.Run("2-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(min(b.N, 1024), maxVarInt2)) })
+	b.Run("4-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(min(b.N, 1024), maxVarInt4)) })
+	b.Run("8-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(min(b.N, 1024), maxVarInt8)) })
+}
+
+func benchmarkAppendWithLen(b *testing.B, inputs []benchmarkValue) {
+	buf := make([]byte, 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf = buf[:0]
+		index := i % 1024
+		buf = AppendWithLen(buf, inputs[index].v, len(inputs[index].b))
+
+		if !bytes.Equal(buf, inputs[index].b) {
+			b.Fatalf("expected to write %v, wrote %v", inputs[index].b, buf)
 		}
 	}
 }


### PR DESCRIPTION
No functional change expected.

golangci-lint v2 prefers this version (#5007), therefore I'm splitting this out of that PR. Also adding a benchmark to make sure it doesn't cause any regression:
```
name                     old time/op  new time/op  delta
AppendWithLen/1-byte-16  3.90ns ± 4%  3.86ns ± 2%   ~     (p=1.000 n=5+5)
AppendWithLen/2-byte-16  5.33ns ± 2%  5.34ns ± 3%   ~     (p=0.952 n=5+5)
AppendWithLen/4-byte-16  5.48ns ± 2%  5.60ns ± 1%   ~     (p=0.056 n=5+5)
AppendWithLen/8-byte-16  5.80ns ± 2%  5.77ns ± 2%   ~     (p=0.841 n=5+5)
```