### PR TITLE
http3: don't close QUIC listeners created by the application

### DIFF
--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -880,6 +880,18 @@ func TestServerConcurrentServeAndClose(t *testing.T) {
 	}
 }
 
+func TestServerImmediateGracefulShutdown(t *testing.T) {
+	s := &Server{TLSConfig: testdata.GetTLSConfig()}
+	errChan := make(chan error, 1)
+	go func() { errChan <- s.Shutdown(context.Background()) }()
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
 func TestServerGracefulShutdown(t *testing.T) {
 	s := &Server{TLSConfig: testdata.GetTLSConfig()}
 	s.init()

--- a/integrationtests/self/http_hotswap_test.go
+++ b/integrationtests/self/http_hotswap_test.go
@@ -1,12 +1,10 @@
 package self_test
 
 import (
-	"context"
 	"io"
 	"net"
 	"net/http"
 	"strconv"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,48 +12,6 @@ import (
 	"github.com/quic-go/quic-go/http3"
 	"github.com/stretchr/testify/require"
 )
-
-type listenerWrapper struct {
-	http3.QUICEarlyListener
-	listenerClosed bool
-	count          atomic.Int32
-}
-
-func (ln *listenerWrapper) Close() error {
-	ln.listenerClosed = true
-	return ln.QUICEarlyListener.Close()
-}
-
-func (ln *listenerWrapper) Faker() *fakeClosingListener {
-	ln.count.Add(1)
-	ctx, cancel := context.WithCancel(context.Background())
-	return &fakeClosingListener{
-		listenerWrapper: ln,
-		ctx:             ctx,
-		cancel:          cancel,
-	}
-}
-
-type fakeClosingListener struct {
-	*listenerWrapper
-	closed atomic.Bool
-	ctx    context.Context
-	cancel context.CancelFunc
-}
-
-func (ln *fakeClosingListener) Accept(ctx context.Context) (quic.EarlyConnection, error) {
-	return ln.listenerWrapper.Accept(ln.ctx)
-}
-
-func (ln *fakeClosingListener) Close() error {
-	if ln.closed.CompareAndSwap(false, true) {
-		ln.cancel()
-		if ln.count.Add(-1) == 0 {
-			ln.listenerWrapper.Close()
-		}
-	}
-	return nil
-}
 
 func TestHTTP3ServerHotswap(t *testing.T) {
 	mux1 := http.NewServeMux()
@@ -78,9 +34,8 @@ func TestHTTP3ServerHotswap(t *testing.T) {
 	}
 
 	tlsConf := http3.ConfigureTLSConfig(getTLSConfig())
-	quicLn, err := quic.ListenEarly(newUDPConnLocalhost(t), tlsConf, getQuicConfig(nil))
+	ln, err := quic.ListenEarly(newUDPConnLocalhost(t), tlsConf, getQuicConfig(nil))
 	require.NoError(t, err)
-	ln := &listenerWrapper{QUICEarlyListener: quicLn}
 	port := strconv.Itoa(ln.Addr().(*net.UDPAddr).Port)
 
 	rt := &http3.Transport{
@@ -96,12 +51,8 @@ func TestHTTP3ServerHotswap(t *testing.T) {
 	}()
 
 	// open first server and make single request to it
-	fake1 := ln.Faker()
-	stoppedServing1 := make(chan struct{})
-	go func() {
-		server1.ServeListener(fake1)
-		close(stoppedServing1)
-	}()
+	errChan1 := make(chan error, 1)
+	go func() { errChan1 <- server1.ServeListener(ln) }()
 
 	resp, err := client.Get("https://localhost:" + port + "/hello1")
 	require.NoError(t, err)
@@ -111,36 +62,29 @@ func TestHTTP3ServerHotswap(t *testing.T) {
 	require.Equal(t, "Hello, World 1!\n", string(body))
 
 	// open second server with same underlying listener
-	fake2 := ln.Faker()
-	stoppedServing2 := make(chan struct{})
-	go func() {
-		server2.ServeListener(fake2)
-		close(stoppedServing2)
-	}()
+	errChan2 := make(chan error, 1)
+	go func() { errChan2 <- server2.ServeListener(ln) }()
 
-	// Verify both servers are running by waiting a bit and checking channels aren't closed
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(scaleDuration(20 * time.Millisecond))
 	select {
-	case <-stoppedServing1:
-		t.Fatal("server1 stopped unexpectedly")
-	case <-stoppedServing2:
-		t.Fatal("server2 stopped unexpectedly")
+	case err := <-errChan1:
+		t.Fatalf("server1 stopped unexpectedly: %v", err)
+	case err := <-errChan2:
+		t.Fatalf("server2 stopped unexpectedly: %v", err)
 	default:
 	}
 
 	// now close first server
 	require.NoError(t, server1.Close())
 	select {
-	case <-stoppedServing1:
-	case <-time.After(time.Second):
+	case err := <-errChan1:
+		require.ErrorIs(t, err, http.ErrServerClosed)
+	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for server1 to stop")
 	}
-	require.True(t, fake1.closed.Load())
-	require.False(t, fake2.closed.Load())
-	require.False(t, ln.listenerClosed)
 	require.NoError(t, client.Transport.(*http3.Transport).Close())
 
-	// verify that new connections are being initiated from the second server now
+	// verify that new connections are handled by the second server now
 	resp, err = client.Get("https://localhost:" + port + "/hello2")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -148,13 +92,12 @@ func TestHTTP3ServerHotswap(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Hello, World 2!\n", string(body))
 
-	// close the other server - both the fake and the actual listeners must close now
+	// close the other server
 	require.NoError(t, server2.Close())
 	select {
-	case <-stoppedServing2:
+	case err := <-errChan2:
+		require.ErrorIs(t, err, http.ErrServerClosed)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for server2 to stop")
 	}
-	require.True(t, fake2.closed.Load())
-	require.True(t, ln.listenerClosed)
 }


### PR DESCRIPTION
Splitting this out of #5101.