### PR TITLE
http3: implement client-side GOAWAY handling

### DIFF
--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -306,6 +306,9 @@ func testClientExtendedConnect(t *testing.T, enabled bool) {
 	controlStr := mockquic.NewMockStream(mockCtrl)
 	controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
 		<-allowSettings
+		if r.Len() == 0 {
+			<-done
+		}
 		return r.Read(b)
 	}).AnyTimes()
 	conn.EXPECT().AcceptUniStream(gomock.Any()).Return(controlStr, nil)

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -2,6 +2,7 @@ package http3
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -18,6 +19,8 @@ import (
 
 	"github.com/quic-go/qpack"
 )
+
+var errGoAway = errors.New("connection in graceful shutdown")
 
 // Connection is an HTTP/3 connection.
 // It has all methods from the quic.Connection expect for AcceptStream, AcceptUniStream,
@@ -50,8 +53,10 @@ type connection struct {
 
 	decoder *qpack.Decoder
 
-	streamMx sync.Mutex
-	streams  map[protocol.StreamID]*datagrammer
+	streamMx     sync.Mutex
+	streams      map[protocol.StreamID]*datagrammer
+	lastStreamID protocol.StreamID
+	maxStreamID  protocol.StreamID
 
 	settings         *Settings
 	receivedSettings chan struct{}
@@ -78,6 +83,8 @@ func newConnection(
 		decoder:          qpack.NewDecoder(func(hf qpack.HeaderField) {}),
 		receivedSettings: make(chan struct{}),
 		streams:          make(map[protocol.StreamID]*datagrammer),
+		maxStreamID:      protocol.InvalidStreamID,
+		lastStreamID:     protocol.InvalidStreamID,
 	}
 	if idleTimeout > 0 {
 		c.idleTimer = time.AfterFunc(idleTimeout, c.onIdleTimer)
@@ -97,6 +104,13 @@ func (c *connection) clearStream(id quic.StreamID) {
 	if c.idleTimeout > 0 && len(c.streams) == 0 {
 		c.idleTimer.Reset(c.idleTimeout)
 	}
+	// The server is performing a graceful shutdown.
+	// If no more streams are remaining, close the connection.
+	if c.maxStreamID != protocol.InvalidStreamID {
+		if len(c.streams) == 0 {
+			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
+		}
+	}
 }
 
 func (c *connection) openRequestStream(
@@ -106,6 +120,14 @@ func (c *connection) openRequestStream(
 	disableCompression bool,
 	maxHeaderBytes uint64,
 ) (*requestStream, error) {
+	c.streamMx.Lock()
+	maxStreamID := c.maxStreamID
+	lastStreamID := c.lastStreamID
+	c.streamMx.Unlock()
+	if maxStreamID != protocol.InvalidStreamID && lastStreamID >= maxStreamID {
+		return nil, errGoAway
+	}
+
 	str, err := c.OpenStreamSync(ctx)
 	if err != nil {
 		return nil, err
@@ -113,6 +135,7 @@ func (c *connection) openRequestStream(
 	datagrams := newDatagrammer(func(b []byte) error { return c.sendDatagram(str.StreamID(), b) })
 	c.streamMx.Lock()
 	c.streams[str.StreamID()] = datagrams
+	c.lastStreamID = str.StreamID()
 	c.streamMx.Unlock()
 	qstr := newStateTrackingStream(str, c, datagrams)
 	rsp := &http.Response{}
@@ -244,41 +267,94 @@ func (c *connection) handleUnidirectionalStreams(hijack func(StreamType, quic.Co
 				c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeStreamCreationError), "duplicate control stream")
 				return
 			}
-			fp := &frameParser{conn: c.Connection, r: str}
-			f, err := fp.ParseNext()
-			if err != nil {
-				c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameError), "")
-				return
-			}
-			sf, ok := f.(*settingsFrame)
-			if !ok {
-				c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeMissingSettings), "")
-				return
-			}
-			c.settings = &Settings{
-				EnableDatagrams:       sf.Datagram,
-				EnableExtendedConnect: sf.ExtendedConnect,
-				Other:                 sf.Other,
-			}
-			close(c.receivedSettings)
-			if !sf.Datagram {
-				return
-			}
-			// If datagram support was enabled on our side as well as on the server side,
-			// we can expect it to have been negotiated both on the transport and on the HTTP/3 layer.
-			// Note: ConnectionState() will block until the handshake is complete (relevant when using 0-RTT).
-			if c.enableDatagrams && !c.ConnectionState().SupportsDatagrams {
-				c.CloseWithError(quic.ApplicationErrorCode(ErrCodeSettingsError), "missing QUIC Datagram support")
-				return
-			}
-			go func() {
-				if err := c.receiveDatagrams(); err != nil {
-					if c.logger != nil {
-						c.logger.Debug("receiving datagrams failed", "error", err)
-					}
-				}
-			}()
+			c.handleControlStream(str)
 		}(str)
