### PR TITLE
quicvarint: speed up parsing of 1, 2 and 4 byte varints 

### DIFF
--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -97,7 +97,8 @@ func Parse(b []byte) (uint64 /* value */, int /* bytes consumed */, error) {
 		if len(b) < 8 {
 			return 0, 0, io.ErrUnexpectedEOF
 		}
-		tmp := binary.BigEndian.Uint64(b[0:8])
+		// binary.BigEndian.Uint64 only reads the first 8 bytes, so passing the full slice avoids slicing overhead.
+		tmp := binary.BigEndian.Uint64(b)
 		tmp &= 0x3FFFFFFFFFFFFFFF
 		return tmp, 8, nil
 	}

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -84,15 +84,15 @@ func Parse(b []byte) (uint64 /* value */, int /* bytes consumed */, error) {
 		if len(b) < 2 {
 			return 0, 0, io.ErrUnexpectedEOF
 		}
-		return uint64(first&0x3F)<<8 | uint64(b[1]), 2, nil
+		return uint64(b[1]) | uint64(first&0x3F)<<8, 2, nil
 	case 2: // 4-byte encoding: 10xxxxxx
 		if len(b) < 4 {
 			return 0, 0, io.ErrUnexpectedEOF
 		}
-		return uint64(first&0x3F)<<24 |
-			uint64(b[1])<<16 |
+		return uint64(b[3]) |
 			uint64(b[2])<<8 |
-			uint64(b[3]), 4, nil
+			uint64(b[1])<<16 |
+			uint64(first&0x3F)<<24, 4, nil
 	case 3: // 8-byte encoding: 00xxxxxx
 		if len(b) < 8 {
 			return 0, 0, io.ErrUnexpectedEOF

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -93,7 +93,7 @@ func Parse(b []byte) (uint64 /* value */, int /* bytes consumed */, error) {
 			uint64(b[1])<<16 |
 			uint64(b[2])<<8 |
 			uint64(b[3]), 4, nil
-	case 3: // 8-byte encoding: 00xxxxxx 
+	case 3: // 8-byte encoding: 00xxxxxx
 		if len(b) < 8 {
 			return 0, 0, io.ErrUnexpectedEOF
 		}

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -98,7 +98,7 @@ func Parse(b []byte) (uint64 /* value */, int /* bytes consumed */, error) {
 			return 0, 0, io.ErrUnexpectedEOF
 		}
 		tmp := binary.BigEndian.Uint64(b[0:8])
-		tmp &= 0x3FFFFFFFFFFFFFFF // clear top 2 bits
+		tmp &= 0x3FFFFFFFFFFFFFFF
 		return tmp, 8, nil
 	}
 

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -1,6 +1,7 @@
 package quicvarint
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 )
@@ -92,18 +93,13 @@ func Parse(b []byte) (uint64 /* value */, int /* bytes consumed */, error) {
 			uint64(b[1])<<16 |
 			uint64(b[2])<<8 |
 			uint64(b[3]), 4, nil
-	case 3: // 8-byte encoding: 11xxxxxx
+	case 3: // 8-byte encoding
 		if len(b) < 8 {
 			return 0, 0, io.ErrUnexpectedEOF
 		}
-		return uint64(first&0x3F)<<56 |
-			uint64(b[1])<<48 |
-			uint64(b[2])<<40 |
-			uint64(b[3])<<32 |
-			uint64(b[4])<<24 |
-			uint64(b[5])<<16 |
-			uint64(b[6])<<8 |
-			uint64(b[7]), 8, nil
+		tmp := binary.BigEndian.Uint64(b[0:8])
+		tmp &= 0x3FFFFFFFFFFFFFFF // clear top 2 bits
+		return tmp, 8, nil
 	}
 
 	// Should never be reached

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -93,7 +93,7 @@ func Parse(b []byte) (uint64 /* value */, int /* bytes consumed */, error) {
 			uint64(b[1])<<16 |
 			uint64(b[2])<<8 |
 			uint64(b[3]), 4, nil
-	case 3: // 8-byte encoding
+	case 3: // 8-byte encoding: 00xxxxxx 
 		if len(b) < 8 {
 			return 0, 0, io.ErrUnexpectedEOF
 		}

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -70,7 +70,7 @@ func Read(r io.ByteReader) (uint64, error) {
 
 // Parse reads a number in the QUIC varint format.
 // It returns the number of bytes consumed.
-func Parse(b []byte) (uint64, int, error) {
+func Parse(b []byte) (uint64 /* value */, int /* bytes consumed */, error) {
 	if len(b) == 0 {
 		return 0, 0, io.EOF
 	}

--- a/quicvarint/varint.go
+++ b/quicvarint/varint.go
@@ -70,27 +70,44 @@ func Read(r io.ByteReader) (uint64, error) {
 
 // Parse reads a number in the QUIC varint format.
 // It returns the number of bytes consumed.
-func Parse(b []byte) (uint64 /* value */, int /* bytes consumed */, error) {
+func Parse(b []byte) (uint64, int, error) {
 	if len(b) == 0 {
 		return 0, 0, io.EOF
 	}
-	firstByte := b[0]
-	// the first two bits of the first byte encode the length
-	l := 1 << ((firstByte & 0xc0) >> 6)
-	if len(b) < l {
-		return 0, 0, io.ErrUnexpectedEOF
+
+	first := b[0]
+	switch first >> 6 {
+	case 0: // 1-byte encoding: 00xxxxxx
+		return uint64(first & 0x3F), 1, nil
+	case 1: // 2-byte encoding: 01xxxxxx
+		if len(b) < 2 {
+			return 0, 0, io.ErrUnexpectedEOF
+		}
+		return uint64(first&0x3F)<<8 | uint64(b[1]), 2, nil
+	case 2: // 4-byte encoding: 10xxxxxx
+		if len(b) < 4 {
+			return 0, 0, io.ErrUnexpectedEOF
+		}
+		return uint64(first&0x3F)<<24 |
+			uint64(b[1])<<16 |
+			uint64(b[2])<<8 |
+			uint64(b[3]), 4, nil
+	case 3: // 8-byte encoding: 11xxxxxx
+		if len(b) < 8 {
+			return 0, 0, io.ErrUnexpectedEOF
+		}
+		return uint64(first&0x3F)<<56 |
+			uint64(b[1])<<48 |
+			uint64(b[2])<<40 |
+			uint64(b[3])<<32 |
+			uint64(b[4])<<24 |
+			uint64(b[5])<<16 |
+			uint64(b[6])<<8 |
+			uint64(b[7]), 8, nil
 	}
-	b0 := firstByte & (0xff - 0xc0)
-	if l == 1 {
-		return uint64(b0), 1, nil
-	}
-	if l == 2 {
-		return uint64(b[1]) + uint64(b0)<<8, 2, nil
-	}
-	if l == 4 {
-		return uint64(b[3]) + uint64(b[2])<<8 + uint64(b[1])<<16 + uint64(b0)<<24, 4, nil
-	}
-	return uint64(b[7]) + uint64(b[6])<<8 + uint64(b[5])<<16 + uint64(b[4])<<24 + uint64(b[3])<<32 + uint64(b[2])<<40 + uint64(b[1])<<48 + uint64(b0)<<56, 8, nil
+
+	// Should never be reached
+	return 0, 0, io.ErrUnexpectedEOF
 }
 
 // Append appends i in the QUIC varint format.

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -50,15 +50,27 @@ func TestParsingFailures(t *testing.T) {
 			expectedErr: io.EOF,
 		},
 		{
-			name:        "slice too short",
-			input:       Append(nil, maxVarInt2*10)[:3],
+			name:        "2-byte encoding: not enough bytes",
+			input:       []byte{0b01000001},
+			expectedErr: io.ErrUnexpectedEOF,
+		},
+		{
+			name:        "4-byte encoding: not enough bytes",
+			input:       []byte{0b10000000, 0x0, 0x0},
+			expectedErr: io.ErrUnexpectedEOF,
+		},
+		{
+			name:        "8-byte encoding: not enough bytes",
+			input:       []byte{0b11000000, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 			expectedErr: io.ErrUnexpectedEOF,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := Parse(tt.input)
+			value, l, err := Parse(tt.input)
+			require.Equal(t, uint64(0), value)
+			require.Equal(t, 0, l)
 			require.Equal(t, tt.expectedErr, err)
 		})
 	}

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -14,7 +14,7 @@ func TestLimits(t *testing.T) {
 	require.Equal(t, uint64(1<<62-1), uint64(Max))
 }
 
-func TestParsing(t *testing.T) {
+func TestRead(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    []byte
@@ -34,6 +34,29 @@ func TestParsing(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, val)
 			require.Zero(t, b.Len())
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         []byte
+		expectedValue uint64
+		expectedLen   int
+	}{
+		{"1 byte", []byte{0b00011001}, 25, 1},
+		{"2 byte", []byte{0b01111011, 0xbd}, 15293, 2},
+		{"4 byte", []byte{0b10011101, 0x7f, 0x3e, 0x7d}, 494878333, 4},
+		{"8 byte", []byte{0b11000010, 0x19, 0x7c, 0x5e, 0xff, 0x14, 0xe8, 0x8c}, 151288809941952652, 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, l, err := Parse(tt.input)
+			require.Equal(t, tt.expectedValue, value)
+			require.Equal(t, tt.expectedLen, l)
+			require.Nil(t, err)
 		})
 	}
 }


### PR DESCRIPTION
I would like to propose the following changes. quicvarint.Parse is one of the most called functions during parsing, and it is responsible for about 40% of time spend during parsing, at least for this benchmark. Maybe (depending on the number of ACK frames), it may be a bit lower, but even it if was 10%, it would be significant. 

`go test -bench=BenchmarkParseStreamAndACK -cpuprofile=cpu.pprof`

<img width="613" alt="Screenshot 2025-06-17 at 22 10 20" src="https://github.com/user-attachments/assets/e87de867-8ec6-463b-b31c-9df3c8640e1b" />

Thus, if we were to improve the performance of quicvarint.Parse, we could significantly improve the performance during parsing, and I believe adjustments here could be worth the effort. 

I propose the following changes: 

- We can further stop converting the length into a number, to further improve the performance
- We can use a bitwise OR pipe operator instead of the addition - this seems to be slightly faster than the addition, at least minimally. This also seems to be the way to go in the go standard library, see binary.BigEndian.Uint64. 
- We can use the binary.BigEndian module to convert 8 byte directly into an uint64. This seems to be faster for the 8 byte integer only though (even though it uses pretty much the same code, just in the standard library). Adding the bounds check from the standard library directly to our code also didn't made a difference. 

Overall, I believe this change could improve the overall stream parsing by another few percentage points.

```
goos: darwin
goarch: arm64
pkg: github.com/quic-go/quic-go/quicvarint
cpu: Apple M4 Max
                │ original.out │         original-pipe.out          │              plus.out               │                pipe.out                │               binary.out               │                mix.out                 │
                │    sec/op    │   sec/op     vs base               │   sec/op     vs base                │   sec/op     vs base                   │   sec/op     vs base                   │   sec/op     vs base                   │
Parse/1-byte-16    1.947n ± 1%   1.973n ± 1%  +1.34% (p=0.001 n=10)   1.723n ± 0%  -11.50% (p=0.000 n=10)   1.689n ± 1%  -13.25% (p=0.000 n=10+60)   1.705n ± 1%  -12.43% (p=0.000 n=10+60)   1.669n ± 0%  -14.30% (p=0.000 n=10+60)
Parse/2-byte-16    2.030n ± 1%   2.039n ± 0%  +0.44% (p=0.022 n=10)   1.775n ± 0%  -12.54% (p=0.000 n=10)   1.768n ± 0%  -12.88% (p=0.000 n=10+60)   1.769n ± 0%  -12.86% (p=0.000 n=10+60)   1.748n ± 0%  -13.89% (p=0.000 n=10+60)
Parse/4-byte-16    2.012n ± 1%   1.998n ± 1%       ~ (p=0.054 n=10)   1.958n ± 0%   -2.71% (p=0.000 n=10)   1.972n ± 0%   -1.99% (p=0.000 n=10+60)   1.956n ± 0%   -2.78% (p=0.000 n=10+60)   1.948n ± 0%   -3.16% (p=0.000 n=10+60)
Parse/8-byte-16    2.014n ± 0%   2.002n ± 1%  -0.60% (p=0.003 n=10)   2.444n ± 1%  +21.32% (p=0.000 n=10)   2.414n ± 2%  +19.83% (p=0.000 n=10+60)   2.201n ± 0%   +9.28% (p=0.000 n=10+60)   2.193n ± 0%   +8.89% (p=0.000 n=10+60)
geomean            2.001n        2.003n       +0.12%                  1.956n        -2.23%                  1.942n        -2.94%                     1.898n        -5.11%                     1.879n        -6.08%
```


I ran the following benchmarks: 

- original.out: The original code from before
- original-pipe.out: The original code, just with a bitwise OR instead of an addition
- pipe.out: The code attached below
- plus.out: The code for pipe.out, just replaced the | with an +
- binary.out: Attached below, it uses the binary module for the 4 byte / 8 byte varint
- mix.out: Using binary.BigEndian seems to be faster for 8 byte varints only. Thus, we're using this module here, and this is the version of the PR. I'm not fully sure why it is faster, as in the standard library, it is implemented the same way as if we wrote it here (and the bounds check should be omitted due to checking the length before anyway). still, it's faster this way. 

pipe.out:
```
func Parse(b []byte) (uint64 /* value */, int /* bytes consumed */, error) {
	if len(b) == 0 {
		return 0, 0, io.EOF
	}

	first := b[0]
	switch first >> 6 {
	case 0: // 1-byte encoding: 00xxxxxx
		return uint64(first & 0x3F), 1, nil
	case 1: // 2-byte encoding: 01xxxxxx
		if len(b) < 2 {
			return 0, 0, io.ErrUnexpectedEOF
		}
		return uint64(first&0x3F)<<8 | uint64(b[1]), 2, nil
	case 2: // 4-byte encoding: 10xxxxxx
		if len(b) < 4 {
			return 0, 0, io.ErrUnexpectedEOF
		}
		return uint64(first&0x3F)<<24 |
			uint64(b[1])<<16 |
			uint64(b[2])<<8 |
			uint64(b[3]), 4, nil
	case 3: // 8-byte encoding: 11xxxxxx
		if len(b) < 8 {
			return 0, 0, io.ErrUnexpectedEOF
		}
		return uint64(first&0x3F)<<56 |
			uint64(b[1])<<48 |
			uint64(b[2])<<40 |
			uint64(b[3])<<32 |
			uint64(b[4])<<24 |
			uint64(b[5])<<16 |
			uint64(b[6])<<8 |
			uint64(b[7]), 8, nil
	}

	// Should never be reached
	return 0, 0, io.ErrUnexpectedEOF
}
```

binary.out:
```
func Parse(b []byte) (uint64 /* value */, int /* bytes consumed */, error) {
	if len(b) == 0 {
		return 0, 0, io.EOF
	}

	first := b[0]
	switch first >> 6 {
	case 0: // 1-byte encoding: 00xxxxxx
		return uint64(first & 0x3F), 1, nil
	case 1: // 2-byte encoding: 01xxxxxx
		if len(b) < 2 {
			return 0, 0, io.ErrUnexpectedEOF
		}
		return uint64(first&0x3F)<<8 | uint64(b[1]), 2, nil
	case 2: // 4-byte encoding
		if len(b) < 4 {
			return 0, 0, io.ErrUnexpectedEOF
		}
		// inject the top 6 bits into the highest byte
		tmp := binary.BigEndian.Uint32(b[0:4])
		tmp &= 0x3FFFFFFF // clear top 2 bits (in first byte)
		return uint64(tmp), 4, nil

	case 3: // 8-byte encoding
		if len(b) < 8 {
			return 0, 0, io.ErrUnexpectedEOF
		}
		tmp := binary.BigEndian.Uint64(b[0:8])
		tmp &= 0x3FFFFFFFFFFFFFFF // clear top 2 bits
		return tmp, 8, nil
	}

	// Should never be reached
	return 0, 0, io.ErrUnexpectedEOF
}
```