### PR TITLE
http3: migrate the state tracking stream tests away from Ginkgo

### DIFF
--- a/http3/http3_helper_test.go
+++ b/http3/http3_helper_test.go
@@ -7,16 +7,8 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 )
-
-func TestHttp3(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "HTTP/3 Suite")
-}
 
 func newUDPConnLocalhost(t testing.TB) *net.UDPConn {
 	t.Helper()
@@ -25,16 +17,6 @@ func newUDPConnLocalhost(t testing.TB) *net.UDPConn {
 	t.Cleanup(func() { conn.Close() })
 	return conn
 }
-
-var mockCtrl *gomock.Controller
-
-var _ = BeforeEach(func() {
-	mockCtrl = gomock.NewController(GinkgoT())
-})
-
-var _ = AfterEach(func() {
-	mockCtrl.Finish()
-})
 
 func scaleDuration(t time.Duration) time.Duration {
 	scaleFactor := 1

--- a/http3/state_tracking_stream_test.go
+++ b/http3/state_tracking_stream_test.go
@@ -6,280 +6,16 @@ import (
 	"errors"
 	"io"
 	"os"
+	"testing"
+	"time"
 
 	"github.com/quic-go/quic-go"
 	mockquic "github.com/quic-go/quic-go/internal/mocks/quic"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
-
-var someStreamID = quic.StreamID(12)
-
-var _ = Describe("State Tracking Stream", func() {
-	It("recognizes when the receive side is closed", func() {
-		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
-		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-
-		var (
-			clearer mockStreamClearer
-			setter  mockErrorSetter
-			str     = newStateTrackingStream(qstr, &clearer, &setter)
-		)
-
-		buf := bytes.NewBuffer([]byte("foobar"))
-		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
-		for i := 0; i < 3; i++ {
-			_, err := str.Read([]byte{0})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(clearer.cleared).To(BeNil())
-			Expect(setter.recvErrs).To(BeEmpty())
-			Expect(setter.sendErrs).To(BeEmpty())
-		}
-		_, err := io.ReadAll(str)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(HaveLen(1))
-		Expect(setter.recvErrs[0]).To(Equal(io.EOF))
-		Expect(setter.sendErrs).To(BeEmpty())
-	})
-
-	It("recognizes local read cancellations", func() {
-		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
-		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-
-		var (
-			clearer mockStreamClearer
-			setter  mockErrorSetter
-			str     = newStateTrackingStream(qstr, &clearer, &setter)
-		)
-
-		buf := bytes.NewBuffer([]byte("foobar"))
-		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
-		qstr.EXPECT().CancelRead(quic.StreamErrorCode(1337))
-		_, err := str.Read(make([]byte, 3))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(BeEmpty())
-		Expect(setter.sendErrs).To(BeEmpty())
-
-		str.CancelRead(1337)
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(HaveLen(1))
-		Expect(setter.recvErrs[0]).To(Equal(&quic.StreamError{StreamID: someStreamID, ErrorCode: 1337}))
-		Expect(setter.sendErrs).To(BeEmpty())
-	})
-
-	It("recognizes remote cancellations", func() {
-		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
-		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-
-		var (
-			clearer mockStreamClearer
-			setter  mockErrorSetter
-			str     = newStateTrackingStream(qstr, &clearer, &setter)
-		)
-
-		testErr := errors.New("test error")
-		qstr.EXPECT().Read(gomock.Any()).Return(0, testErr)
-		_, err := str.Read(make([]byte, 3))
-		Expect(err).To(MatchError(testErr))
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(HaveLen(1))
-		Expect(setter.recvErrs[0]).To(Equal(testErr))
-		Expect(setter.sendErrs).To(BeEmpty())
-	})
-
-	It("doesn't misinterpret read deadline errors", func() {
-		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
-		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-
-		var (
-			clearer mockStreamClearer
-			setter  mockErrorSetter
-			str     = newStateTrackingStream(qstr, &clearer, &setter)
-		)
-
-		qstr.EXPECT().Read(gomock.Any()).Return(0, os.ErrDeadlineExceeded)
-		_, err := str.Read(make([]byte, 3))
-		Expect(err).To(MatchError(os.ErrDeadlineExceeded))
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(BeEmpty())
-		Expect(setter.sendErrs).To(BeEmpty())
-	})
-
-	It("recognizes when the send side is closed, when write errors", func() {
-		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
-		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-
-		var (
-			clearer mockStreamClearer
-			setter  mockErrorSetter
-			str     = newStateTrackingStream(qstr, &clearer, &setter)
-		)
-
-		testErr := errors.New("test error")
-		qstr.EXPECT().Write([]byte("foo")).Return(3, nil)
-		qstr.EXPECT().Write([]byte("bar")).Return(0, testErr)
-
-		_, err := str.Write([]byte("foo"))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(BeEmpty())
-		Expect(setter.sendErrs).To(BeEmpty())
-
-		_, err = str.Write([]byte("bar"))
-		Expect(err).To(MatchError(testErr))
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(BeEmpty())
-		Expect(setter.sendErrs).To(HaveLen(1))
-		Expect(setter.sendErrs[0]).To(Equal(testErr))
-	})
-
-	It("recognizes when the send side is closed, when write errors", func() {
-		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
-		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-
-		var (
-			clearer mockStreamClearer
-			setter  mockErrorSetter
-			str     = newStateTrackingStream(qstr, &clearer, &setter)
-		)
-
-		qstr.EXPECT().Write([]byte("foo")).Return(0, os.ErrDeadlineExceeded)
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(BeEmpty())
-		Expect(setter.sendErrs).To(BeEmpty())
-
-		_, err := str.Write([]byte("foo"))
-		Expect(err).To(MatchError(os.ErrDeadlineExceeded))
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(BeEmpty())
-		Expect(setter.sendErrs).To(BeEmpty())
-	})
-
-	It("recognizes when the send side is closed, when CancelWrite is called", func() {
-		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
-		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-
-		var (
-			clearer mockStreamClearer
-			setter  mockErrorSetter
-			str     = newStateTrackingStream(qstr, &clearer, &setter)
-		)
-
-		qstr.EXPECT().Write(gomock.Any())
-		qstr.EXPECT().CancelWrite(quic.StreamErrorCode(1337))
-		_, err := str.Write([]byte("foobar"))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(BeEmpty())
-		Expect(setter.sendErrs).To(BeEmpty())
-
-		str.CancelWrite(1337)
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(BeEmpty())
-		Expect(setter.sendErrs).To(HaveLen(1))
-		Expect(setter.sendErrs[0]).To(Equal(&quic.StreamError{StreamID: someStreamID, ErrorCode: 1337}))
-	})
-
-	It("recognizes when the send side is closed, when the stream context is canceled", func() {
-		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes()
-		ctx, cancel := context.WithCancelCause(context.Background())
-		qstr.EXPECT().Context().Return(ctx).AnyTimes()
-
-		var (
-			clearer mockStreamClearer
-			setter  = mockErrorSetter{
-				sendSent: make(chan struct{}),
-			}
-		)
-
-		_ = newStateTrackingStream(qstr, &clearer, &setter)
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(BeEmpty())
-		Expect(setter.sendErrs).To(BeEmpty())
-
-		testErr := errors.New("test error")
-		cancel(testErr)
-		Eventually(setter.sendSent).Should(BeClosed())
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(BeEmpty())
-		Expect(setter.sendErrs).To(HaveLen(1))
-		Expect(setter.sendErrs[0]).To(Equal(testErr))
-	})
-
-	It("clears the stream when receive is closed followed by send is closed", func() {
-		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
-		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-
-		var (
-			clearer mockStreamClearer
-			setter  mockErrorSetter
-			str     = newStateTrackingStream(qstr, &clearer, &setter)
-		)
-
-		buf := bytes.NewBuffer([]byte("foobar"))
-		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
-		_, err := io.ReadAll(str)
-		Expect(err).ToNot(HaveOccurred())
-
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.recvErrs).To(HaveLen(1))
-		Expect(setter.recvErrs[0]).To(Equal(io.EOF))
-
-		testErr := errors.New("test error")
-		qstr.EXPECT().Write([]byte("bar")).Return(0, testErr)
-
-		_, err = str.Write([]byte("bar"))
-		Expect(err).To(MatchError(testErr))
-		Expect(setter.sendErrs).To(HaveLen(1))
-		Expect(setter.sendErrs[0]).To(Equal(testErr))
-
-		Expect(clearer.cleared).To(Equal(&someStreamID))
-	})
-
-	It("clears the stream when send is closed followed by receive is closed", func() {
-		qstr := mockquic.NewMockStream(mockCtrl)
-		qstr.EXPECT().StreamID().AnyTimes().Return(someStreamID)
-		qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
-
-		var (
-			clearer mockStreamClearer
-			setter  mockErrorSetter
-			str     = newStateTrackingStream(qstr, &clearer, &setter)
-		)
-
-		testErr := errors.New("test error")
-		qstr.EXPECT().Write([]byte("bar")).Return(0, testErr)
-
-		_, err := str.Write([]byte("bar"))
-		Expect(err).To(MatchError(testErr))
-		Expect(clearer.cleared).To(BeNil())
-		Expect(setter.sendErrs).To(HaveLen(1))
-		Expect(setter.sendErrs[0]).To(Equal(testErr))
-
-		buf := bytes.NewBuffer([]byte("foobar"))
-		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
-
-		_, err = io.ReadAll(str)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(setter.recvErrs).To(HaveLen(1))
-		Expect(setter.recvErrs[0]).To(Equal(io.EOF))
-
-		Expect(clearer.cleared).To(Equal(&someStreamID))
-	})
-})
 
 type mockStreamClearer struct {
 	cleared *quic.StreamID
@@ -306,4 +42,252 @@ func (e *mockErrorSetter) SetSendError(err error) {
 
 func (e *mockErrorSetter) SetReceiveError(err error) {
 	e.recvErrs = append(e.recvErrs, err)
+}
+
+func TestStateTrackingStreamRead(t *testing.T) {
+	t.Run("io.EOF", func(t *testing.T) {
+		testStateTrackingStreamRead(t, io.EOF)
+	})
+	t.Run("remote stream reset", func(t *testing.T) {
+		testStateTrackingStreamRead(t, assert.AnError)
+	})
+}
+
+func testStateTrackingStreamRead(t *testing.T, expectedErr error) {
+	mockCtrl := gomock.NewController(t)
+	qstr := mockquic.NewMockStream(mockCtrl)
+	qstr.EXPECT().StreamID().AnyTimes().Return(quic.StreamID(1337))
+	qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
+
+	var (
+		clearer mockStreamClearer
+		setter  mockErrorSetter
+		str     = newStateTrackingStream(qstr, &clearer, &setter)
+	)
+
+	// deadline errors are ignored
+	qstr.EXPECT().Read(gomock.Any()).Return(0, os.ErrDeadlineExceeded)
+	_, err := str.Read(make([]byte, 3))
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+	require.Nil(t, clearer.cleared)
+	require.Empty(t, setter.recvErrs)
+	require.Empty(t, setter.sendErrs)
+
+	if expectedErr == io.EOF {
+		buf := bytes.NewBuffer([]byte("foobar"))
+		qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+
+		for i := 0; i < 3; i++ {
+			_, err := str.Read([]byte{0})
+			require.NoError(t, err)
+			require.Nil(t, clearer.cleared)
+			require.Empty(t, setter.recvErrs)
+			require.Empty(t, setter.sendErrs)
+		}
+	} else {
+		qstr.EXPECT().Read(gomock.Any()).Return(0, expectedErr).AnyTimes()
+	}
+
+	_, err = io.ReadAll(str)
+	if expectedErr == io.EOF {
+		require.NoError(t, err)
+	} else {
+		require.ErrorIs(t, err, expectedErr)
+	}
+	require.Nil(t, clearer.cleared)
+	require.Len(t, setter.recvErrs, 1)
+	require.Equal(t, expectedErr, setter.recvErrs[0])
+	require.Empty(t, setter.sendErrs)
+}
+
+func TestStateTrackingStreamWrite(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	qstr := mockquic.NewMockStream(mockCtrl)
+	qstr.EXPECT().StreamID().AnyTimes().Return(quic.StreamID(1337))
+	qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
+
+	var (
+		clearer mockStreamClearer
+		setter  mockErrorSetter
+		str     = newStateTrackingStream(qstr, &clearer, &setter)
+	)
+
+	qstr.EXPECT().Write([]byte("foo")).Return(3, nil)
+	qstr.EXPECT().Write([]byte("baz")).Return(0, os.ErrDeadlineExceeded)
+	qstr.EXPECT().Write([]byte("bar")).Return(0, assert.AnError)
+
+	_, err := str.Write([]byte("foo"))
+	require.NoError(t, err)
+	require.Nil(t, clearer.cleared)
+	require.Empty(t, setter.recvErrs)
+	require.Empty(t, setter.sendErrs)
+
+	// deadline errors are ignored
+	_, err = str.Write([]byte("baz"))
+	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+	require.Nil(t, clearer.cleared)
+	require.Empty(t, setter.recvErrs)
+	require.Empty(t, setter.sendErrs)
+
+	_, err = str.Write([]byte("bar"))
+	require.ErrorIs(t, err, assert.AnError)
+	require.Nil(t, clearer.cleared)
+	require.Empty(t, setter.recvErrs)
+	require.Len(t, setter.sendErrs, 1)
+	require.Equal(t, assert.AnError, setter.sendErrs[0])
+}
+
+func TestStateTrackingStreamCancelRead(t *testing.T) {
+	const streamID quic.StreamID = 42
+	mockCtrl := gomock.NewController(t)
+	qstr := mockquic.NewMockStream(mockCtrl)
+	qstr.EXPECT().StreamID().AnyTimes().Return(streamID)
+	qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
+
+	var (
+		clearer mockStreamClearer
+		setter  mockErrorSetter
+		str     = newStateTrackingStream(qstr, &clearer, &setter)
+	)
+
+	buf := bytes.NewBuffer([]byte("foobar"))
+	qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+	qstr.EXPECT().CancelRead(quic.StreamErrorCode(1337))
+	_, err := str.Read(make([]byte, 3))
+	require.NoError(t, err)
+	require.Nil(t, clearer.cleared)
+	require.Empty(t, setter.recvErrs)
+	require.Empty(t, setter.sendErrs)
+
+	str.CancelRead(1337)
+	require.Nil(t, clearer.cleared)
+	require.Len(t, setter.recvErrs, 1)
+	require.Equal(t, &quic.StreamError{StreamID: streamID, ErrorCode: 1337}, setter.recvErrs[0])
+	require.Empty(t, setter.sendErrs)
+}
+
+func TestStateTrackingStreamCancelWrite(t *testing.T) {
+	const streamID quic.StreamID = 1234
+	mockCtrl := gomock.NewController(t)
+	qstr := mockquic.NewMockStream(mockCtrl)
+	qstr.EXPECT().StreamID().AnyTimes().Return(streamID)
+	qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
+
+	var (
+		clearer mockStreamClearer
+		setter  mockErrorSetter
+		str     = newStateTrackingStream(qstr, &clearer, &setter)
+	)
+
+	qstr.EXPECT().Write(gomock.Any())
+	qstr.EXPECT().CancelWrite(quic.StreamErrorCode(1337))
+	_, err := str.Write([]byte("foobar"))
+	require.NoError(t, err)
+	require.Nil(t, clearer.cleared)
+	require.Empty(t, setter.recvErrs)
+	require.Empty(t, setter.sendErrs)
+
+	str.CancelWrite(1337)
+	require.Nil(t, clearer.cleared)
+	require.Empty(t, setter.recvErrs)
+	require.Len(t, setter.sendErrs, 1)
+	require.Equal(t, &quic.StreamError{StreamID: streamID, ErrorCode: 1337}, setter.sendErrs[0])
+}
+
+func TestStateTrackingStreamContext(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	qstr := mockquic.NewMockStream(mockCtrl)
+	qstr.EXPECT().StreamID().AnyTimes()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	qstr.EXPECT().Context().Return(ctx).AnyTimes()
+
+	var (
+		clearer mockStreamClearer
+		setter  = mockErrorSetter{
+			sendSent: make(chan struct{}),
+		}
+	)
+
+	_ = newStateTrackingStream(qstr, &clearer, &setter)
+	require.Nil(t, clearer.cleared)
+	require.Empty(t, setter.recvErrs)
+	require.Empty(t, setter.sendErrs)
+
+	testErr := errors.New("test error")
+	cancel(testErr)
+	select {
+	case <-setter.sendSent:
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+	require.Nil(t, clearer.cleared)
+	require.Empty(t, setter.recvErrs)
+	require.Len(t, setter.sendErrs, 1)
+	require.Equal(t, testErr, setter.sendErrs[0])
+}
+
+func TestStateTrackingStreamReceiveThenSend(t *testing.T) {
+	streamID := quic.StreamID(1234)
+	mockCtrl := gomock.NewController(t)
+	qstr := mockquic.NewMockStream(mockCtrl)
+	qstr.EXPECT().StreamID().AnyTimes().Return(streamID)
+	qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
+
+	var (
+		clearer mockStreamClearer
+		setter  mockErrorSetter
+		str     = newStateTrackingStream(qstr, &clearer, &setter)
+	)
+
+	buf := bytes.NewBuffer([]byte("foobar"))
+	qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+	_, err := io.ReadAll(str)
+	require.NoError(t, err)
+
+	require.Nil(t, clearer.cleared)
+	require.Len(t, setter.recvErrs, 1)
+	require.Equal(t, io.EOF, setter.recvErrs[0])
+
+	testErr := errors.New("test error")
+	qstr.EXPECT().Write([]byte("bar")).Return(0, testErr)
+
+	_, err = str.Write([]byte("bar"))
+	require.ErrorIs(t, err, testErr)
+	require.Len(t, setter.sendErrs, 1)
+	require.Equal(t, testErr, setter.sendErrs[0])
+
+	require.Equal(t, &streamID, clearer.cleared)
+}
+
+func TestStateTrackingStreamSendThenReceive(t *testing.T) {
+	streamID := quic.StreamID(1337)
+	mockCtrl := gomock.NewController(t)
+	qstr := mockquic.NewMockStream(mockCtrl)
+	qstr.EXPECT().StreamID().AnyTimes().Return(streamID)
+	qstr.EXPECT().Context().Return(context.Background()).AnyTimes()
+
+	var (
+		clearer mockStreamClearer
+		setter  mockErrorSetter
+		str     = newStateTrackingStream(qstr, &clearer, &setter)
+	)
+
+	testErr := errors.New("test error")
+	qstr.EXPECT().Write([]byte("bar")).Return(0, testErr)
+
+	_, err := str.Write([]byte("bar"))
+	require.ErrorIs(t, err, testErr)
+	require.Nil(t, clearer.cleared)
+	require.Len(t, setter.sendErrs, 1)
+	require.Equal(t, testErr, setter.sendErrs[0])
+
+	buf := bytes.NewBuffer([]byte("foobar"))
+	qstr.EXPECT().Read(gomock.Any()).DoAndReturn(buf.Read).AnyTimes()
+
+	_, err = io.ReadAll(str)
+	require.NoError(t, err)
+	require.Len(t, setter.recvErrs, 1)
+	require.Equal(t, io.EOF, setter.recvErrs[0])
+
+	require.Equal(t, &streamID, clearer.cleared)
 }


### PR DESCRIPTION
Part of #3652. This PR concludes the migration of the tests in the HTTP/3 package 🎉