### PR TITLE
ci: only apply the interop Docker build concurrency group for pushes

### DIFF
--- a/.github/workflows/build-interop-docker.yml
+++ b/.github/workflows/build-interop-docker.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   interop:


### PR DESCRIPTION
There’s no risk that the uploaded Docker image gets overwritten for pull requests, since pull requests don’t upload the image.