### PR TITLE
Multipath QUIC - Rudimentary Multi-Path Operations

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -928,7 +928,7 @@ func TestConnectionMaxUnprocessedPackets(t *testing.T) {
 		// nothing here should block
 		tc.conn.handlePacket(receivedPacket{data: []byte("foobar")})
 	}
-	tracer.EXPECT().DroppedPacket(logging.PacketTypeNotDetermined, protocol.InvalidPacketNumber, logging.ByteCount(6), logging.PacketDropDOSPrevention).Do(func(logging.PacketType, logging.PacketNumber, logging.ByteCount, logging.PacketDropReason) {
+	tracer.EXPECT().DroppedPacket(logging.PacketTypeNotDetermined, protocol.InvalidPacketNumber, logging.ByteCount(6), logging.PacketDropDOSPrevention).Do(func(logging.PacketType, protocol.PacketNumber, logging.ByteCount, logging.PacketDropReason) {
 		close(done)
 	})
 	tc.conn.handlePacket(receivedPacket{data: []byte("foobar")})
@@ -3102,4 +3102,66 @@ func testConnectionMigration(t *testing.T, enabled bool) {
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
 	}
+}
+
+// TestTransportParameterInitialMaxPathID verifies the sending and receiving
+// of the initial_max_path_id transport parameter.
+func TestTransportParameterInitialMaxPathID(t *testing.T) {
+	t.Skip("TODO: Implement test for initial_max_path_id transport parameter")
+	// Test scenarios:
+	// 1. Client sends MaxPaths, Server receives and processes it.
+	// 2. Server sends MaxPaths, Client receives and processes it.
+	// 3. Both send MaxPaths=0 (disabled), verify negotiatedMaxPathID is 1.
+	// 4. Client sends N, Server sends M, verify negotiatedMaxPathID is min(N,M) (or 1 if N or M is 0).
+	// 5. Parameter omitted by one side, verify behavior (should be treated as 0, so negotiated is 1).
+}
+
+// TestPerPathMTUDiscovererInitialization verifies that an MtuDiscoverer
+// is initialized for the primary path.
+func TestPerPathMTUDiscovererInitialization(t *testing.T) {
+	t.Skip("TODO: Implement test for per-path MTU discoverer initialization")
+	// Test scenarios:
+	// 1. Connection established, verify s.paths[0].mtuDiscoverer is not nil.
+	// 2. Verify it's initialized with correct initial and max sizes based on config and peer TPs.
+	// 3. Verify for client and server perspectives.
+}
+
+// TestSendPacketsUsesPathMTU verifies that sendPackets (via maxPacketSize)
+// uses the MTU size from the correct path's MtuDiscoverer.
+func TestSendPacketsUsesPathMTU(t *testing.T) {
+	t.Skip("TODO: Implement test for sendPackets using path-specific MTU size")
+	// Test scenarios:
+	// 1. Setup a connection with a primary path and its MTU discoverer.
+	// 2. Mock the CurrentSize() of the MTU discoverer.
+	// 3. Call sendPackets (or a helper that leads to it) and verify that packets are sized according to the mocked MTU.
+	//    (This might involve checking the packer or the buffer lengths).
+}
+
+// TestSendPacketsSendsPathMTUProbes verifies that sendPackets sends MTU
+// probes for the correct path when its MtuDiscoverer indicates a probe is needed.
+func TestSendPacketsSendsPathMTUProbes(t *testing.T) {
+	t.Skip("TODO: Implement test for sendPackets sending path-specific MTU probes")
+	// Test scenarios:
+	// 1. Setup a connection with a primary path and its MTU discoverer.
+	// 2. Mock ShouldSendProbe() to return true and GetPing() to return a specific PING frame and size.
+	// 3. Call sendPackets.
+	// 4. Verify that a packet containing the expected PING frame and matching the probe size is sent.
+	//    (This might involve inspecting packets captured by a mock sendConn).
+}
+
+// TestNegotiatedMaxPathIDLogic verifies the logic for calculating
+// negotiatedMaxPathID based on local and peer advertised values.
+func TestNegotiatedMaxPathIDLogic(t *testing.T) {
+	t.Skip("TODO: Implement test for negotiatedMaxPathID logic")
+	// Test scenarios:
+	// - local=2, peer=3 -> negotiated=2
+	// - local=3, peer=2 -> negotiated=2
+	// - local=1, peer=5 -> negotiated=1
+	// - local=5, peer=1 -> negotiated=1
+	// - local=0, peer=5 -> negotiated=1 (local advertises 0)
+	// - local=5, peer=0 -> negotiated=1 (peer advertises 0)
+	// - local=0, peer=0 -> negotiated=1
+	// - local=1, peer=1 -> negotiated=1
+	// This test might involve creating minimal connection objects or directly testing
+	// the transport parameter handling logic that sets negotiatedMaxPathID.
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -69,6 +69,26 @@ func connectionOptHandshakeConfirmed() testConnectionOpt {
 	}
 }
 
+func TestPathPacketNumberSpaceUsage(t *testing.T) {
+	t.Skip("TODO: Implement test for path-specific packet number space usage via connection calls")
+	// High-level test scenarios:
+	// - After connection setup, send a 1-RTT data packet.
+	// - Verify (possibly by mocking pnGen or packer) that s.paths[0].pnSpace.pnGen was used.
+	// - If client probes a new path, verify packets on that path use its specific pnGen.
+}
+
+// TestPathAwarePackerCalls verifies that connection methods correctly pass path context to packer methods.
+func TestPathAwarePackerCalls(t *testing.T) {
+	t.Skip("TODO: Implement test to verify connection methods pass correct path to packer.")
+	// Scenarios:
+	// - sendPackets calls packer.PackCoalescedPacket with primary path.
+	// - sendPackets calls packer.PackMTUProbePacket with primary path.
+	// - maybeSendAckOnlyPacket calls packer.PackAckOnlyPacket with primary path.
+	// - sendProbePacket calls packer.PackPTOProbePacket with primary path (for 1-RTT).
+	// - sendConnectionClose calls packer.PackConnectionClose/ApplicationClose with primary path.
+	// This test would likely involve a mock packer to assert the *path argument.
+}
+
 func connectionOptRTT(rtt time.Duration) testConnectionOpt {
 	var rttStats utils.RTTStats
 	rttStats.UpdateRTT(rtt, 0)

--- a/interface.go
+++ b/interface.go
@@ -262,6 +262,11 @@ type Config struct {
 	// Enable QUIC datagram support (RFC 9221).
 	EnableDatagrams bool
 	Tracer          func(context.Context, logging.Perspective, ConnectionID) *logging.ConnectionTracer
+	// MaxPaths is the maximum number of paths that this endpoint is willing to use and advertise.
+	// A value of 0 indicates no support for multipath / multipath disabled.
+	// The negotiated number of paths will be the minimum of the client's and server's advertised values.
+	// If either side advertises 0, the connection will operate in single-path mode (negotiated value will be 1).
+	MaxPaths uint8 // User-configured value.
 }
 
 // ClientHelloInfo contains information about an incoming connection attempt.

--- a/multipath_manager.go
+++ b/multipath_manager.go
@@ -1,0 +1,174 @@
+// multipath_manager.go
+package quic
+
+import (
+	"errors"
+	"net"
+	"sync"
+
+	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils"
+	"github.com/quic-go/quic-go/logging"
+)
+
+// PathState defines the state of a network path.
+type PathState uint8
+
+const (
+	// PathStateValidating indicates the path is undergoing validation (e.g., PATH_CHALLENGE sent).
+	PathStateValidating PathState = iota
+	// PathStateActive indicates the path is validated and available for sending data.
+	PathStateActive
+	// PathStateClosing indicates the path is being closed (e.g., NEW_CONNECTION_ID with retire_prior_to used).
+	PathStateClosing
+	// PathStateClosed indicates the path is no longer in use.
+	PathStateClosed
+)
+
+func (s PathState) String() string {
+	switch s {
+	case PathStateValidating:
+		return "VALIDATING"
+	case PathStateActive:
+		return "ACTIVE"
+	case PathStateClosing:
+		return "CLOSING"
+	case PathStateClosed:
+		return "CLOSED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// pathPacketNumberSpace holds packet number related state for a single path.
+type pathPacketNumberSpace struct {
+	pnGen ackhandler.PacketNumberGenerator
+}
+
+// multipathManager manages multiple paths for a QUIC connection.
+type multipathManager struct {
+	mutex sync.RWMutex
+	paths []*path // Slice of active and validating paths
+
+	rttStats    *utils.RTTStats
+	config      *Config
+	tracer      *logging.ConnectionTracer
+	perspective protocol.Perspective
+}
+
+// newMultipathManager creates a new multipathManager.
+func newMultipathManager(
+	rttStats *utils.RTTStats,
+	config *Config,
+	tracer *logging.ConnectionTracer,
+	perspective protocol.Perspective,
+) *multipathManager {
+	return &multipathManager{
+		paths:       make([]*path, 0, 1), // Initial capacity for the primary path
+		rttStats:    rttStats,
+		config:      config,
+		tracer:      tracer,
+		perspective: perspective,
+	}
+}
+
+func (m *multipathManager) addPath(remoteAddr net.Addr, pathID uint64, negotiatedMaxConnPaths uint64, peerMaxUDPPayloadSize protocol.ByteCount) (*path, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	for _, p := range m.paths {
+		if p.pathID == pathID {
+			if !utils.AreAddressesEqual(p.RemoteAddr, remoteAddr) && remoteAddr != nil {
+				if m.tracer != nil && m.tracer.PathRemoteAddressChanged != nil {
+					m.tracer.PathRemoteAddressChanged(pathID, p.RemoteAddr, remoteAddr)
+				}
+				p.RemoteAddr = remoteAddr
+			}
+			return p, nil
+		}
+	}
+
+	if uint64(len(m.paths)) >= negotiatedMaxConnPaths && negotiatedMaxConnPaths > 0 { // negotiatedMaxConnPaths > 0 means the limit is active
+		return nil, errors.New("cannot add new path: maximum number of paths reached according to negotiation")
+	}
+
+	newPath := &path{
+		pathID:     pathID,
+		RemoteAddr: remoteAddr,
+		State:      PathStateValidating, // Initial state
+		// Initialize packet number space for the new path.
+		// Each path starts with packet number 0 conceptually for its own space.
+		pnSpace:    &pathPacketNumberSpace{pnGen: ackhandler.NewPacketNumberGenerator(protocol.InitialPacketNumber)},
+	}
+
+	initialMTU := protocol.ByteCount(m.config.InitialPacketSize)
+	maxMTU := protocol.ByteCount(protocol.MaxPacketBufferSize)
+	if peerMaxUDPPayloadSize > 0 && peerMaxUDPPayloadSize < maxMTU {
+		maxMTU = peerMaxUDPPayloadSize
+	}
+
+	newPath.mtuDiscoverer = newMTUDiscoverer(
+		m.rttStats,
+		initialMTU,
+		maxMTU,
+		m.tracer,
+	)
+
+	m.paths = append(m.paths, newPath)
+	if m.tracer != nil && m.tracer.PathAdded != nil {
+		m.tracer.PathAdded(pathID, remoteAddr)
+	}
+	return newPath, nil
+}
+
+func (m *multipathManager) getPath(pathID uint64) *path {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	for _, p := range m.paths {
+		if p.pathID == pathID {
+			return p
+		}
+	}
+	return nil
+}
+
+func (m *multipathManager) getPrimaryPath() *path {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	for _, p := range m.paths {
+		if p.pathID == 0 {
+			return p
+		}
+	}
+	return nil
+}
+
+func (m *multipathManager) getActivePaths() []*path {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	activePaths := make([]*path, 0, len(m.paths))
+	for _, p := range m.paths {
+		if p.State == PathStateActive {
+			activePaths = append(activePaths, p)
+		}
+	}
+	return activePaths
+}
+
+func (m *multipathManager) setPathState(pathID uint64, newState PathState) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	for _, p := range m.paths {
+		if p.pathID == pathID {
+			if p.State != newState {
+				if m.tracer != nil && m.tracer.PathStateChanged != nil {
+					m.tracer.PathStateChanged(pathID, p.RemoteAddr, p.State, newState)
+				}
+				p.State = newState
+			}
+			return true
+		}
+	}
+	return false
+}

--- a/multipath_manager_test.go
+++ b/multipath_manager_test.go
@@ -1,0 +1,53 @@
+// multipath_manager_test.go
+package quic
+
+import (
+	"net"
+	"testing"
+
+	// "github.com/quic-go/quic-go/internal/protocol"
+	// "github.com/quic-go/quic-go/internal/utils"
+	// "github.com/stretchr/testify/require"
+	// Add other necessary imports, e.g., for logging.NoopTracer if used
+)
+
+func TestMultipathManagerAddPath(t *testing.T) {
+	t.Skip("TODO: Implement test for multipathManager.addPath")
+	// Test scenarios:
+	// 1. Add a primary path (ID 0).
+	// 2. Add a second path.
+	// 3. Try to add more paths than negotiatedMaxConnPaths allows.
+	// 4. Try to add a path with an existing ID (should return existing).
+	// 5. Verify mtuDiscoverer and pnSpace are initialized for new paths.
+	// 6. Verify remoteAddr and initial state are set.
+}
+
+func TestMultipathManagerGetPath(t *testing.T) {
+	t.Skip("TODO: Implement test for multipathManager.getPath")
+	// Test scenarios:
+	// 1. Get an existing path.
+	// 2. Get a non-existing path (should return nil).
+}
+
+func TestMultipathManagerGetPrimaryPath(t *testing.T) {
+	t.Skip("TODO: Implement test for multipathManager.getPrimaryPath")
+	// Test scenarios:
+	// 1. Get primary path when it exists.
+	// 2. Get primary path when it doesn't exist (should return nil).
+}
+
+func TestMultipathManagerGetActivePaths(t *testing.T) {
+	t.Skip("TODO: Implement test for multipathManager.getActivePaths")
+	// Test scenarios:
+	// 1. No active paths.
+	// 2. One active path.
+	// 3. Multiple active paths, some validating/closed.
+}
+
+func TestMultipathManagerSetPathState(t *testing.T) {
+	t.Skip("TODO: Implement test for multipathManager.setPathState")
+	// Test scenarios:
+	// 1. Set state of an existing path.
+	// 2. Set state of a non-existing path.
+	// 3. Verify tracer call on state change.
+}

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -978,3 +978,58 @@ func TestPackPathProbePacket(t *testing.T) {
 	require.True(t, p.IsPathProbePacket)
 	require.False(t, p.IsPathMTUProbePacket)
 }
+
+func TestPackerAppendPacketWithPathPN(t *testing.T) {
+	t.Skip("TODO: Implement test for packer.AppendPacket using path-specific PN")
+	// Test scenarios:
+	// - Provide a path with a pnGen. Verify AppendPacket uses it for PN.
+	// - Verify error if path or pnSpace is nil.
+}
+
+func TestPackerPackAckOnlyPacketWithPathPN(t *testing.T) {
+	t.Skip("TODO: Implement test for packer.PackAckOnlyPacket using path-specific PN")
+	// Test scenarios:
+	// - Provide a path with a pnGen. Verify PackAckOnlyPacket uses it for PN.
+	// - Verify error if path or pnSpace is nil.
+}
+
+func TestPackerPackMTUProbePacketWithPathPN(t *testing.T) {
+	t.Skip("TODO: Implement test for packer.PackMTUProbePacket using path-specific PN")
+	// Test scenarios:
+	// - Provide a path with a pnGen. Verify PackMTUProbePacket uses it for PN.
+	// - Verify error if path or pnSpace is nil.
+}
+
+func TestPackerPackPTOProbePacketWithPathPN(t *testing.T) {
+	t.Skip("TODO: Implement test for packer.PackPTOProbePacket using path-specific PN for 1-RTT")
+	// Test scenarios:
+	// - For 1-RTT, provide a path with pnGen, verify it's used. Error if path/pnSpace nil.
+	// - For Initial/Handshake, verify global PN is used (path arg might be nil).
+}
+
+func TestPackerPackCoalescedPacketWithPathPN(t *testing.T) {
+	t.Skip("TODO: Implement test for packer.PackCoalescedPacket using path-specific PN for 1-RTT part")
+	// Test scenarios:
+	// - For 1-RTT component, provide path with pnGen, verify it's used. Error if path/pnSpace nil and 1-RTT packed.
+	// - For Initial/Handshake components, verify global PN is used.
+}
+
+func TestPackerPackConnectionCloseWithPathPN(t *testing.T) {
+	t.Skip("TODO: Implement test for packer.PackConnectionClose using path-specific PN for 1-RTT")
+	// Test scenarios:
+	// - For 1-RTT, provide path with pnGen, verify it's used. Error if path/pnSpace nil.
+	// - For Long Header, verify global PN is used.
+}
+
+func TestPackerPackApplicationCloseWithPathPN(t *testing.T) {
+	t.Skip("TODO: Implement test for packer.PackApplicationClose using path-specific PN")
+	// Test scenarios:
+	// - Provide path with pnGen, verify it's used. Error if path/pnSpace nil.
+}
+
+func TestPackerPackPathProbePacketWithPathPN(t *testing.T) {
+	t.Skip("TODO: Implement test for packer.PackPathProbePacket using path-specific PN or fallback")
+	// Test scenarios:
+	// - Provide path with pnGen, verify it's used.
+	// - Provide nil path, verify fallback to global 1-RTT PN is used.
+}


### PR DESCRIPTION
Branch Name: multipath-phase3-multi-path-rudiments

Commit Message:

feat: Multipath QUIC - Rudimentary Multi-Path Operations

This commit enables more concrete multi-path operations, building upon
the foundational path-aware packet numbering and management.

Key changes include:

1.  Enable Creation and Validation of Additional Paths (Client-side):
    *   `connection.AddPath` now coordinates with `multipathManager` to generate unique `uint64` path IDs for new paths.
    *   `path_manager_outgoing.go` was updated:
        *   Its internal path representation (`Path` struct, `pathOutgoing` struct, and related map keys/slices) now uses `uint64` path IDs.
        *   `NewPath` method accepts the `uint64` ID generated by `mpManager`.
        *   `NextPathToProbe` accepts a `getPathCtx` callback from `connection.go` to retrieve the main `*quic.path` object (which holds the `pnSpace`) for the path ID it's about to probe. This ensures client-initiated path probes use the correct path-specific packet number space.
        *   A `pathValidatedCallback` was added to `pathManagerOutgoing`. When `HandlePathResponseFrame` validates a path, this callback is invoked.
    *   `connection.go` provides this `pathValidatedCallback` to `pathManagerOutgoing`, which then calls `s.mpManager.setPathState` to update the path's state to `PathStateActive`.

2.  Path Selection for Sending (Rudimentary):
    *   In `connection.go`'s `sendPackets` function, the `currentSendPath` is now selected by calling `s.mpManager.getActivePaths()` and, for this initial version, picking the first path from the returned list.
    *   If no paths are active, `currentSendPath` remains `nil`, and logic dependent on it (like sending 1-RTT data or path-specific probes) will not execute.

3.  Processing Packets on Multiple Paths (Server-side and Client-side):
    *   The `path` struct in `connection.go` now includes a `lastActivityTime` field.
    *   `multipathManager.go` has new methods:
        *   `getPathByRemoteAddress(remoteAddr net.Addr) *path`: Finds a path based on its remote address (read-only).
        *   `updatePathActivityTime(p *path, now time.Time)`: Updates the `lastActivityTime` for a given path.
    *   In `connection.go`'s main packet processing loop (`run` -> `handleOnePacket`), the `ingressPath` for an incoming packet is identified using `mpManager.getPathByRemoteAddress`, and its `lastActivityTime` is updated.
    *   This `ingressPath` is now threaded through packet handling functions (`handleLongHeaderPacket`, `handleShortHeaderPacket`, etc.) to make the connection aware of the arrival path.
    *   Server-side logic in `handleShortHeaderPacket` now uses `ingressPath` to determine if a packet is from a new/unvalidated address before invoking the older `s.pathManager` for path validation (sending PATH_CHALLENGEs). PATH_CHALLENGEs sent this way use the packer's fallback (global 1-RTT) PN generation.

4.  Associate Connection IDs with Paths (Conceptual Review):
    *   Reviewed IETF multipath draft (section 7.2): `NEW_CONNECTION_ID` frames do not tie CIDs to specific paths; new CIDs can be used on any path.
    *   Source CIDs in long headers (Initial, Handshake) are determined by QUIC handshake rules and initial CIDs.
    *   Path-specific *selection strategy* for an endpoint's own source CIDs for 1-RTT packets (if using multiple source CIDs for privacy/routing) is a more advanced feature and deferred. No code changes made for this item in this phase, assuming current long header CID logic is largely correct.

5.  Basic Path Closure (Path Abandonment):
    *   `path_manager_outgoing.go` was updated:
        *   Added `pathClosedCallback func(pathID uint64)` to its struct and constructor.
        *   `removePathImpl` (called by `Path.Close()`) now invokes this callback with the ID of the path being closed.
    *   `connection.go` provides the `pathClosedCallback` when initializing `pathManagerOutgoing`. This callback calls `s.mpManager.setPathState(closedPathID, PathStateClosed)`.
    *   The `sendPackets` logic, by using `getActivePaths()`, will naturally ignore paths marked as `PathStateClosed`.

6.  Updated Unit Test Stubs:
    *   Added new test stubs in `connection_test.go` and `multipat