### PR TITLE
use ed25519 instead of RSA in tests and examples

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,11 @@ linters:
             - '!$test'
           allow:
             - $gostd
+        rsa:
+          list-mode: original
+          deny:
+            - pkg: crypto/rsa
+              desc: "use crypto/ed25519 instead"
     misspell:
       ignore-rules:
         - ect

--- a/example/echo/echo.go
+++ b/example/echo/echo.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"log"
@@ -24,8 +23,7 @@ const message = "foobar"
 func main() {
 	go func() { log.Fatal(echoServer()) }()
 
-	err := clientMain()
-	if err != nil {
+	if err := clientMain(); err != nil {
 		panic(err)
 	}
 }
@@ -72,14 +70,12 @@ func clientMain() error {
 	defer stream.Close()
 
 	fmt.Printf("Client: Sending '%s'\n", message)
-	_, err = stream.Write([]byte(message))
-	if err != nil {
+	if _, err := stream.Write([]byte(message)); err != nil {
 		return err
 	}
 
 	buf := make([]byte, len(message))
-	_, err = io.ReadFull(stream, buf)
-	if err != nil {
+	if _, err := io.ReadFull(stream, buf); err != nil {
 		return err
 	}
 	fmt.Printf("Client: Got '%s'\n", buf)
@@ -97,24 +93,21 @@ func (w loggingWriter) Write(b []byte) (int, error) {
 
 // Setup a bare-bones TLS config for the server
 func generateTLSConfig() *tls.Config {
-	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		panic(err)
 	}
 	template := x509.Certificate{SerialNumber: big.NewInt(1)}
-	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
 	if err != nil {
 		panic(err)
 	}
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 
-	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		panic(err)
-	}
 	return &tls.Config{
-		Certificates: []tls.Certificate{tlsCert},
-		NextProtos:   []string{"quic-echo-example"},
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{certDER},
+			PrivateKey:  priv,
+		}},
+		NextProtos: []string{"quic-echo-example"},
 	}
 }

--- a/fuzzing/handshake/fuzz.go
+++ b/fuzzing/handshake/fuzz.go
@@ -2,8 +2,8 @@ package handshake
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -30,7 +30,7 @@ var (
 )
 
 func init() {
-	priv, err := rsa.GenerateKey(rand.Reader, 1024)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func init() {
 		log.Fatal(err)
 	}
 
-	privClient, err := rsa.GenerateKey(rand.Reader, 1024)
+	_, privClient, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/integrationtests/tools/crypto.go
+++ b/integrationtests/tools/crypto.go
@@ -4,7 +4,6 @@ import (
 	"crypto"
 	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -69,7 +68,7 @@ func GenerateLeafCert(ca *x509.Certificate, caPriv crypto.PrivateKey) (*x509.Cer
 // GenerateTLSConfigWithLongCertChain generates a tls.Config that uses a long certificate chain.
 // The Root CA used is the same as for the config returned from getTLSConfig().
 func GenerateTLSConfigWithLongCertChain(ca *x509.Certificate, caPrivateKey crypto.PrivateKey) (*tls.Config, error) {
-	const chainLen = 7
+	const chainLen = 16
 	certTempl := &x509.Certificate{
 		SerialNumber:          big.NewInt(2019),
 		Subject:               pkix.Name{},
@@ -83,13 +82,13 @@ func GenerateTLSConfigWithLongCertChain(ca *x509.Certificate, caPrivateKey crypt
 
 	lastCA := ca
 	lastCAPrivKey := caPrivateKey
-	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, err
 	}
 	certs := make([]*x509.Certificate, chainLen)
-	for i := 0; i < chainLen; i++ {
-		caBytes, err := x509.CreateCertificate(rand.Reader, certTempl, lastCA, &privKey.PublicKey, lastCAPrivKey)
+	for i := range chainLen {
+		caBytes, err := x509.CreateCertificate(rand.Reader, certTempl, lastCA, priv.Public(), lastCAPrivKey)
 		if err != nil {
 			return nil, err
 		}
@@ -99,7 +98,7 @@ func GenerateTLSConfigWithLongCertChain(ca *x509.Certificate, caPrivateKey crypt
 		}
 		certs[i] = ca
 		lastCA = ca
-		lastCAPrivKey = privKey
+		lastCAPrivKey = priv
 	}
 	leafCert, leafPrivateKey, err := GenerateLeafCert(lastCA, lastCAPrivKey)
 	if err != nil {

--- a/integrationtests/tools/crypto_test.go
+++ b/integrationtests/tools/crypto_test.go
@@ -1,0 +1,99 @@
+package tools
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type countingConn struct {
+	net.Conn
+	BytesReceived int
+}
+
+func (c *countingConn) Read(b []byte) (int, error) {
+	n, err := c.Conn.Read(b)
+	c.BytesReceived += n
+	return n, err
+}
+
+func TestGenerateTLSConfig(t *testing.T) {
+	ca, caPriv, err := GenerateCA()
+	require.NoError(t, err)
+	certPool := x509.NewCertPool()
+	certPool.AddCert(ca)
+	clientConf := &tls.Config{
+		ServerName: "localhost",
+		RootCAs:    certPool,
+	}
+
+	t.Run("short chain", func(t *testing.T) {
+		leaf, leafPriv, err := GenerateLeafCert(ca, caPriv)
+		require.NoError(t, err)
+
+		serverConf := &tls.Config{
+			Certificates: []tls.Certificate{{
+				Certificate: [][]byte{leaf.Raw},
+				PrivateKey:  leafPriv,
+			}},
+		}
+
+		bytesReceived := testGenerateTLSConfig(t, serverConf, clientConf)
+		t.Logf("bytes received: %d", bytesReceived)
+		require.Less(t, bytesReceived, 2000)
+	})
+
+	t.Run("long chain", func(t *testing.T) {
+		serverConf, err := GenerateTLSConfigWithLongCertChain(ca, caPriv)
+		require.NoError(t, err)
+
+		bytesReceived := testGenerateTLSConfig(t, serverConf, clientConf)
+		t.Logf("bytes received: %d", bytesReceived)
+		require.Greater(t, bytesReceived, 5000)
+	})
+}
+
+func testGenerateTLSConfig(t *testing.T, serverConf, clientConf *tls.Config) int {
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverConf)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	type result struct {
+		err error
+		msg string
+	}
+
+	resultChan := make(chan result, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			resultChan <- result{err: err}
+			return
+		}
+		defer conn.Close()
+		msg, err := io.ReadAll(conn)
+		resultChan <- result{err: err, msg: string(msg)}
+	}()
+
+	tcpConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer tcpConn.Close()
+	countingConn := &countingConn{Conn: tcpConn}
+
+	tlsConn := tls.Client(countingConn, clientConf)
+	require.NoError(t, tlsConn.Handshake())
+
+	_, err = tlsConn.Write([]byte("foobar"))
+	require.NoError(t, err)
+	require.NoError(t, tlsConn.Close())
+
+	res := <-resultChan
+	require.NoError(t, res.err)
+	require.Equal(t, "foobar", res.msg)
+
+	return countingConn.BytesReceived
+}

--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -2,8 +2,8 @@ package handshake
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -252,17 +252,17 @@ func TestHelloRetryRequest(t *testing.T) {
 }
 
 func TestWithClientAuth(t *testing.T) {
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)
 	tmpl := &x509.Certificate{
 		SerialNumber:          big.NewInt(1),
 		Subject:               pkix.Name{},
-		SignatureAlgorithm:    x509.SHA256WithRSA,
+		SignatureAlgorithm:    x509.PureEd25519,
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(time.Hour),
 		BasicConstraintsValid: true,
 	}
-	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, priv.Public(), priv)
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
 	require.NoError(t, err)
 	clientCert := tls.Certificate{
 		PrivateKey:  priv,


### PR DESCRIPTION
Also adds a golangci-lint depguard rules that forbids importing crypto/rsa.

As suggested by @Lekensteyn in #5048.