### PR TITLE
Fix tests in FIPS 140 mode

### DIFF
--- a/fuzzing/handshake/fuzz.go
+++ b/fuzzing/handshake/fuzz.go
@@ -2,8 +2,9 @@ package handshake
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -30,7 +31,7 @@ var (
 )
 
 func init() {
-	priv, err := rsa.GenerateKey(rand.Reader, 1024)
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -39,7 +40,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	privClient, err := rsa.GenerateKey(rand.Reader, 1024)
+	privClient, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/quic-go/quic-go"
 	quicproxy "github.com/quic-go/quic-go/integrationtests/tools/proxy"
+	"github.com/quic-go/quic-go/internal/fips140"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/qtls"
@@ -119,6 +120,9 @@ func TestHandshakeCipherSuites(t *testing.T) {
 		tls.TLS_CHACHA20_POLY1305_SHA256,
 	} {
 		t.Run(tls.CipherSuiteName(suiteID), func(t *testing.T) {
+			if suiteID == tls.TLS_CHACHA20_POLY1305_SHA256 && fips140.Enabled() {
+				t.Skip("TLS_CHACHA20_POLY1305_SHA256 not available in FIPS mode")
+			}
 			reset := qtls.SetCipherSuite(suiteID)
 			defer reset()
 

--- a/integrationtests/tools/crypto.go
+++ b/integrationtests/tools/crypto.go
@@ -2,9 +2,9 @@ package tools
 
 import (
 	"crypto"
-	"crypto/ed25519"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -26,11 +26,11 @@ func GenerateCA() (*x509.Certificate, crypto.PrivateKey, error) {
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 	}
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, err
 	}
-	caBytes, err := x509.CreateCertificate(rand.Reader, certTempl, certTempl, pub, priv)
+	caBytes, err := x509.CreateCertificate(rand.Reader, certTempl, certTempl, priv.Public(), priv)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -51,11 +51,11 @@ func GenerateLeafCert(ca *x509.Certificate, caPriv crypto.PrivateKey) (*x509.Cer
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, err
 	}
-	certBytes, err := x509.CreateCertificate(rand.Reader, certTempl, ca, pub, caPriv)
+	certBytes, err := x509.CreateCertificate(rand.Reader, certTempl, ca, priv.Public(), caPriv)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -83,7 +83,7 @@ func GenerateTLSConfigWithLongCertChain(ca *x509.Certificate, caPrivateKey crypt
 
 	lastCA := ca
 	lastCAPrivKey := caPrivateKey
-	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fips140/boring.go
+++ b/internal/fips140/boring.go
@@ -1,0 +1,11 @@
+//go:build boringcrypto
+
+package fips140
+
+import "crypto/boring"
+
+// Enabled reports whether the cryptography libraries are operating in FIPS
+// 140-3 mode.
+func Enabled() bool {
+	return boring.Enabled()
+}

--- a/internal/fips140/notboring_fips140.go
+++ b/internal/fips140/notboring_fips140.go
@@ -1,0 +1,11 @@
+//go:build !boringcrypto && go1.24
+
+package fips140
+
+import "crypto/fips140"
+
+// Enabled reports whether the cryptography libraries are operating in FIPS
+// 140-3 mode.
+func Enabled() bool {
+	return fips140.Enabled()
+}

--- a/internal/fips140/notboring_go123.go
+++ b/internal/fips140/notboring_go123.go
@@ -1,0 +1,9 @@
+//go:build !boringcrypto && !go1.24
+
+package fips140
+
+// Enabled reports whether the cryptography libraries are operating in FIPS
+// 140-3 mode.
+func Enabled() bool {
+	return false
+}

--- a/internal/qtls/cipher_suite_test.go
+++ b/internal/qtls/cipher_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/quic-go/quic-go/internal/fips140"
 	"github.com/quic-go/quic-go/internal/testdata"
 
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,9 @@ func TestCipherSuiteSelection(t *testing.T) {
 }
 
 func testCipherSuiteSelection(t *testing.T, cs uint16) {
+	if cs == tls.TLS_CHACHA20_POLY1305_SHA256 && fips140.Enabled() {
+		t.Skip("TLS_CHACHA20_POLY1305_SHA256 not available in FIPS mode")
+	}
 	reset := SetCipherSuite(cs)
 	defer reset()
 


### PR DESCRIPTION
Two easy test suite improvements to avoid blowing up when running in FIPS mode.

Hopefully this also lays down the basis for future NewGCM improvements per https://github.com/quic-go/quic-go/issues/4894#issuecomment-2793761639.
___
 * Replace RSA-1024 and Ed25519 test certs by P-256
    
    In FIPS mode, signing with RSA keys of 1024 bits and use of Ed25519 are
    not permitted, replace them by NIST P-256. This can also a little bit
    faster which might matter for fuzzing, but it is really insignificant.
    This fixes an explosion of errors while running:
    
        GODEBUG=fips140=on go test ./...
    
    This also fixes failures with `import _ "crypto/tls/fipsonly"` present:
    
        GOEXPERIMENT=boringcrypto go test ./...

 * Fix failing tests in FIPS mode due to TLS_CHACHA20_POLY1305_SHA256
    
    Skip disallowed cipher suite ChaCha20Poly1305 in FIPS mode. Tested with
    `GOEXPERIMENT=boringcrypto` (with `import _ "crypto/tls/fipsonly"`), and
    `GODEBUG=fips140=on`.
    
    `GODEBUG=fips140=only` still explodes for various reasons, including use
    of SHA-1 for fuzzing corpus filenames, and use of NewGCM as reported in
    https://github.com/quic-go/quic-go/issues/4894#issuecomment-2793761639

