### PR TITLE
http3: reset request stream if the server sends too many 1xx responses

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -345,6 +345,8 @@ func (c *ClientConn) doRequest(req *http.Request, str *requestStream) (*http.Res
 		if is1xxNonTerminal {
 			num1xx++
 			if num1xx > max1xxResponses {
+				str.CancelRead(quic.StreamErrorCode(ErrCodeExcessiveLoad))
+				str.CancelWrite(quic.StreamErrorCode(ErrCodeExcessiveLoad))
 				return nil, errors.New("http3: too many 1xx informational responses")
 			}
 			traceGot1xxResponse(trace, resCode, textproto.MIMEHeader(res.Header))

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -412,6 +412,10 @@ func testClient1xxHandling(t *testing.T, numEarlyHints int, terminalStatus int, 
 	str.EXPECT().Write(gomock.Any()).DoAndReturn(buf.Write).AnyTimes()
 	str.EXPECT().Close()
 	str.EXPECT().Read(gomock.Any()).DoAndReturn(bytes.NewReader(rspBytes).Read).AnyTimes()
+	if tooMany {
+		str.EXPECT().CancelRead(quic.StreamErrorCode(ErrCodeExcessiveLoad))
+		str.EXPECT().CancelWrite(quic.StreamErrorCode(ErrCodeExcessiveLoad))
+	}
 	conn.EXPECT().OpenStreamSync(gomock.Any()).Return(str, nil)
 
 	cc := (&Transport{}).NewClientConn(conn)


### PR DESCRIPTION
Fixes #5131.

Not sure if H3_EXCESSIVE_LOAD is the most appropriate error code, but the others seem even less applicable.