### PR TITLE
http3: fix documentation for Server.ServeListener

### DIFF
--- a/http3/server.go
+++ b/http3/server.go
@@ -271,7 +271,7 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 // ServeListener serves an existing QUIC listener.
 // Make sure you use http3.ConfigureTLSConfig to configure a tls.Config
 // and use it to construct a http3-friendly QUIC listener.
-// Closing the server does close the listener.
+// Closing the server does not close the listener. It is the application's responsibility to close them.
 // ServeListener always returns a non-nil error. After Shutdown or Close, the returned error is http.ErrServerClosed.
 func (s *Server) ServeListener(ln QUICListener) error {
 	s.mutex.Lock()


### PR DESCRIPTION
In the release log for [v0.52.0](https://github.com/quic-go/quic-go/releases/tag/v0.52.0), it's stated that:

>QUIC listeners created by the HTTP/3 server (i.e. when using http3.Server.ListenAndServe and ListenAndServeTLS) are immediately closed (https://github.com/quic-go/quic-go/pull/5101). QUIC listeners created by the application (i.e. when using http3.Server.ServeListener) are left running, it is the application's responsibility to close them, or use them in a new server instance (https://github.com/quic-go/quic-go/pull/5129).

This caused problems for the latest version of caddy as caddy used to let http3 servers to close these listeners.