### PR TITLE
don't use net.Errors for streams map error

### DIFF
--- a/streams_map.go
+++ b/streams_map.go
@@ -2,9 +2,7 @@ package quic
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net"
 	"sync"
 
 	"github.com/quic-go/quic-go/internal/flowcontrol"
@@ -32,19 +30,6 @@ func convertStreamError(err error, stype protocol.StreamType, pers protocol.Pers
 		ids[i] = num.StreamID(stype, pers)
 	}
 	return fmt.Errorf(strError.Error(), ids...)
-}
-
-type streamOpenErr struct{ error }
-
-var _ net.Error = &streamOpenErr{}
-
-func (streamOpenErr) Timeout() bool   { return false }
-func (e streamOpenErr) Unwrap() error { return e.error }
-
-func (e streamOpenErr) Temporary() bool {
-	// In older versions of quic-go, the stream limit error was documented to be a net.Error.Temporary.
-	// This function was since deprecated, but we keep the existing behavior.
-	return errors.Is(e, &StreamLimitReachedError{})
 }
 
 // StreamLimitReachedError is returned from Connection.OpenStream and Connection.OpenUniStream

--- a/streams_map_outgoing.go
+++ b/streams_map_outgoing.go
@@ -58,7 +58,7 @@ func (m *outgoingStreamsMap[T]) OpenStream() (T, error) {
 	// if there are OpenStreamSync calls waiting, return an error here
 	if len(m.openQueue) > 0 || m.nextStream > m.maxStream {
 		m.maybeSendBlockedFrame()
-		return *new(T), streamOpenErr{&StreamLimitReachedError{}}
+		return *new(T), &StreamLimitReachedError{}
 	}
 	return m.openStream(), nil
 }

--- a/streams_map_test.go
+++ b/streams_map_test.go
@@ -275,20 +275,20 @@ func testStreamsMapStreamLimits(t *testing.T, perspective protocol.Perspective) 
 
 	// increase via transport parameters
 	_, err := m.OpenStream()
-	checkTooManyStreamsError(t, err)
+	require.ErrorIs(t, err, &StreamLimitReachedError{})
 	m.UpdateLimits(&wire.TransportParameters{MaxBidiStreamNum: 1})
 	_, err = m.OpenStream()
 	require.NoError(t, err)
 	_, err = m.OpenStream()
-	checkTooManyStreamsError(t, err)
+	require.ErrorIs(t, err, &StreamLimitReachedError{})
 
 	_, err = m.OpenUniStream()
-	checkTooManyStreamsError(t, err)
+	require.ErrorIs(t, err, &StreamLimitReachedError{})
 	m.UpdateLimits(&wire.TransportParameters{MaxUniStreamNum: 1})
 	_, err = m.OpenUniStream()
 	require.NoError(t, err)
 	_, err = m.OpenUniStream()
-	checkTooManyStreamsError(t, err)
+	require.ErrorIs(t, err, &StreamLimitReachedError{})
 
 	// increase via MAX_STREAMS frames
 	m.HandleMaxStreamsFrame(&wire.MaxStreamsFrame{
@@ -298,7 +298,7 @@ func testStreamsMapStreamLimits(t *testing.T, perspective protocol.Perspective) 
 	_, err = m.OpenStream()
 	require.NoError(t, err)
 	_, err = m.OpenStream()
-	checkTooManyStreamsError(t, err)
+	require.ErrorIs(t, err, &StreamLimitReachedError{})
 
 	m.HandleMaxStreamsFrame(&wire.MaxStreamsFrame{
 		Type:         protocol.StreamTypeUni,
@@ -307,12 +307,12 @@ func testStreamsMapStreamLimits(t *testing.T, perspective protocol.Perspective) 
 	_, err = m.OpenUniStream()
 	require.NoError(t, err)
 	_, err = m.OpenUniStream()
-	checkTooManyStreamsError(t, err)
+	require.ErrorIs(t, err, &StreamLimitReachedError{})
 
 	// decrease via transport parameters
 	m.UpdateLimits(&wire.TransportParameters{MaxBidiStreamNum: 0})
 	_, err = m.OpenStream()
-	checkTooManyStreamsError(t, err)
+	require.ErrorIs(t, err, &StreamLimitReachedError{})
 }
 
 func TestStreamsMapClosing(t *testing.T) {
@@ -411,5 +411,5 @@ func TestStreamsMap0RTTRejection(t *testing.T) {
 	m.UseResetMaps()
 	_, err = m.OpenStream()
 	require.Error(t, err)
-	checkTooManyStreamsError(t, err)
+	require.ErrorIs(t, err, &StreamLimitReachedError{})
 }


### PR DESCRIPTION
In older versions of quic-go, the error returned from `Open{Uni}Stream{Sync}` used to return a `net.Error`. We have been discouraging this by introducing a `StreamLimitReachedError` in https://github.com/quic-go/quic-go/pull/4579.