### PR TITLE
fix ECN control messages on big-endian architectures

### DIFF
--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -332,7 +332,7 @@ func appendIPv6ECNMsg(b []byte, val protocol.ECN) []byte {
 	h.SetLen(unix.CmsgLen(dataLen))
 
 	// UnixRights uses the private `data` method, but I *think* this achieves the same goal.
-	dataPtr := unsafe.Pointer(uintptr(unsafe.Pointer(h)) + uintptr(unix.CmsgSpace(0)))
-	*(*int32)(dataPtr) = int32(val.ToHeaderBits())
+	offset := startLen + unix.CmsgSpace(0)
+	binary.NativeEndian.PutUint32(b[offset:offset+dataLen], uint32(val.ToHeaderBits()))
 	return b
 }

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -220,7 +220,7 @@ func (c *oobConn) ReadPacket() (receivedPacket, error) {
 				if len(body) != 4 {
 					return receivedPacket{}, errors.New("invalid IPV6_TCLASS size")
 				}
-				bits := byte(binary.NativeEndian.Uint32(body) & ecnMask)
+				bits := uint8(binary.NativeEndian.Uint32(body)) & ecnMask
 				p.ecn = protocol.ParseECNHeaderBits(bits)
 			case unix.IPV6_PKTINFO:
 				// struct in6_pktinfo {

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -317,8 +317,8 @@ func appendIPv4ECNMsg(b []byte, val protocol.ECN) []byte {
 	h.SetLen(unix.CmsgLen(ecnIPv4DataLen))
 
 	// UnixRights uses the private `data` method, but I *think* this achieves the same goal.
-	dataPtr := unsafe.Pointer(uintptr(unsafe.Pointer(h)) + uintptr(unix.CmsgSpace(0)))
-	*(*int32)(dataPtr) = int32(val.ToHeaderBits())
+	offset := startLen + unix.CmsgSpace(0)
+	b[offset] = val.ToHeaderBits()
 	return b
 }
 


### PR DESCRIPTION
This patch should fix the ECN issue on big-endian platforms.

Follow #5088