### PR TITLE
ackhandler: generalize check for missing packets below threshold

### DIFF
--- a/internal/ackhandler/received_packet_history.go
+++ b/internal/ackhandler/received_packet_history.go
@@ -23,7 +23,9 @@ type receivedPacketHistory struct {
 }
 
 func newReceivedPacketHistory() *receivedPacketHistory {
-	return &receivedPacketHistory{}
+	return &receivedPacketHistory{
+		deletedBelow: protocol.InvalidPacketNumber,
+	}
 }
 
 // ReceivedPacket registers a packet with PacketNumber p and updates the ranges
@@ -115,13 +117,25 @@ func (h *receivedPacketHistory) AppendAckRanges(ackRanges []wire.AckRange) []wir
 	return ackRanges
 }
 
-func (h *receivedPacketHistory) GetHighestAckRange() wire.AckRange {
-	ackRange := wire.AckRange{}
-	if len(h.ranges) > 0 {
-		ackRange.Smallest = h.ranges[len(h.ranges)-1].Start
-		ackRange.Largest = h.ranges[len(h.ranges)-1].End
+func (h *receivedPacketHistory) HighestMissingUpTo(p protocol.PacketNumber) protocol.PacketNumber {
+	if len(h.ranges) == 0 || (h.deletedBelow != protocol.InvalidPacketNumber && p < h.deletedBelow) {
+		return protocol.InvalidPacketNumber
 	}
-	return ackRange
+	p = min(h.ranges[len(h.ranges)-1].End, p)
+	for i := len(h.ranges) - 1; i >= 0; i-- {
+		r := h.ranges[i]
+		if p >= r.Start && p <= r.End {
+			highest := r.Start - 1
+			if h.deletedBelow != protocol.InvalidPacketNumber && highest < h.deletedBelow {
+				return protocol.InvalidPacketNumber
+			}
+			return highest
+		}
+		if i >= 1 && p > h.ranges[i-1].End && p <= r.End {
+			return p
+		}
+	}
+	return p
 }
 
 func (h *receivedPacketHistory) IsPotentiallyDuplicate(p protocol.PacketNumber) bool {

--- a/internal/ackhandler/received_packet_history.go
+++ b/internal/ackhandler/received_packet_history.go
@@ -124,14 +124,15 @@ func (h *receivedPacketHistory) HighestMissingUpTo(p protocol.PacketNumber) prot
 	p = min(h.ranges[len(h.ranges)-1].End, p)
 	for i := len(h.ranges) - 1; i >= 0; i-- {
 		r := h.ranges[i]
-		if p >= r.Start && p <= r.End {
-			highest := r.Start - 1
+		if p >= r.Start && p <= r.End { // p is contained in this range
+			highest := r.Start - 1 // highest packet in the gap before this range
 			if h.deletedBelow != protocol.InvalidPacketNumber && highest < h.deletedBelow {
 				return protocol.InvalidPacketNumber
 			}
 			return highest
 		}
-		if i >= 1 && p > h.ranges[i-1].End && p <= r.End {
+		if i >= 1 && p > h.ranges[i-1].End && p <= r.Start {
+			// p is in the gap between the previous range and this range
 			return p
 		}
 	}

--- a/internal/ackhandler/received_packet_tracker_test.go
+++ b/internal/ackhandler/received_packet_tracker_test.go
@@ -55,11 +55,11 @@ func TestAppDataReceivedPacketTrackerECN(t *testing.T) {
 
 	require.NoError(t, tr.ReceivedPacket(0, protocol.ECT0, time.Now(), true))
 	pn := protocol.PacketNumber(1)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		require.NoError(t, tr.ReceivedPacket(pn, protocol.ECT1, time.Now(), true))
 		pn++
 	}
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		require.NoError(t, tr.ReceivedPacket(pn, protocol.ECNCE, time.Now(), true))
 		pn++
 	}
@@ -124,18 +124,30 @@ func TestAppDataReceivedPacketTrackerQueuesECNCE(t *testing.T) {
 func TestAppDataReceivedPacketTrackerMissingPackets(t *testing.T) {
 	tr := newAppDataReceivedPacketTracker(utils.DefaultLogger)
 
+	now := time.Now()
 	// the first packet is always acknowledged
-	require.NoError(t, tr.ReceivedPacket(0, protocol.ECNNon, time.Now(), true))
-	require.NotNil(t, tr.GetAckFrame(time.Now(), true))
+	require.NoError(t, tr.ReceivedPacket(0, protocol.ECNNon, now, true))
+	require.NotNil(t, tr.GetAckFrame(now, true))
 
-	require.NoError(t, tr.ReceivedPacket(5, protocol.ECNNon, time.Now(), true))
-	ack := tr.GetAckFrame(time.Now(), true) // ACK: 0 and 5, missing: 1, 2, 3, 4
+	require.NoError(t, tr.ReceivedPacket(5, protocol.ECNNon, now, true))
+	ack := tr.GetAckFrame(now, true) // ACK: 0 and 5, missing: 1, 2, 3, 4
 	require.NotNil(t, ack)
 	require.Equal(t, []wire.AckRange{{Smallest: 5, Largest: 5}, {Smallest: 0, Largest: 0}}, ack.AckRanges)
 
 	// now receive one of the missing packets
-	require.NoError(t, tr.ReceivedPacket(3, protocol.ECNNon, time.Now(), true))
-	require.NotNil(t, tr.GetAckFrame(time.Now(), true))
+	require.NoError(t, tr.ReceivedPacket(3, protocol.ECNNon, now, true))
+	ack = tr.GetAckFrame(now, true)
+	require.NotNil(t, ack)
+	require.Equal(t, []wire.AckRange{
+		{Smallest: 5, Largest: 5},
+		{Smallest: 3, Largest: 3},
+		{Smallest: 0, Largest: 0},
+	}, ack.AckRanges)
+
+	require.NoError(t, tr.ReceivedPacket(6, protocol.ECNNon, now, true))
+	require.Nil(t, tr.GetAckFrame(now, true))
+	require.NoError(t, tr.ReceivedPacket(8, protocol.ECNNon, now, true))
+	require.NotNil(t, tr.GetAckFrame(now, true))
 }
 
 func TestAppDataReceivedPacketTrackerDelayTime(t *testing.T) {


### PR DESCRIPTION
No functional change expected.

For #2482.

With the Acknowledgement Frequency extension, the reordering threshold will become configurable. With this change, it will be easy to use the peer-requested value instead of the predefined constant.