### PR TITLE
pass ClientInfo to ConnContext, allow rejecting of handshakes

### DIFF
--- a/integrationtests/self/handshake_context_test.go
+++ b/integrationtests/self/handshake_context_test.go
@@ -165,7 +165,7 @@ func testConnContextRejection(t *testing.T, reject bool) {
 	pc := newUDPConnLocalhost(t)
 	c, err := quic.Dial(ctx, pc, server.Addr(), getTLSClientConfig(), getQuicConfig(nil))
 	if reject {
-		require.ErrorContains(t, err, "CONNECTION_REFUSED")
+		require.ErrorIs(t, err, &quic.TransportError{Remote: true, ErrorCode: quic.ConnectionRefused})
 		return
 	}
 	require.NoError(t, err)

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -597,7 +597,7 @@ func TestHTTPContextFromQUIC(t *testing.T) {
 	tr := &quic.Transport{
 		Conn: conn,
 		ConnContext: func(ctx context.Context, _ *quic.ClientInfo) (context.Context, error) {
-			return context.WithValue(ctx, "foo", "bar"), nil //nolint:staticcheck
+			return context.WithValue(ctx, "foo", "bar"), nil
 		},
 	}
 	defer tr.Close()

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -596,8 +596,8 @@ func TestHTTPContextFromQUIC(t *testing.T) {
 	conn := newUDPConnLocalhost(t)
 	tr := &quic.Transport{
 		Conn: conn,
-		ConnContext: func(ctx context.Context) context.Context {
-			return context.WithValue(ctx, "foo", "bar") //nolint:staticcheck
+		ConnContext: func(ctx context.Context, _ *quic.ClientInfo) (context.Context, error) {
+			return context.WithValue(ctx, "foo", "bar"), nil //nolint:staticcheck
 		},
 	}
 	defer tr.Close()

--- a/server.go
+++ b/server.go
@@ -82,7 +82,7 @@ type baseServer struct {
 	nextZeroRTTCleanup time.Time
 	zeroRTTQueues      map[protocol.ConnectionID]*zeroRTTQueue // only initialized if acceptEarlyConns == true
 
-	connContext func(context.Context) context.Context
+	connContext func(context.Context, *ClientInfo) (context.Context, error)
 
 	// set as a member, so they can be set in the tests
 	newConn func(
@@ -250,7 +250,7 @@ func newServer(
 	tr *Transport,
 	connIDGenerator ConnectionIDGenerator,
 	statelessResetter *statelessResetter,
-	connContext func(context.Context) context.Context,
+	connContext func(context.Context, *ClientInfo) (context.Context, error),
 	tlsConf *tls.Config,
 	config *Config,
 	tracer *logging.Tracer,
@@ -648,20 +648,15 @@ func (s *baseServer) handleInitialImpl(p receivedPacket, hdr *wire.Header) error
 	}
 
 	config := s.config
+	clientInfo := &ClientInfo{
+		RemoteAddr:   p.remoteAddr,
+		AddrVerified: clientAddrVerified,
+	}
 	if s.config.GetConfigForClient != nil {
-		conf, err := s.config.GetConfigForClient(&ClientInfo{
-			RemoteAddr:   p.remoteAddr,
-			AddrVerified: clientAddrVerified,
-		})
+		conf, err := s.config.GetConfigForClient(clientInfo)
 		if err != nil {
 			s.logger.Debugf("Rejecting new connection due to GetConfigForClient callback")
-			delete(s.zeroRTTQueues, hdr.DestConnectionID)
-			select {
-			case s.connectionRefusedQueue <- rejectedPacket{receivedPacket: p, hdr: hdr}:
-			default:
-				// drop packet if we can't send out the CONNECTION_REFUSED fast enough
-				p.buffer.Release()
-			}
+			s.refuseNewConn(p, hdr)
 			return nil
 		}
 		config = populateConfig(conf)
@@ -671,7 +666,14 @@ func (s *baseServer) handleInitialImpl(p receivedPacket, hdr *wire.Header) error
 	var cancel context.CancelCauseFunc
 	ctx, cancel1 := context.WithCancelCause(context.Background())
 	if s.connContext != nil {
-		ctx = s.connContext(ctx)
+		var err error
+		ctx, err = s.connContext(ctx, clientInfo)
+		if err != nil {
+			cancel1(err)
+			s.logger.Debugf("Rejecting new connection due to ConnContext callback: %s", err)
+			s.refuseNewConn(p, hdr)
+			return nil
+		}
 		if ctx == nil {
 			panic("quic: ConnContext returned nil")
 		}
@@ -747,6 +749,16 @@ func (s *baseServer) handleInitialImpl(p receivedPacket, hdr *wire.Header) error
 	}()
 	go conn.run()
 	return nil
+}
+
+func (s *baseServer) refuseNewConn(p receivedPacket, hdr *wire.Header) {
+	delete(s.zeroRTTQueues, hdr.DestConnectionID)
+	select {
+	case s.connectionRefusedQueue <- rejectedPacket{receivedPacket: p, hdr: hdr}:
+	default:
+		// drop packet if we can't send out the CONNECTION_REFUSED fast enough
+		p.buffer.Release()
+	}
 }
 
 func (s *baseServer) handleNewConn(conn quicConn) {

--- a/server_test.go
+++ b/server_test.go
@@ -66,7 +66,7 @@ func newTestServer(t *testing.T, serverOpts *serverOpts) *testServer {
 		&Transport{handlerMap: newPacketHandlerMap(nil, utils.DefaultLogger)},
 		&protocol.DefaultConnectionIDGenerator{},
 		&statelessResetter{},
-		func(ctx context.Context) context.Context { return ctx },
+		func(ctx context.Context, _ *ClientInfo) (context.Context, error) { return ctx, nil },
 		&tls.Config{},
 		config,
 		serverOpts.tracer,

--- a/transport.go
+++ b/transport.go
@@ -115,7 +115,8 @@ type Transport struct {
 	// implementation of this callback (negating its return value).
 	VerifySourceAddress func(net.Addr) bool
 
-	// ConnContext is called when the server accepts a new connection.
+	// ConnContext is called when the server accepts a new connection. To reject a connection return
+	// a non-nil error.
 	// The context is closed when the connection is closed, or when the handshake fails for any reason.
 	// The context returned from the callback is used to derive every other context used during the
 	// lifetime of the connection:
@@ -124,7 +125,7 @@ type Transport struct {
 	// * the context returned from Connection.Context
 	// * the context returned from SendStream.Context
 	// It is not used for dialed connections.
-	ConnContext func(context.Context) context.Context
+	ConnContext func(context.Context, *ClientInfo) (context.Context, error)
 
 	// A Tracer traces events that don't belong to a single QUIC connection.
 	// Tracer.Close is called when the transport is closed.


### PR DESCRIPTION
This allows users to set some state related to the client's remote address in `ConnContext`.

This also refuses connection early if the returned context is cancelled.

Fixes: #5013 

See https://github.com/libp2p/go-libp2p/pull/3283/ for the dependant go-libp2p change. 