+	}
+}
+
+func (c *connection) handleControlStream(str quic.ReceiveStream) {
+	fp := &frameParser{conn: c.Connection, r: str}
+	f, err := fp.ParseNext()
+	if err != nil {
+		var serr *quic.StreamError
+		if err == io.EOF || errors.As(err, &serr) {
+			c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeClosedCriticalStream), "")
+			return
+		}
+		c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameError), "")
+		return
+	}
+	sf, ok := f.(*settingsFrame)
+	if !ok {
+		c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeMissingSettings), "")
+		return
+	}
+	c.settings = &Settings{
+		EnableDatagrams:       sf.Datagram,
+		EnableExtendedConnect: sf.ExtendedConnect,
+		Other:                 sf.Other,
+	}
+	close(c.receivedSettings)
+	if sf.Datagram {
+		// If datagram support was enabled on our side as well as on the server side,
+		// we can expect it to have been negotiated both on the transport and on the HTTP/3 layer.
+		// Note: ConnectionState() will block until the handshake is complete (relevant when using 0-RTT).
+		if c.enableDatagrams && !c.ConnectionState().SupportsDatagrams {
+			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeSettingsError), "missing QUIC Datagram support")
+			return
+		}
+		go func() {
+			if err := c.receiveDatagrams(); err != nil {
+				if c.logger != nil {
+					c.logger.Debug("receiving datagrams failed", "error", err)
+				}
+			}
+		}()
+	}
+
+	// we don't support server push, hence we don't expect any GOAWAY frames from the client
+	if c.perspective == protocol.PerspectiveServer {
+		return
+	}
+
+	for {
+		f, err := fp.ParseNext()
+		if err != nil {
+			var serr *quic.StreamError
+			if err == io.EOF || errors.As(err, &serr) {
+				c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeClosedCriticalStream), "")
+				return
+			}
+			c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameError), "")
+			return
+		}
+		// GOAWAY is the only frame allowed at this point:
+		// * unexpected frames are ignored by the frame parser
+		// * we don't support any extension that might add support for more frames
+		goaway, ok := f.(*goAwayFrame)
+		if !ok {
+			c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
+			return
+		}
+		if goaway.StreamID%4 != 0 { // client-initiated, bidirectional streams
+			c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
+			return
+		}
+		c.streamMx.Lock()
+		if c.maxStreamID != protocol.InvalidStreamID && goaway.StreamID > c.maxStreamID {
+			c.streamMx.Unlock()
+			c.Connection.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
+			return
+		}
+		c.maxStreamID = goaway.StreamID
+		hasActiveStreams := len(c.streams) > 0
+		c.streamMx.Unlock()
+
+		// immediately close the connection if there are currently no active requests
+		if !hasActiveStreams {
+			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "")
+			return
+		}
 	}
 }
 

