### PR TITLE
fix dequeuing logic for tiny CRYPTO frames

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -826,7 +826,9 @@ func (s *connection) handleHandshakeComplete(now time.Time) error {
 	if ticket != nil { // may be nil if session tickets are disabled via tls.Config.SessionTicketsDisabled
 		s.oneRTTStream.Write(ticket)
 		for s.oneRTTStream.HasData() {
-			s.queueControlFrame(s.oneRTTStream.PopCryptoFrame(protocol.MaxPostHandshakeCryptoFrameSize))
+			if cf := s.oneRTTStream.PopCryptoFrame(protocol.MaxPostHandshakeCryptoFrameSize); cf != nil {
+				s.queueControlFrame(cf)
+			}
 		}
 	}
 	token, err := s.tokenGenerator.NewToken(s.conn.RemoteAddr())

--- a/crypto_stream.go
+++ b/crypto_stream.go
@@ -76,6 +76,9 @@ func (s *cryptoStream) HasData() bool {
 func (s *cryptoStream) PopCryptoFrame(maxLen protocol.ByteCount) *wire.CryptoFrame {
 	f := &wire.CryptoFrame{Offset: s.writeOffset}
 	n := min(f.MaxDataLen(maxLen), protocol.ByteCount(len(s.writeBuf)))
+	if n == 0 {
+		return nil
+	}
 	f.Data = s.writeBuf[:n]
 	s.writeBuf = s.writeBuf[n:]
 	s.writeOffset += n

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -561,9 +561,10 @@ func (p *packetPacker) maybeGetCryptoPacket(
 			maxPacketSize -= frameLen
 		}
 	} else if s.HasData() {
-		cf := s.PopCryptoFrame(maxPacketSize)
-		pl.frames = append(pl.frames, ackhandler.Frame{Frame: cf, Handler: handler})
-		pl.length += cf.Length(v)
+		if cf := s.PopCryptoFrame(maxPacketSize); cf != nil {
+			pl.frames = append(pl.frames, ackhandler.Frame{Frame: cf, Handler: handler})
+			pl.length += cf.Length(v)
+		}
 	}
 	return hdr, pl
 }


### PR DESCRIPTION
For very small sizes, `cryptoStream.PopCryptoStream` could have returned CRYPTO frames larger than the requested size.

Discovered while working on #4755.

Instead, it should return a `nil` frame.