### PR TITLE
ci: set a 30 minute timeout for the interop Docker job

### DIFF
--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   interop:
     runs-on: ${{ fromJSON(vars['DOCKER_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU


### PR DESCRIPTION
I've seen this job time out after 6h, probably due to a deadlock somewhere in the Docker action step.

This job usually takes ~6 minutes, so a 30 minute timeout should be plenty.