### PR TITLE
connection: Call newPathManagerOutgoing only once per conn

### DIFF
--- a/path_manager_outgoing.go
+++ b/path_manager_outgoing.go
@@ -128,6 +128,9 @@ type pathManagerOutgoing struct {
 	pathToSwitchTo *pathOutgoing
 }
 
+// newPathManagerOutgoing creates a new pathManagerOutgoing object. This
+// function must be side-effect free as it may be called multiple times for a
+// single connection.
 func newPathManagerOutgoing(
 	getConnID func(pathID) (_ protocol.ConnectionID, ok bool),
 	retireConnID func(pathID),


### PR DESCRIPTION
Noticed this in passing. The compare and swap operation does not do what the comment suggests. Example https://play.golang.com/p/S7dTJ9Pek4W

This is one solution that does what the comment wanted, an alternative is to do something like:
```go
old := ptr.Load()
if old == nil {
  v := init()
  ptr.CompareAndSwap(nil, v)
}
```