### PR TITLE
Tolerate empty reads in `quicvarint.Read`

### DIFF
--- a/quicvarint/io.go
+++ b/quicvarint/io.go
@@ -31,7 +31,12 @@ func NewReader(r io.Reader) Reader {
 
 func (r *byteReader) ReadByte() (byte, error) {
 	var b [1]byte
-	n, err := r.Read(b[:])
+	var n int
+	var err error
+	for n == 0 && err == nil {
+		n, err = r.Read(b[:])
+	}
+
 	if n == 1 && err == io.EOF {
 		err = nil
 	}

--- a/quicvarint/io_test.go
+++ b/quicvarint/io_test.go
@@ -81,6 +81,22 @@ func TestReaderHandlesEOF(t *testing.T) {
 	require.EqualValues(t, 1337, n2)
 }
 
+// Regression test: empty reads were being converted to successful
+// reads of a zero value.
+func TestReaderHandlesEmptyRead(t *testing.T) {
+	r, w := io.Pipe()
+
+	go func() {
+		// io.Pipe turns empty writes into empty reads.
+		w.Write(nil)
+		w.Close()
+	}()
+
+	br := NewReader(r)
+	_, err := Read(br)
+	require.ErrorIs(t, err, io.EOF)
+}
+
 func TestWriterPassesThroughUnchanged(t *testing.T) {
 	b := &bytes.Buffer{}
 	w := NewWriter(b)


### PR DESCRIPTION
Currently, `quicvarint.Read` misinterprets an empty read (`n==0`) as a single zero byte.  While empty reads are "discouraged" in the `io.Reader` interface, they do sometimes happen, especially when using `io.Pipe()`.

This change tolerates empty reads, adds a corresponding unit test, and also includes some additional test coverage related to empty capsules