### PR TITLE
ci: remove stray GITREF env from Docker interop workflow

### DIFF
--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -36,10 +36,8 @@ jobs:
         run: |
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             echo "tag=${GITHUB_REF#refs/tags/}" | tee -a $GITHUB_OUTPUT;
-            echo "gitref=${GITHUB_REF#refs/tags/}" | tee -a $GITHUB_OUTPUT;
           else
             echo 'tag=latest' | tee -a $GITHUB_OUTPUT;
-            echo 'gitref=${{ github.sha }}' | tee -a $GITHUB_OUTPUT;
           fi
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Apparently we forgot to remove this in #5115.