### PR TITLE
http3: update `Hijacker` and `HTTPStreamer` documentation

### DIFF
--- a/http3/body.go
+++ b/http3/body.go
@@ -9,7 +9,7 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-// A Hijacker allows hijacking of the stream creating part of a quic.Connection from a http.Response.Body.
+// A Hijacker allows hijacking of the stream creating part of a quic.Connection from a http.ResponseWriter.
 // It is used by WebTransport to create WebTransport streams after a session has been established.
 type Hijacker interface {
 	Connection() Connection

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -14,8 +14,7 @@ import (
 	"golang.org/x/net/http/httpguts"
 )
 
-// The HTTPStreamer allows taking over a HTTP/3 stream. The interface is implemented the http.Response.Body.
-// On the client side, the stream will be closed for writing, unless the DontCloseRequestStream RoundTripOpt was set.
+// The HTTPStreamer allows taking over a HTTP/3 stream. The interface is implemented by the http.ResponseWriter.
 // When a stream is taken over, it's the caller's responsibility to close the stream.
 type HTTPStreamer interface {
 	HTTPStream() Stream


### PR DESCRIPTION
Hi,

tl;dr: update documentation for `http3.Hijacker` and `http3.HTTPStreamer` to match API.

I was trying to get the hijacking to work with the current documentation and had trouble making it work. I soon realised that there was an API change (#4469 I think) and the documentation did not follow.

I also took the liberty to remove the mention of the now inexistant `DontCloseRequestStream` round tripper option.

Please let me know if I should rework some things.

