### PR TITLE
fix flaky TestHandshakeCloseListener

### DIFF
--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -426,6 +426,8 @@ func testHandshakeCloseListener(t *testing.T, createListener func(*tls.Config) *
 	conn, err := quic.Dial(ctx, newUDPConnLocalhost(t), ln.Addr(), getTLSClientConfig(), getQuicConfig(nil))
 	require.NoError(t, err)
 	defer conn.CloseWithError(0, "")
+	_, err = ln.Accept(ctx)
+	require.NoError(t, err)
 
 	errChan := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
We need to accept the connection on the server side, otherwise it might still be stuck in the server's accept queue when the server is closed.