### PR TITLE
http3: return http.ErrServerClosed for ServeQUICConn after Server.Close

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -264,6 +264,11 @@ func (s *Server) decreaseConnCount() {
 // ServeQUICConn serves a single QUIC connection.
 func (s *Server) ServeQUICConn(conn quic.Connection) error {
 	s.mutex.Lock()
+	if s.closed {
+		s.mutex.Unlock()
+		return http.ErrServerClosed
+	}
+
 	s.init()
 	s.mutex.Unlock()
 

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -883,6 +883,7 @@ var _ = Describe("Server", func() {
 		serv := &Server{}
 		Expect(serv.Close()).To(Succeed())
 		Expect(serv.ListenAndServeTLS(testdata.GetCertificatePaths())).To(MatchError(http.ErrServerClosed))
+		Expect(serv.ServeQUICConn(nil)).To(MatchError(http.ErrServerClosed))
 	})
 
 	It("handles concurrent Serve and Close", func() {


### PR DESCRIPTION
I discovered this when working on #5085.