### PR TITLE
http3: simplify connection closing in the frame parser

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -155,8 +155,8 @@ func (c *ClientConn) handleBidirectionalStreams(streamHijacker func(FrameType, q
 			return
 		}
 		fp := &frameParser{
-			r:    str,
-			conn: &c.connection,
+			r:         str,
+			closeConn: c.CloseWithError,
 			unknownFrameHandler: func(ft FrameType, e error) (processed bool, err error) {
 				id := c.Context().Value(quic.ConnectionTracingKey).(quic.ConnectionTracingID)
 				return streamHijacker(ft, id, str, e)

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -287,7 +287,7 @@ func (c *connection) handleUnidirectionalStreams(hijack func(StreamType, quic.Co
 }
 
 func (c *connection) handleControlStream(str *quic.ReceiveStream) {
-	fp := &frameParser{conn: c.Connection, r: str}
+	fp := &frameParser{closeConn: c.Connection.CloseWithError, r: str}
 	f, err := fp.ParseNext()
 	if err != nil {
 		var serr *quic.StreamError

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -21,7 +21,7 @@ var errHijacked = errors.New("hijacked")
 
 type frameParser struct {
 	r                   io.Reader
-	conn                quic.Connection
+	closeConn           func(quic.ApplicationErrorCode, string) error
 	unknownFrameHandler unknownFrameHandlerFunc
 }
 
@@ -70,7 +70,7 @@ func (p *frameParser) ParseNext() (frame, error) {
 			return parseGoAwayFrame(qr, l)
 		case 0xd: // MAX_PUSH_ID
 		case 0x2, 0x6, 0x8, 0x9:
-			p.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
+			p.closeConn(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
 			return nil, fmt.Errorf("http3: reserved frame type: %d", t)
 		}
 		// skip over unknown frames

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -37,8 +37,8 @@ func TestParserReservedFrameType(t *testing.T) {
 			data = append(data, []byte("foobar")...)
 
 			fp := frameParser{
-				r:    bytes.NewReader(data),
-				conn: client,
+				r:         bytes.NewReader(data),
+				closeConn: client.CloseWithError,
 			}
 			_, err := fp.ParseNext()
 			require.Error(t, err)

--- a/http3/server.go
+++ b/http3/server.go
@@ -562,7 +562,7 @@ func (s *Server) handleRequest(conn *connection, str datagramStream, decoder *qp
 			)
 		}
 	}
-	fp := &frameParser{conn: conn, r: str, unknownFrameHandler: ufh}
+	fp := &frameParser{closeConn: conn.CloseWithError, r: str, unknownFrameHandler: ufh}
 	frame, err := fp.ParseNext()
 	if err != nil {
 		if !errors.Is(err, errHijacked) {

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -54,8 +54,8 @@ func newStream(str datagramStream, conn *connection, parseTrailer func(io.Reader
 
 func (s *Stream) Read(b []byte) (int, error) {
 	fp := &frameParser{
-		r:    s.datagramStream,
-		conn: s.conn,
+		r:         s.datagramStream,
+		closeConn: s.conn.CloseWithError,
 	}
 	if s.bytesRemainingInFrame == 0 {
 	parseLoop:
@@ -196,7 +196,7 @@ func (s *RequestStream) SendRequestHeader(req *http.Request) error {
 func (s *RequestStream) ReadResponse() (*http.Response, error) {
 	qstr := s.datagramStream
 	fp := &frameParser{
-		conn: s.conn,
+		closeConn: s.conn.CloseWithError,
 		r: &tracingReader{
 			Reader: qstr,
 			first:  &s.firstByte,


### PR DESCRIPTION
No functional change expected.

This will make it easier to convert the `quic.Connection` to a struct, see #4968.