--- a/http3/conn_test.go
+++ b/http3/conn_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -149,35 +150,96 @@ func TestConnResetUnknownUniStream(t *testing.T) {
 }
 
 func TestConnControlStreamFailures(t *testing.T) {
-	t.Run("missing settings", func(t *testing.T) {
-		testConnControlStreamFailures(t, (&dataFrame{}).Append(nil), ErrCodeMissingSettings)
+	t.Run("missing SETTINGS", func(t *testing.T) {
+		testConnControlStreamFailures(t, (&dataFrame{}).Append(nil), nil, ErrCodeMissingSettings)
 	})
 	t.Run("frame error", func(t *testing.T) {
 		testConnControlStreamFailures(t,
+			// 1337 is invalid value for the Extended CONNECT setting
 			(&settingsFrame{Other: map[uint64]uint64{settingExtendedConnect: 1337}}).Append(nil),
+			nil,
 			ErrCodeFrameError,
+		)
+	})
+	t.Run("control stream closed before SETTINGS", func(t *testing.T) {
+		testConnControlStreamFailures(t, nil, io.EOF, ErrCodeClosedCriticalStream)
+	})
+	t.Run("control stream reset before SETTINGS", func(t *testing.T) {
+		testConnControlStreamFailures(t,
+			nil,
+			&quic.StreamError{Remote: true, ErrorCode: 42},
+			ErrCodeClosedCriticalStream,
 		)
 	})
 }
 
-func testConnControlStreamFailures(t *testing.T, data []byte, expectedErr ErrCode) {
+func TestConnGoAwayFailures(t *testing.T) {
+	t.Run("invalid frame", func(t *testing.T) {
+		b := (&settingsFrame{}).Append(nil)
+		// 1337 is invalid value for the Extended CONNECT setting
+		b = (&settingsFrame{Other: map[uint64]uint64{settingExtendedConnect: 1337}}).Append(b)
+		testConnControlStreamFailures(t, b, nil, ErrCodeFrameError)
+	})
+	t.Run("not a GOAWAY", func(t *testing.T) {
+		b := (&settingsFrame{}).Append(nil)
+		// GOAWAY is the only allowed frame type after SETTINGS
+		b = (&headersFrame{}).Append(b)
+		testConnControlStreamFailures(t, b, nil, ErrCodeFrameUnexpected)
+	})
+	t.Run("stream closed before GOAWAY", func(t *testing.T) {
+		testConnControlStreamFailures(t, (&settingsFrame{}).Append(nil), io.EOF, ErrCodeClosedCriticalStream)
+	})
+	t.Run("stream reset before GOAWAY", func(t *testing.T) {
+		testConnControlStreamFailures(t,
+			(&settingsFrame{}).Append(nil),
+			&quic.StreamError{Remote: true, ErrorCode: 42},
+			ErrCodeClosedCriticalStream,
+		)
+	})
+	t.Run("invalid stream ID", func(t *testing.T) {
+		data := (&settingsFrame{}).Append(nil)
+		data = (&goAwayFrame{StreamID: 1}).Append(data)
+		testConnControlStreamFailures(t, data, nil, ErrCodeIDError)
+	})
+	t.Run("increased stream ID", func(t *testing.T) {
+		data := (&settingsFrame{}).Append(nil)
+		data = (&goAwayFrame{StreamID: 4}).Append(data)
+		data = (&goAwayFrame{StreamID: 8}).Append(data)
+		testConnControlStreamFailures(t, data, nil, ErrCodeIDError)
+	})
+}
+
+func testConnControlStreamFailures(t *testing.T, data []byte, readErr error, expectedErr ErrCode) {
 	mockCtrl := gomock.NewController(t)
 	qconn := mockquic.NewMockEarlyConnection(mockCtrl)
 	conn := newConnection(
 		context.Background(),
 		qconn,
 		false,
-		protocol.PerspectiveServer,
+		protocol.PerspectiveClient,
 		nil,
 		0,
 	)
 	b := quicvarint.Append(nil, streamTypeControlStream)
 	b = append(b, data...)
+	r := bytes.NewReader(b)
 	controlStr := mockquic.NewMockStream(mockCtrl)
-	controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(bytes.NewReader(b).Read).AnyTimes()
+	controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
+		if r.Len() == 0 {
+			return 0, readErr
+		}
+		return r.Read(b)
+	}).AnyTimes()
 	qconn.EXPECT().AcceptUniStream(gomock.Any()).Return(controlStr, nil)
 	qconn.EXPECT().AcceptUniStream(gomock.Any()).Return(nil, errors.New("test done"))
 	closed := make(chan struct{})
+
+	str := mockquic.NewMockStream(mockCtrl)
+	str.EXPECT().StreamID().Return(4).AnyTimes()
+	str.EXPECT().Context().Return(context.Background()).AnyTimes()
+	qconn.EXPECT().OpenStreamSync(gomock.Any()).Return(str, nil)
+	conn.openRequestStream(context.Background(), nil, nil, true, 1000)
+
 	qconn.EXPECT().CloseWithError(quic.ApplicationErrorCode(expectedErr), gomock.Any()).Do(func(quic.ApplicationErrorCode, string) error {
 		close(closed)
 		return nil
@@ -196,6 +258,88 @@ func testConnControlStreamFailures(t *testing.T, data []byte, expectedErr ErrCod
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
+	}
+}
+
+func TestConnGoAway(t *testing.T) {
+	t.Run("no active streams", func(t *testing.T) {
+		testConnGoAway(t, false)
+	})
+	t.Run("active stream", func(t *testing.T) {
+		testConnGoAway(t, true)
+	})
+}
+
+func testConnGoAway(t *testing.T, withStream bool) {
+	mockCtrl := gomock.NewController(t)
+	qconn := mockquic.NewMockEarlyConnection(mockCtrl)
+	conn := newConnection(
+		context.Background(),
+		qconn,
+		false,
+		protocol.PerspectiveClient,
+		nil,
+		0,
+	)
+	b := quicvarint.Append(nil, streamTypeControlStream)
+	b = (&settingsFrame{}).Append(b)
+	b = (&goAwayFrame{StreamID: 4}).Append(b)
+
+	var mockStr *mockquic.MockStream
+	var str quic.Stream
+	if withStream {
+		mockStr = mockquic.NewMockStream(mockCtrl)
+		mockStr.EXPECT().StreamID().Return(4).AnyTimes()
+		mockStr.EXPECT().Context().Return(context.Background()).AnyTimes()
+		qconn.EXPECT().OpenStreamSync(gomock.Any()).Return(mockStr, nil)
+		s, err := conn.openRequestStream(context.Background(), nil, nil, true, 1000)
+		require.NoError(t, err)
+		str = s
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+	r := bytes.NewReader(b)
+	controlStr := mockquic.NewMockStream(mockCtrl)
+	controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
+		if r.Len() == 0 {
+			<-done
+			return 0, errors.New("test done")
+		}
+		return r.Read(b)
+	}).AnyTimes()
+	qconn.EXPECT().AcceptUniStream(gomock.Any()).Return(controlStr, nil)
+	qconn.EXPECT().AcceptUniStream(gomock.Any()).Return(nil, errors.New("test done"))
+	closed := make(chan struct{})
+	qconn.EXPECT().CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), gomock.Any()).Do(func(quic.ApplicationErrorCode, string) error {
+		close(closed)
+		return nil
+	})
+	// duplicate calls to CloseWithError are a no-op
+	qconn.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).AnyTimes()
+	go conn.handleUnidirectionalStreams(nil)
+
+	// the connection should be closed after the stream is closed
+	if withStream {
+		select {
+		case <-closed:
+			t.Fatal("connection closed")
+		case <-time.After(scaleDuration(10 * time.Millisecond)):
+		}
+
+		_, err := conn.openRequestStream(context.Background(), nil, nil, true, 1000)
+		require.ErrorIs(t, err, errGoAway)
+
+		mockStr.EXPECT().Close()
+		str.Close()
+		mockStr.EXPECT().CancelRead(gomock.Any())
+		str.CancelRead(1337)
+	}
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for close")
 	}
 }
 
