### PR TITLE
ci: enable the nolintlint linter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - nolintlint
     - prealloc
     - staticcheck
     - unconvert

--- a/connection.go
+++ b/connection.go
@@ -701,8 +701,6 @@ runLoop:
 }
 
 // blocks until the early connection can be used
-//
-//nolint:unused // False positive: This function is used by Transport.doDial.
 func (c *Conn) earlyConnReady() <-chan struct{} {
 	return c.earlyConnReadyChan
 }
@@ -1992,7 +1990,6 @@ func (c *Conn) triggerSending(now time.Time) error {
 	c.pacingDeadline = time.Time{}
 
 	sendMode := c.sentPacketHandler.SendMode(now)
-	//nolint:exhaustive // No need to handle pacing limited here.
 	switch sendMode {
 	case ackhandler.SendAny:
 		return c.sendPackets(now)

--- a/integrationtests/self/handshake_context_test.go
+++ b/integrationtests/self/handshake_context_test.go
@@ -229,7 +229,7 @@ func TestContextOnClientSide(t *testing.T) {
 		return &tlsServerConf.Certificates[0], nil
 	}
 
-	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), "foo", "bar")) //nolint:staticcheck
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), "foo", "bar"))
 	conn, err := quic.Dial(
 		ctx,
 		newUDPConnLocalhost(t),

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -675,7 +675,7 @@ func TestHTTPConnContext(t *testing.T) {
 		func(s *http3.Server) {
 			s.ConnContext = func(ctx context.Context, c *quic.Conn) context.Context {
 				connCtxChan <- ctx
-				ctx = context.WithValue(ctx, "foo", "bar") //nolint:staticcheck
+				ctx = context.WithValue(ctx, "foo", "bar")
 				return ctx
 			}
 		},

--- a/internal/protocol/version.go
+++ b/internal/protocol/version.go
@@ -37,7 +37,6 @@ func IsValidVersion(v Version) bool {
 }
 
 func (vn Version) String() string {
-	//nolint:exhaustive
 	switch vn {
 	case VersionUnknown:
 		return "unknown"

--- a/internal/wire/extended_header.go
+++ b/internal/wire/extended_header.go
@@ -61,7 +61,6 @@ func (h *ExtendedHeader) Append(b []byte, v protocol.Version) ([]byte, error) {
 
 	var packetType uint8
 	if v == protocol.Version2 {
-		//nolint:exhaustive
 		switch h.Type {
 		case protocol.PacketTypeInitial:
 			packetType = 0b01
@@ -73,7 +72,6 @@ func (h *ExtendedHeader) Append(b []byte, v protocol.Version) ([]byte, error) {
 			packetType = 0b00
 		}
 	} else {
-		//nolint:exhaustive
 		switch h.Type {
 		case protocol.PacketTypeInitial:
 			packetType = 0b00

--- a/qlog/types.go
+++ b/qlog/types.go
@@ -318,7 +318,6 @@ func (s congestionState) String() string {
 type ecn logging.ECN
 
 func (e ecn) String() string {
-	//nolint:exhaustive // The unsupported value is never logged.
 	switch logging.ECN(e) {
 	case logging.ECTNot:
 		return "Not-ECT"


### PR DESCRIPTION
This linter helps us find unneeded nolint statements.