### PR TITLE
use testing.B.Loop in all benchmark tests

### DIFF
--- a/integrationtests/self/benchmark_test.go
+++ b/integrationtests/self/benchmark_test.go
@@ -31,8 +31,7 @@ func BenchmarkHandshake(b *testing.B) {
 	tr := &quic.Transport{Conn: newUDPConnLocalhost(b)}
 	defer tr.Close()
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		c, err := tr.Dial(context.Background(), ln.Addr(), tlsClientConfig, nil)
 		require.NoError(b, err)
 		serverConn := <-connChan
@@ -68,8 +67,7 @@ func BenchmarkStreamChurn(b *testing.B) {
 		}
 	}()
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		str, err := conn.OpenStreamSync(context.Background())
 		require.NoError(b, err)
 		require.NoError(b, str.Close())

--- a/internal/handshake/hkdf_test.go
+++ b/internal/handshake/hkdf_test.go
@@ -65,8 +65,8 @@ func benchmarkHKDFExpandLabel(b *testing.B, cipherSuite uint16, useStdLib bool) 
 	cs := cipherSuiteTLS13ByID(cipherSuite)
 	secret := make([]byte, 32)
 	rand.Read(secret)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		if useStdLib {
 			nextTrafficSecret(cs, secret)
 		} else {

--- a/internal/handshake/initial_aead_test.go
+++ b/internal/handshake/initial_aead_test.go
@@ -246,7 +246,8 @@ func TestInitialAEADEncryptsAndDecryptsHeader(t *testing.T) {
 func BenchmarkInitialAEADCreate(b *testing.B) {
 	b.ReportAllocs()
 	connID := protocol.ParseConnectionID([]byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef})
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		NewInitialAEAD(connID, protocol.PerspectiveServer, protocol.Version1)
 	}
 }
