### PR TITLE
fix retransmission logic for path probing packets

### DIFF
--- a/path_manager_outgoing.go
+++ b/path_manager_outgoing.go
@@ -50,6 +50,7 @@ func (p *Path) Probe(ctx context.Context) error {
 			p.validated.Store(true)
 			return nil
 		case <-timerChan:
+			nextProbeDur *= 2 // exponential backoff
 			p.pathManager.enqueueProbe(p)
 		case <-path.ProbeSent():
 		case <-p.abandon:
@@ -61,7 +62,6 @@ func (p *Path) Probe(ctx context.Context) error {
 		}
 		timer = time.NewTimer(nextProbeDur)
 		timerChan = timer.C
-		nextProbeDur *= 2 // exponential backoff
 	}
 }
 


### PR DESCRIPTION
To achieve an exponential backoff, the timer should only be reset after having fired.

This should also fix #5199.