@@ -299,8 +443,16 @@ func TestConnSendAndReceiveDatagram(t *testing.T) {
 	)
 	b := quicvarint.Append(nil, streamTypeControlStream)
 	b = (&settingsFrame{Datagram: true}).Append(b)
+	r := bytes.NewReader(b)
+	done := make(chan struct{})
+	defer close(done)
 	controlStr := mockquic.NewMockStream(mockCtrl)
-	controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(bytes.NewReader(b).Read).AnyTimes()
+	controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
+		if r.Len() == 0 {
+			<-done
+		}
+		return r.Read(b)
+	}).AnyTimes()
 	qconn.EXPECT().AcceptUniStream(gomock.Any()).Return(controlStr, nil).MaxTimes(1)
 	qconn.EXPECT().AcceptUniStream(gomock.Any()).Return(nil, errors.New("test done")).MaxTimes(1)
 	qconn.EXPECT().ConnectionState().Return(quic.ConnectionState{SupportsDatagrams: true}).MaxTimes(1)
@@ -351,6 +503,8 @@ func TestConnSendAndReceiveDatagram(t *testing.T) {
 	expected = append(expected, []byte("foobaz")...)
 	qconn.EXPECT().SendDatagram(expected).Return(assert.AnError)
 	require.ErrorIs(t, conn.sendDatagram(strID2, []byte("foobaz")), assert.AnError)
+
+	qconn.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).AnyTimes()
 }
 
 func TestConnDatagramFailures(t *testing.T) {
@@ -376,18 +530,24 @@ func testConnDatagramFailures(t *testing.T, datagram []byte) {
 	b := quicvarint.Append(nil, streamTypeControlStream)
 	b = (&settingsFrame{Datagram: true}).Append(b)
 	r := bytes.NewReader(b)
+	done := make(chan struct{})
 	controlStr := mockquic.NewMockStream(mockCtrl)
-	controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(r.Read).AnyTimes()
+	controlStr.EXPECT().Read(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {
+		if r.Len() == 0 {
+			<-done
+		}
+		return r.Read(b)
+	}).AnyTimes()
 	qconn.EXPECT().AcceptUniStream(gomock.Any()).Return(controlStr, nil).MaxTimes(1)
 	qconn.EXPECT().AcceptUniStream(gomock.Any()).Return(nil, errors.New("test done")).MaxTimes(1)
 	qconn.EXPECT().ConnectionState().Return(quic.ConnectionState{SupportsDatagrams: true}).MaxTimes(1)
 
 	qconn.EXPECT().ReceiveDatagram(gomock.Any()).Return(datagram, nil)
-	done := make(chan struct{})
 	qconn.EXPECT().CloseWithError(qerr.ApplicationErrorCode(ErrCodeDatagramError), gomock.Any()).Do(func(qerr.ApplicationErrorCode, string) error {
 		close(done)
 		return nil
 	})
+	qconn.EXPECT().CloseWithError(gomock.Any(), gomock.Any()).AnyTimes() // further calls to CloseWithError are a no-op
 	go func() { conn.handleUnidirectionalStreams(nil) }()
 	select {
 	case <-done:


### PR DESCRIPTION
Fixes #5083. This is also the last missing piece to fully support graceful shutdown, so it also fixes #153.

When receiving a GOAWAY frame, the client:
* immediately closes the connection if there are no active requests
* refuses to open streams with stream IDs larger than the stream ID in the GOAWAY frame
* closes the connection once the stream count drops to zero