### PR TITLE
switch packet packer to math/rand/v2

### DIFF
--- a/packet_packer.go
+++ b/packet_packer.go
@@ -5,9 +5,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"time"
-
-	"golang.org/x/exp/rand"
 
 	"github.com/quic-go/quic-go/internal/ackhandler"
 	"github.com/quic-go/quic-go/internal/handshake"
@@ -152,7 +151,7 @@ func newPacketPacker(
 	datagramQueue *datagramQueue,
 	perspective protocol.Perspective,
 ) *packetPacker {
-	var b [8]byte
+	var b [16]byte
 	_, _ = crand.Read(b[:])
 
 	return &packetPacker{
@@ -166,7 +165,7 @@ func newPacketPacker(
 		perspective:         perspective,
 		framer:              framer,
 		acks:                acks,
-		rand:                *rand.New(rand.NewSource(binary.BigEndian.Uint64(b[:]))),
+		rand:                *rand.New(rand.NewPCG(binary.BigEndian.Uint64(b[:8]), binary.BigEndian.Uint64(b[8:]))),
 		pnManager:           packetNumberManager,
 	}
 }


### PR DESCRIPTION
For #4473.

```
❯ benchstat old.txt new_pcg.txt
name                        old time/op    new time/op    delta
PacketPackerConstructor-16     117ns ± 4%     266ns ± 8%  +127.61%  (p=0.000 n=10+10)

name                        old alloc/op   new alloc/op   delta
PacketPackerConstructor-16      224B ± 0%      208B ± 0%    -7.14%  (p=0.000 n=10+10)

name                        old allocs/op  new allocs/op  delta
PacketPackerConstructor-16      2.00 ± 0%      2.00 ± 0%      ~     (all equal)
```

Constructing the packet packer takes significantly longer, however, it allocates 16 bytes less, and this saving is expected to persist over the lifetime of the connection.

```go
func BenchmarkPacketPackerConstructor(b *testing.B) {
	for i := 0; i < b.N; i++ {
		newPacketPacker(
			protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
			nil,
			nil,
			nil,
			nil,
			nil,
			nil,
			nil,
			nil,
			nil,
			protocol.PerspectiveServer,
		)
	}
}
```