### PR TITLE
remove stray assertion that handshakes are running from tests

### DIFF
--- a/integrationtests/self/self_test.go
+++ b/integrationtests/self/self_test.go
@@ -161,12 +161,6 @@ func newUDPConnLocalhost(t testing.TB) *net.UDPConn {
 	return conn
 }
 
-func areHandshakesRunning() bool {
-	var b bytes.Buffer
-	pprof.Lookup("goroutine").WriteTo(&b, 1)
-	return strings.Contains(b.String(), "RunHandshake")
-}
-
 func areTransportsRunning() bool {
 	var b bytes.Buffer
 	pprof.Lookup("goroutine").WriteTo(&b, 1)
@@ -193,10 +187,6 @@ func TestMain(m *testing.M) {
 	status := m.Run()
 	if status != 0 {
 		os.Exit(status)
-	}
-	if areHandshakesRunning() {
-		fmt.Println("stray handshake goroutines found")
-		os.Exit(1)
 	}
 	if areTransportsRunning() {
 		fmt.Println("stray transport goroutines found")

--- a/integrationtests/self/timeout_test.go
+++ b/integrationtests/self/timeout_test.go
@@ -498,8 +498,6 @@ func testFaultyPacketConn(t *testing.T, pers protocol.Perspective) {
 		require.True(t, nerr.Timeout())
 	}
 
-	require.Eventually(t, func() bool { return !areHandshakesRunning() }, 5*handshakeTimeout, 5*time.Millisecond)
-
 	select {
 	case serverErr := <-serverErrChan: // The handshake completed on the server side.
 		require.Error(t, serverErr)


### PR DESCRIPTION
The `RunHandshake` method this function was basing its assertion on was removed a long time ago.