### PR TITLE
fix: close transport when dial error

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,6 +31,7 @@ func DialAddr(ctx context.Context, addr string, tlsConf *tls.Config, conf *Confi
 	}
 	conn, err := tr.dial(ctx, udpAddr, addr, tlsConf, conf, false)
 	if err != nil {
+		tr.Close()
 		return nil, err
 	}
 	return conn, nil


### PR DESCRIPTION
Close the transport after dial fails to avoid memory leaks.

---

I noticed that `DialAddrEarly` has `tr.Close()` but `DialAddr` does not, if this is intentional then please close this PR