### PR TITLE
rename ClientHelloInfo to ClientInfo

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -137,7 +137,7 @@ func TestConfigCloning(t *testing.T) {
 	t.Run("function fields", func(t *testing.T) {
 		var calledAllowConnectionWindowIncrease, calledTracer bool
 		c1 := &Config{
-			GetConfigForClient:            func(info *ClientHelloInfo) (*Config, error) { return nil, errors.New("nope") },
+			GetConfigForClient:            func(info *ClientInfo) (*Config, error) { return nil, errors.New("nope") },
 			AllowConnectionWindowIncrease: func(Connection, uint64) bool { calledAllowConnectionWindowIncrease = true; return true },
 			Tracer: func(context.Context, logging.Perspective, ConnectionID) *logging.ConnectionTracer {
 				calledTracer = true
@@ -147,7 +147,7 @@ func TestConfigCloning(t *testing.T) {
 		c2 := c1.Clone()
 		c2.AllowConnectionWindowIncrease(nil, 1234)
 		require.True(t, calledAllowConnectionWindowIncrease)
-		_, err := c2.GetConfigForClient(&ClientHelloInfo{})
+		_, err := c2.GetConfigForClient(&ClientInfo{})
 		require.EqualError(t, err, "nope")
 		c2.Tracer(context.Background(), logging.PerspectiveClient, protocol.ConnectionID{})
 		require.True(t, calledTracer)

--- a/integrationtests/self/handshake_rtt_test.go
+++ b/integrationtests/self/handshake_rtt_test.go
@@ -45,7 +45,7 @@ func TestHandshakeRTTWithoutRetry(t *testing.T) {
 	defer ln.Close()
 
 	clientConfig := getQuicConfig(&quic.Config{
-		GetConfigForClient: func(info *quic.ClientHelloInfo) (*quic.Config, error) {
+		GetConfigForClient: func(info *quic.ClientInfo) (*quic.Config, error) {
 			require.False(t, info.AddrVerified)
 			return nil, nil
 		},
@@ -71,7 +71,7 @@ func TestHandshakeRTTWithRetry(t *testing.T) {
 	defer ln.Close()
 
 	clientConfig := getQuicConfig(&quic.Config{
-		GetConfigForClient: func(info *quic.ClientHelloInfo) (*quic.Config, error) {
+		GetConfigForClient: func(info *quic.ClientInfo) (*quic.Config, error) {
 			require.True(t, info.AddrVerified)
 			return nil, nil
 		},

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -448,7 +448,7 @@ func TestTokensFromNewTokenFrames(t *testing.T) {
 func testTokensFromNewTokenFrames(t *testing.T, maxTokenAge time.Duration, expectTokenUsed bool) {
 	addrVerifiedChan := make(chan bool, 2)
 	quicConf := getQuicConfig(nil)
-	quicConf.GetConfigForClient = func(info *quic.ClientHelloInfo) (*quic.Config, error) {
+	quicConf.GetConfigForClient = func(info *quic.ClientInfo) (*quic.Config, error) {
 		addrVerifiedChan <- info.AddrVerified
 		return quicConf, nil
 	}
@@ -570,7 +570,7 @@ func TestInvalidToken(t *testing.T) {
 func TestGetConfigForClient(t *testing.T) {
 	var calledFrom net.Addr
 	serverConfig := getQuicConfig(&quic.Config{EnableDatagrams: true})
-	serverConfig.GetConfigForClient = func(info *quic.ClientHelloInfo) (*quic.Config, error) {
+	serverConfig.GetConfigForClient = func(info *quic.ClientInfo) (*quic.Config, error) {
 		conf := serverConfig.Clone()
 		conf.EnableDatagrams = true
 		calledFrom = info.RemoteAddr
@@ -610,7 +610,7 @@ func TestGetConfigForClientErrorsConnectionRejection(t *testing.T) {
 		newUDPConnLocalhost(t),
 		getTLSConfig(),
 		getQuicConfig(&quic.Config{
-			GetConfigForClient: func(info *quic.ClientHelloInfo) (*quic.Config, error) {
+			GetConfigForClient: func(info *quic.ClientInfo) (*quic.Config, error) {
 				return nil, errors.New("rejected")
 			},
 		}),

--- a/interface.go
+++ b/interface.go
@@ -63,7 +63,7 @@ type ConnectionTracingID uint64
 type connTracingCtxKey struct{}
 
 // QUICVersionContextKey can be used to find out the QUIC version of a TLS handshake from the
-// context returned by tls.Config.ClientHelloInfo.Context.
+// context returned by tls.Config.ClientInfo.Context.
 var QUICVersionContextKey = handshake.QUICVersionContextKey
 
 // Stream is the interface implemented by QUIC streams
@@ -264,7 +264,7 @@ type ConnectionIDGenerator interface {
 type Config struct {
 	// GetConfigForClient is called for incoming connections.
 	// If the error is not nil, the connection attempt is refused.
-	GetConfigForClient func(info *ClientHelloInfo) (*Config, error)
+	GetConfigForClient func(info *ClientInfo) (*Config, error)
 	// The QUIC versions that can be negotiated.
 	// If not set, it uses all versions available.
 	Versions []Version
@@ -344,7 +344,12 @@ type Config struct {
 }
 
 // ClientHelloInfo contains information about an incoming connection attempt.
-type ClientHelloInfo struct {
+//
+// Deprecated: Use ClientInfo instead.
+type ClientHelloInfo = ClientInfo
+
+// ClientInfo contains information about an incoming connection attempt.
+type ClientInfo struct {
 	// RemoteAddr is the remote address on the Initial packet.
 	// Unless AddrVerified is set, the address is not yet verified, and could be a spoofed IP address.
 	RemoteAddr net.Addr

--- a/server.go
+++ b/server.go
@@ -649,7 +649,7 @@ func (s *baseServer) handleInitialImpl(p receivedPacket, hdr *wire.Header) error
 
 	config := s.config
 	if s.config.GetConfigForClient != nil {
-		conf, err := s.config.GetConfigForClient(&ClientHelloInfo{
+		conf, err := s.config.GetConfigForClient(&ClientInfo{
 			RemoteAddr:   p.remoteAddr,
 			AddrVerified: clientAddrVerified,
 		})

--- a/server_test.go
+++ b/server_test.go
@@ -792,7 +792,7 @@ func TestServerGetConfigForClientAccept(t *testing.T) {
 	recorder := newConnConstructorRecorder(c)
 	server := newTestServer(t, &serverOpts{
 		config: &Config{
-			GetConfigForClient: func(*ClientHelloInfo) (*Config, error) {
+			GetConfigForClient: func(*ClientInfo) (*Config, error) {
 				return &Config{MaxIncomingStreams: 1234}, nil
 			},
 		},
@@ -831,7 +831,7 @@ func TestServerGetConfigForClientReject(t *testing.T) {
 	server := newTestServer(t, &serverOpts{
 		tracer: tracer,
 		config: &Config{
-			GetConfigForClient: func(*ClientHelloInfo) (*Config, error) {
+			GetConfigForClient: func(*ClientInfo) (*Config, error) {
 				return nil, errors.New("rejected")
 			},
 		},


### PR DESCRIPTION
Fixes #5015.

There’s no ClientHello (which is a TLS concept) involved here.