### PR TITLE
clarify that Config.InitialPacketSize constitutes a lower limit

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -323,10 +323,10 @@ type Config struct {
 	// If set to 0, then no keep alive is sent. Otherwise, the keep alive is sent on that period (or at most
 	// every half of MaxIdleTimeout, whichever is smaller).
 	KeepAlivePeriod time.Duration
-	// InitialPacketSize is the initial size of packets sent.
-	// It is usually not necessary to manually set this value,
-	// since Path MTU discovery very quickly finds the path's MTU.
-	// If set too high, the path might not support packets that large, leading to a timeout of the QUIC handshake.
+	// InitialPacketSize is the initial size (and the lower limit) for packets sent.
+	// Under most circumstances, it is not necessary to manually set this value,
+	// since path MTU discovery quickly finds the path's MTU.
+	// If set too high, the path might not support packets of that size, leading to a timeout of the QUIC handshake.
 	// Values below 1200 are invalid.
 	InitialPacketSize uint16
 	// DisablePathMTUDiscovery disables Path MTU Discovery (RFC 8899).


### PR DESCRIPTION
See #5041.