### PR TITLE
s/go 1.23/go/1.23.0/

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quic-go/quic-go
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/francoispqt/gojay v1.2.13


### PR DESCRIPTION
This avoids an error on my dev machine:

```
go: download go1.23 for darwin/arm64: toolchain not available
```

See https://github.com/golang/go/issues/66175