### PR TITLE
quic: fix documentaion for EarlyListener.Close

### DIFF
--- a/server.go
+++ b/server.go
@@ -161,7 +161,10 @@ func (l *EarlyListener) Accept(ctx context.Context) (*Conn, error) {
 	return conn, nil
 }
 
-// Close the server. All active connections will be closed.
+// Close closes the listener.
+// Accept will return [ErrServerClosed] as soon as all connections in the accept queue have been accepted.
+// Early connections that are still in flight will be rejected with a CONNECTION_REFUSED error.
+// Already established (accepted)connections will be unaffected.
 func (l *EarlyListener) Close() error {
 	return l.baseServer.Close()
 }

--- a/server.go
+++ b/server.go
@@ -132,7 +132,7 @@ func (l *Listener) Accept(ctx context.Context) (*Conn, error) {
 // Close closes the listener.
 // Accept will return [ErrServerClosed] as soon as all connections in the accept queue have been accepted.
 // QUIC handshakes that are still in flight will be rejected with a CONNECTION_REFUSED error.
-// Already established (accepted)connections will be unaffected.
+// Already established (accepted) connections will be unaffected.
 func (l *Listener) Close() error {
 	return l.baseServer.Close()
 }
@@ -164,7 +164,7 @@ func (l *EarlyListener) Accept(ctx context.Context) (*Conn, error) {
 // Close closes the listener.
 // Accept will return [ErrServerClosed] as soon as all connections in the accept queue have been accepted.
 // Early connections that are still in flight will be rejected with a CONNECTION_REFUSED error.
-// Already established (accepted)connections will be unaffected.
+// Already established (accepted) connections will be unaffected.
 func (l *EarlyListener) Close() error {
 	return l.baseServer.Close()
 }


### PR DESCRIPTION
In the release notes for [v0.52.0](https://github.com/quic-go/quic-go/releases/tag/v0.52.0), under the **Breaking Changes** section:

>Connections accepted from a Listener using the Listen and ListenAddr convenience functions now aren't closed when the listener is closed. This makes the shutdown behavior consistent with listeners created from a Transport, and the standard library's net.Listener: https://github.com/quic-go/quic-go/pull/5108.

Nothing is said if the same holds for `EarlyListener` created from `ListenEarly` and `ListenAddrEarly`.

However, in the tests from [5129](https://github.com/quic-go/quic-go/pull/5129/files#diff-5afd3e8a7a929c03c61e5a76a9a67211de70b66fcdd294ecbd55ff2d080b7a70R254), when using `ListenAndServe`, it actually creates `*quic.EarlyListener`

https://github.com/quic-go/quic-go/blob/c2e784aaf21fe66f55b166249d8c9dc9b0aa0fc7/http3/server.go#L342-L344

I checked the implementation of both `Close`, it's the same, the only difference is how new connections are rejected

https://github.com/quic-go/quic-go/blob/f0042715d7fdbf84fdb37b87d3722ff55c553db0/server.go#L772-L793

And since the related tests passed, I assume the same is true for `EarlyListener`.