### PR TITLE
avoid triggering macOS dual-stack flakiness in HTTP/3 integration tests

### DIFF
--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -85,6 +85,7 @@ func newHTTP3Client(t *testing.T) *http.Client {
 		QUICConfig:         getQuicConfig(&quic.Config{MaxIdleTimeout: 10 * time.Second}),
 		DisableCompression: true,
 	}
+	addDialCallback(t, tr)
 	t.Cleanup(func() { tr.Close() })
 	return &http.Client{Transport: tr}
 }
@@ -356,7 +357,13 @@ func TestHTTPDifferentOrigins(t *testing.T) {
 	})
 	port := startHTTPServer(t, mux)
 
-	cl := newHTTP3Client(t)
+	tr := &http3.Transport{
+		TLSClientConfig: getTLSClientConfigWithoutServerName(),
+		QUICConfig:      getQuicConfig(nil),
+	}
+	t.Cleanup(func() { tr.Close() })
+	cl := &http.Client{Transport: tr}
+
 	resp, err := cl.Get(fmt.Sprintf("https://localhost:%d/remote-addr", port))
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -888,6 +895,7 @@ func TestHTTP0RTT(t *testing.T) {
 		DisableCompression: true,
 	}
 	defer tr.Close()
+	addDialCallback(t, tr)
 
 	proxyPort := proxy.LocalAddr().(*net.UDPAddr).Port
 	req, err := http.NewRequest(http3.MethodGet0RTT, fmt.Sprintf("https://localhost:%d/0rtt", proxyPort), nil)
@@ -912,6 +920,7 @@ func TestHTTP0RTT(t *testing.T) {
 		DisableCompression: true,
 	}
 	defer tr2.Close()
+	addDialCallback(t, tr2)
 	rsp, err = tr2.RoundTrip(req)
 	require.NoError(t, err)
 	require.Equal(t, 200, rsp.StatusCode)
@@ -949,6 +958,7 @@ func TestHTTPStreamer(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.CloseWithError(0, "")
 	tr := http3.Transport{}
+	addDialCallback(t, &tr)
 	cc := tr.NewClientConn(conn)
 	str, err := cc.OpenRequestStream(ctx)
 	require.NoError(t, err)

--- a/integrationtests/self/http_trace_test.go
+++ b/integrationtests/self/http_trace_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go/http3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,7 +63,13 @@ func TestHTTPClientTrace(t *testing.T) {
 	}
 	ctx := httptrace.WithClientTrace(context.Background(), &trace)
 
-	cl := newHTTP3Client(t)
+	tr := &http3.Transport{
+		TLSClientConfig: getTLSClientConfigWithoutServerName(),
+		QUICConfig:      getQuicConfig(nil),
+	}
+	t.Cleanup(func() { tr.Close() })
+	cl := &http.Client{Transport: tr}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/client-trace", port), nil)
 	require.NoError(t, err)
 	resp, err := cl.Do(req)


### PR DESCRIPTION
Fixes #4902. Fixes #5139.

Unfortunately, there’s still no fix in sight for https://github.com/golang/go/issues/67226.