@@ -282,7 +283,8 @@ func BenchmarkInitialAEAD(b *testing.B) {
 func benchmarkOpen(b *testing.B, aead LongHeaderOpener, msg, hdr []byte) {
 	b.ReportAllocs()
 	dst := make([]byte, 0, 1500)
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		dst = dst[:0]
 		if _, err := aead.Open(dst, msg, 42, hdr); err != nil {
 			b.Fatalf("opening failed: %s", err)
@@ -293,8 +295,11 @@ func benchmarkOpen(b *testing.B, aead LongHeaderOpener, msg, hdr []byte) {
 func benchmarkSeal(b *testing.B, aead LongHeaderSealer, msg, hdr []byte) {
 	b.ReportAllocs()
 	dst := make([]byte, 0, 1500)
-	for i := 0; i < b.N; i++ {
+
+	var pn protocol.PacketNumber
+	for b.Loop() {
 		dst = dst[:0]
-		aead.Seal(dst, msg, protocol.PacketNumber(i), hdr)
+		aead.Seal(dst, msg, pn, hdr)
+		pn++
 	}
 }

--- a/internal/utils/ringbuffer/ringbuffer_bench_test.go
+++ b/internal/utils/ringbuffer/ringbuffer_bench_test.go
@@ -4,9 +4,11 @@ import "testing"
 
 func BenchmarkRingBuffer(b *testing.B) {
 	r := RingBuffer[int]{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		r.PushBack(i)
+
+	var val int
+	for b.Loop() {
+		r.PushBack(val)
 		r.PopFront()
+		val++
 	}
 }

--- a/internal/wire/extended_header_test.go
+++ b/internal/wire/extended_header_test.go
@@ -239,6 +239,8 @@ func TestLogsRetryPacketsWithToken(t *testing.T) {
 }
 
 func BenchmarkParseExtendedHeader(b *testing.B) {
+	b.ReportAllocs()
+
 	data, err := (&ExtendedHeader{
 		Header: Header{
 			Type:             protocol.PacketTypeHandshake,
@@ -255,9 +257,7 @@ func BenchmarkParseExtendedHeader(b *testing.B) {
 	}
 	data = append(data, make([]byte, 1231)...)
 
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		hdr, _, _, err := ParsePacket(data)
 		if err != nil {
 			b.Fatal(err)

--- a/internal/wire/frame_parser_test.go
+++ b/internal/wire/frame_parser_test.go
@@ -818,15 +818,13 @@ func BenchmarkParseDatagramFrame(b *testing.B) {
 }
 
 func benchmarkFrames(b *testing.B, frames ...Frame) {
-	buf := writeFrames(b, frames...)
+	b.ReportAllocs()
 
+	buf := writeFrames(b, frames...)
 	parser := NewFrameParser(true, true, true)
 	parser.SetAckDelayExponent(3)
 
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for range b.N {
+	for b.Loop() {
 		parseFrames(b, parser, buf, frames...)
 	}
 }

--- a/internal/wire/short_header_test.go
+++ b/internal/wire/short_header_test.go
@@ -94,7 +94,8 @@ func BenchmarkWriteShortHeader(b *testing.B) {
 	b.ReportAllocs()
 	buf := make([]byte, 100)
 	connID := protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6})
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		var err error
 		buf, err = AppendShortHeader(buf, connID, 1337, protocol.PacketNumberLen4, protocol.KeyPhaseOne)
 		if err != nil {

--- a/internal/wire/transport_parameter_test.go
+++ b/internal/wire/transport_parameter_test.go
@@ -878,6 +878,8 @@ func BenchmarkTransportParameters(b *testing.B) {
 }
 
 func benchmarkTransportParameters(b *testing.B, withPreferredAddress bool) {
+	b.ReportAllocs()
+
 	var token protocol.StatelessResetToken
 	rand.Read(token[:])
 	rcid := protocol.ParseConnectionID([]byte{0xde, 0xad, 0xc0, 0xde})
@@ -915,10 +917,8 @@ func benchmarkTransportParameters(b *testing.B, withPreferredAddress bool) {
 	}
 	data := params.Marshal(protocol.PerspectiveServer)
 
-	b.ResetTimer()
-	b.ReportAllocs()
 	var p TransportParameters
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if err := p.Unmarshal(data, protocol.PerspectiveServer); err != nil {
 			b.Fatal(err)
 		}

--- a/internal/wire/version_negotiation_test.go
+++ b/internal/wire/version_negotiation_test.go
@@ -92,10 +92,12 @@ versionLoop:
 
 func BenchmarkComposeVersionNegotiationPacket(b *testing.B) {
 	b.ReportAllocs()
+
 	supportedVersions := []protocol.Version{protocol.Version2, protocol.Version1, 0x1337}
 	destConnID := protocol.ArbitraryLenConnectionID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0xa, 0xb, 0xc, 0xd}
 	srcConnID := protocol.ArbitraryLenConnectionID{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		ComposeVersionNegotiation(destConnID, srcConnID, supportedVersions)
 	}
 }

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -212,9 +212,10 @@ type benchmarkValue struct {
 	v uint64
 }
 
-func randomValues(num int, maxValue uint64) []benchmarkValue {
+func randomValues(maxValue uint64) []benchmarkValue {
 	r := rand.New(rand.NewPCG(13, 37))
 
+	const num = 1025
 	bv := make([]benchmarkValue, num)
 	for i := range num {
 		v := r.Uint64() % maxValue
@@ -226,18 +227,18 @@ func randomValues(num int, maxValue uint64) []benchmarkValue {
 
 // using a reader that is also an io.ByteReader
 func BenchmarkReadBytesReader(b *testing.B) {
-	b.Run("1-byte", func(b *testing.B) { benchmarkRead(b, randomValues(min(b.N, 1024), maxVarInt1), false) })
-	b.Run("2-byte", func(b *testing.B) { benchmarkRead(b, randomValues(min(b.N, 1024), maxVarInt2), false) })
-	b.Run("4-byte", func(b *testing.B) { benchmarkRead(b, randomValues(min(b.N, 1024), maxVarInt4), false) })
-	b.Run("8-byte", func(b *testing.B) { benchmarkRead(b, randomValues(min(b.N, 1024), maxVarInt8), false) })
+	b.Run("1-byte", func(b *testing.B) { benchmarkRead(b, randomValues(maxVarInt1), false) })
+	b.Run("2-byte", func(b *testing.B) { benchmarkRead(b, randomValues(maxVarInt2), false) })
+	b.Run("4-byte", func(b *testing.B) { benchmarkRead(b, randomValues(maxVarInt4), false) })
+	b.Run("8-byte", func(b *testing.B) { benchmarkRead(b, randomValues(maxVarInt8), false) })
 }
 
 // using a reader that is not an io.ByteReader
 func BenchmarkReadSimpleReader(b *testing.B) {
-	b.Run("1-byte", func(b *testing.B) { benchmarkRead(b, randomValues(min(b.N, 1024), maxVarInt1), true) })
-	b.Run("2-byte", func(b *testing.B) { benchmarkRead(b, randomValues(min(b.N, 1024), maxVarInt2), true) })
-	b.Run("4-byte", func(b *testing.B) { benchmarkRead(b, randomValues(min(b.N, 1024), maxVarInt4), true) })
-	b.Run("8-byte", func(b *testing.B) { benchmarkRead(b, randomValues(min(b.N, 1024), maxVarInt8), true) })
+	b.Run("1-byte", func(b *testing.B) { benchmarkRead(b, randomValues(maxVarInt1), true) })
+	b.Run("2-byte", func(b *testing.B) { benchmarkRead(b, randomValues(maxVarInt2), true) })
+	b.Run("4-byte", func(b *testing.B) { benchmarkRead(b, randomValues(maxVarInt4), true) })
+	b.Run("8-byte", func(b *testing.B) { benchmarkRead(b, randomValues(maxVarInt8), true) })
 }
 
 // simpleReader satisfies io.Reader, but not io.ByteReader
@@ -254,9 +255,11 @@ func benchmarkRead(b *testing.B, inputs []benchmarkValue, wrapBytesReader bool) 
 	} else {
 		vr = NewReader(r)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	var i int
+	for b.Loop() {
 		index := i % len(inputs)
+		i++
 		r.Reset(inputs[index].b)
 		val, err := Read(vr)
 		if err != nil {
@@ -269,16 +272,17 @@ func benchmarkRead(b *testing.B, inputs []benchmarkValue, wrapBytesReader bool) 
 }
 
 func BenchmarkParse(b *testing.B) {
-	b.Run("1-byte", func(b *testing.B) { benchmarkParse(b, randomValues(min(b.N, 1024), maxVarInt1)) })
-	b.Run("2-byte", func(b *testing.B) { benchmarkParse(b, randomValues(min(b.N, 1024), maxVarInt2)) })
-	b.Run("4-byte", func(b *testing.B) { benchmarkParse(b, randomValues(min(b.N, 1024), maxVarInt4)) })
-	b.Run("8-byte", func(b *testing.B) { benchmarkParse(b, randomValues(min(b.N, 1024), maxVarInt8)) })
+	b.Run("1-byte", func(b *testing.B) { benchmarkParse(b, randomValues(maxVarInt1)) })
+	b.Run("2-byte", func(b *testing.B) { benchmarkParse(b, randomValues(maxVarInt2)) })
+	b.Run("4-byte", func(b *testing.B) { benchmarkParse(b, randomValues(maxVarInt4)) })
+	b.Run("8-byte", func(b *testing.B) { benchmarkParse(b, randomValues(maxVarInt8)) })
 }
 
 func benchmarkParse(b *testing.B, inputs []benchmarkValue) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		index := i % 1024
+	var i int
+	for b.Loop() {
+		index := i % len(inputs)
+		i++
 		val, n, err := Parse(inputs[index].b)
 		if err != nil {
 			b.Fatal(err)
@@ -293,18 +297,20 @@ func benchmarkParse(b *testing.B, inputs []benchmarkValue) {
 }
 
 func BenchmarkAppend(b *testing.B) {
-	b.Run("1-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(min(b.N, 1024), maxVarInt1)) })
-	b.Run("2-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(min(b.N, 1024), maxVarInt2)) })
-	b.Run("4-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(min(b.N, 1024), maxVarInt4)) })
-	b.Run("8-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(min(b.N, 1024), maxVarInt8)) })
+	b.Run("1-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(maxVarInt1)) })
+	b.Run("2-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(maxVarInt2)) })
+	b.Run("4-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(maxVarInt4)) })
+	b.Run("8-byte", func(b *testing.B) { benchmarkAppend(b, randomValues(maxVarInt8)) })
 }
 
 func benchmarkAppend(b *testing.B, inputs []benchmarkValue) {
 	buf := make([]byte, 8)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	var i int
+	for b.Loop() {
 		buf = buf[:0]
-		index := i % 1024
+		index := i % len(inputs)
+		i++
 		buf = Append(buf, inputs[index].v)
 
 		if !bytes.Equal(buf, inputs[index].b) {
@@ -314,18 +320,20 @@ func benchmarkAppend(b *testing.B, inputs []benchmarkValue) {
 }
 
 func BenchmarkAppendWithLen(b *testing.B) {
-	b.Run("1-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(min(b.N, 1024), maxVarInt1)) })
-	b.Run("2-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(min(b.N, 1024), maxVarInt2)) })
-	b.Run("4-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(min(b.N, 1024), maxVarInt4)) })
-	b.Run("8-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(min(b.N, 1024), maxVarInt8)) })
+	b.Run("1-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(maxVarInt1)) })
+	b.Run("2-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(maxVarInt2)) })
+	b.Run("4-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(maxVarInt4)) })
+	b.Run("8-byte", func(b *testing.B) { benchmarkAppendWithLen(b, randomValues(maxVarInt8)) })
 }
 
 func benchmarkAppendWithLen(b *testing.B, inputs []benchmarkValue) {
 	buf := make([]byte, 8)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	var i int
+	for b.Loop() {
 		buf = buf[:0]
-		index := i % 1024
+		index := i % len(inputs)
+		i++
 		buf = AppendWithLen(buf, inputs[index].v, len(inputs[index].b))
 
 		if !bytes.Equal(buf, inputs[index].b) {


### PR DESCRIPTION
Fixes #5002.

`go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -category=bloop -fix -test ./...` was used as a starting point.