### PR TITLE
http3: only retry requests for which it is safe to do so

### DIFF
--- a/http3/transport.go
+++ b/http3/transport.go
@@ -204,8 +204,12 @@ func (t *Transport) roundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
 		}
 	}
 
-	trace := httptrace.ContextClientTrace(req.Context())
+	return t.doRoundTripOpt(req, opt, false)
+}
+
+func (t *Transport) doRoundTripOpt(req *http.Request, opt RoundTripOpt, isRetried bool) (*http.Response, error) {
 	hostname := authorityAddr(hostnameFromURL(req.URL))
+	trace := httptrace.ContextClientTrace(req.Context())
 	traceGetConn(trace, hostname)
 	cl, isReused, err := t.getClient(req.Context(), hostname, opt.OnlyCachedConn)
 	if err != nil {
@@ -222,8 +226,8 @@ func (t *Transport) roundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
 		t.removeClient(hostname)
 		return nil, cl.dialErr
 	}
-	traceGotConn(trace, cl.conn, isReused)
 	defer cl.useCount.Add(-1)
+	traceGotConn(trace, cl.conn, isReused)
 	rsp, err := cl.clientConn.RoundTrip(req)
 	if err != nil {
 		// request aborted due to context cancellation
@@ -232,26 +236,49 @@ func (t *Transport) roundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Res
 			return nil, err
 		default:
 		}
-
-		// Retry the request on a new connection if:
-		// 1. it was sent on a reused connection,
-		// 2. this connection is now closed,
-		// 3. and the error is a timeout error.
-		select {
-		case <-cl.conn.Context().Done():
-			t.removeClient(hostname)
-			if isReused {
-				var nerr net.Error
-				if errors.As(err, &nerr) && nerr.Timeout() {
-					return t.RoundTripOpt(req, opt)
-				}
-			}
-			return nil, err
-		default:
+		if isRetried {
 			return nil, err
 		}
+
+		t.removeClient(hostname)
+		req, err = canRetryRequest(err, req)
+		if err != nil {
+			return nil, err
+		}
+		return t.doRoundTripOpt(req, opt, true)
 	}
 	return rsp, nil
+}
+
+func canRetryRequest(err error, req *http.Request) (*http.Request, error) {
+	// error occurred while opening the stream, we can be sure that the request wasn't sent out
+	var connErr *errConnUnusable
+	if errors.As(err, &connErr) {
+		return req, nil
+	}
+
+	// If the request stream is reset, we can only be sure that the request wasn't processed
+	// if the error code is H3_REQUEST_REJECTED.
+	var e *Error
+	if !errors.As(err, &e) || e.ErrorCode != ErrCodeRequestRejected {
+		return nil, err
+	}
+	// if the body is nil (or http.NoBody), it's safe to reuse this request and its body
+	if req.Body == nil || req.Body == http.NoBody {
+		return req, nil
+	}
+	// if the request body can be reset back to its original state via req.GetBody, do that
+	if req.GetBody != nil {
+		newBody, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		reqCopy := *req
+		reqCopy.Body = newBody
+		req = &reqCopy
+		return &reqCopy, nil
+	}
+	return nil, fmt.Errorf("http3: Transport: cannot retry err [%w] after Request.Body was written; define Request.GetBody to avoid this error", err)
 }
 
 // RoundTrip does a round trip.


### PR DESCRIPTION
Fixes #4612.

This PR implements the logic outlined in https://github.com/quic-go/quic-go/issues/4612#issuecomment-2875107997. It is safe to retry a request if:
* an error that happen while opening the stream: if we can't open the stream, we obviously can't have sent the request
* the server reset the request stream using a H3_REQUEST_REJECTED error

Once we implement the client-side of graceful shutdown (#5083), we can also apply this logic to all streams with stream IDs higher than the stream ID sent in the GOAWAY frame.
