### PR TITLE
fix: parse ifindex from packet correctly

### DIFF
--- a/sys_conn_helper_darwin.go
+++ b/sys_conn_helper_darwin.go
@@ -30,7 +30,7 @@ func parseIPv4PktInfo(body []byte) (ip netip.Addr, ifIndex uint32, ok bool) {
 	if len(body) != 12 {
 		return netip.Addr{}, 0, false
 	}
-	return netip.AddrFrom4(*(*[4]byte)(body[8:12])), binary.LittleEndian.Uint32(body), true
+	return netip.AddrFrom4(*(*[4]byte)(body[8:12])), binary.NativeEndian.Uint32(body), true
 }
 
 func isGSOEnabled(syscall.RawConn) bool { return false }

--- a/sys_conn_helper_linux.go
+++ b/sys_conn_helper_linux.go
@@ -58,7 +58,7 @@ func parseIPv4PktInfo(body []byte) (ip netip.Addr, ifIndex uint32, ok bool) {
 	if len(body) != 12 {
 		return netip.Addr{}, 0, false
 	}
-	return netip.AddrFrom4(*(*[4]byte)(body[8:12])), binary.LittleEndian.Uint32(body), true
+	return netip.AddrFrom4(*(*[4]byte)(body[8:12])), binary.NativeEndian.Uint32(body), true
 }
 
 // isGSOEnabled tests if the kernel supports GSO.

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -222,7 +222,7 @@ func (c *oobConn) ReadPacket() (receivedPacket, error) {
 				// };
 				if len(body) == 20 {
 					p.info.addr = netip.AddrFrom16(*(*[16]byte)(body[:16])).Unmap()
-					p.info.ifIndex = binary.LittleEndian.Uint32(body[16:])
+					p.info.ifIndex = binary.NativeEndian.Uint32(body[16:])
 				} else {
 					invalidCmsgOnceV6.Do(func() {
 						log.Printf("Received invalid IPv6 packet info control message: %+x. "+


### PR DESCRIPTION
Updates #5088 

Now `ipi_ifindex` can be properly parsed from the packet.

I guess this probably won't affect `darwin`, since it seems they only build `small-endian` devices today, but it's decided at compile time anyway and doesn't introduce additional overhead.