### PR TITLE
replace `interface{}` with `any`

### DIFF
--- a/http3/frames.go
+++ b/http3/frames.go
@@ -15,7 +15,7 @@ type FrameType uint64
 
 type unknownFrameHandlerFunc func(FrameType, error) (processed bool, err error)
 
-type frame interface{}
+type frame any
 
 var errHijacked = errors.New("hijacked")
 

--- a/internal/utils/log.go
+++ b/internal/utils/log.go
@@ -31,9 +31,9 @@ type Logger interface {
 	WithPrefix(prefix string) Logger
 	Debug() bool
 
-	Errorf(format string, args ...interface{})
-	Infof(format string, args ...interface{})
-	Debugf(format string, args ...interface{})
+	Errorf(format string, args ...any)
+	Infof(format string, args ...any)
+	Debugf(format string, args ...any)
 }
 
 // DefaultLogger is used by quic-go for logging.
@@ -61,27 +61,27 @@ func (l *defaultLogger) SetLogTimeFormat(format string) {
 }
 
 // Debugf logs something
-func (l *defaultLogger) Debugf(format string, args ...interface{}) {
+func (l *defaultLogger) Debugf(format string, args ...any) {
 	if l.logLevel == LogLevelDebug {
 		l.logMessage(format, args...)
 	}
 }
 
 // Infof logs something
-func (l *defaultLogger) Infof(format string, args ...interface{}) {
+func (l *defaultLogger) Infof(format string, args ...any) {
 	if l.logLevel >= LogLevelInfo {
 		l.logMessage(format, args...)
 	}
 }
 
 // Errorf logs something
-func (l *defaultLogger) Errorf(format string, args ...interface{}) {
+func (l *defaultLogger) Errorf(format string, args ...any) {
 	if l.logLevel >= LogLevelError {
 		l.logMessage(format, args...)
 	}
 }
 
-func (l *defaultLogger) logMessage(format string, args ...interface{}) {
+func (l *defaultLogger) logMessage(format string, args ...any) {
 	var pre string
 
 	if len(l.timeFormat) > 0 {

--- a/internal/wire/pool.go
+++ b/internal/wire/pool.go
@@ -9,7 +9,7 @@ import (
 var pool sync.Pool
 
 func init() {
-	pool.New = func() interface{} {
+	pool.New = func() any {
 		return &StreamFrame{
 			Data:     make([]byte, 0, protocol.MaxPacketBufferSize),
 			fromPool: true,

--- a/logging/frame.go
+++ b/logging/frame.go
@@ -3,7 +3,7 @@ package logging
 import "github.com/quic-go/quic-go/internal/wire"
 
 // A Frame is a QUIC frame
-type Frame interface{}
+type Frame any
 
 // The AckRange is used within the AckFrame.
 // It is a range of packet numbers that is being acknowledged.

--- a/qlog/connection_tracer_test.go
+++ b/qlog/connection_tracer_test.go
@@ -39,14 +39,14 @@ func TestConnectionTraceMetadata(t *testing.T) {
 	tracer, buf := newConnectionTracer()
 	tracer.Close()
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	require.NoError(t, unmarshal(buf.Bytes(), &m))
 	require.Equal(t, "0.3", m["qlog_version"])
 	require.Contains(t, m, "title")
 	require.Contains(t, m, "trace")
-	trace := m["trace"].(map[string]interface{})
+	trace := m["trace"].(map[string]any)
 	require.Contains(t, trace, "common_fields")
-	commonFields := trace["common_fields"].(map[string]interface{})
+	commonFields := trace["common_fields"].(map[string]any)
 	require.Equal(t, "deadbeef", commonFields["ODCID"])
 	require.Equal(t, "deadbeef", commonFields["group_id"])
 	require.Contains(t, commonFields, "reference_time")
@@ -54,7 +54,7 @@ func TestConnectionTraceMetadata(t *testing.T) {
 	require.WithinDuration(t, time.Now(), referenceTime, scaleDuration(10*time.Millisecond))
 	require.Equal(t, "relative", commonFields["time_format"])
 	require.Contains(t, trace, "vantage_point")
-	vantagePoint := trace["vantage_point"].(map[string]interface{})
+	vantagePoint := trace["vantage_point"].(map[string]any)
 	require.Equal(t, "server", vantagePoint["type"])
 }
 
@@ -102,8 +102,8 @@ func TestVersionNegotiationWithPriorAttempts(t *testing.T) {
 	ev := entry.Event
 	require.Len(t, ev, 3)
 	require.Equal(t, "1337", ev["chosen_version"])
-	require.Equal(t, []interface{}{"1", "2", "3"}, ev["client_versions"])
-	require.Equal(t, []interface{}{"4", "5", "6"}, ev["server_versions"])
+	require.Equal(t, []any{"1", "2", "3"}, ev["client_versions"])
+	require.Equal(t, []any{"4", "5", "6"}, ev["server_versions"])
 }
 
 func TestIdleTimeouts(t *testing.T) {
@@ -302,7 +302,7 @@ func testTransportParametersWithPreferredAddress(t *testing.T, hasIPv4, hasIPv6 
 	ev := entry.Event
 	require.Equal(t, "local", ev["owner"])
 	require.Contains(t, ev, "preferred_address")
-	pa := ev["preferred_address"].(map[string]interface{})
+	pa := ev["preferred_address"].(map[string]any)
 	if hasIPv4 {
 		require.Equal(t, "12.34.56.78", pa["ip_v4"])
 		require.Equal(t, float64(123), pa["port_v4"])
@@ -399,20 +399,20 @@ func TestSentLongHeaderPacket(t *testing.T) {
 	require.Equal(t, "transport:packet_sent", entry.Name)
 	ev := entry.Event
 	require.Contains(t, ev, "raw")
-	raw := ev["raw"].(map[string]interface{})
+	raw := ev["raw"].(map[string]any)
 	require.Equal(t, float64(987), raw["length"])
 	require.Equal(t, float64(1337), raw["payload_length"])
 	require.Contains(t, ev, "header")
-	hdr := ev["header"].(map[string]interface{})
+	hdr := ev["header"].(map[string]any)
 	require.Equal(t, "handshake", hdr["packet_type"])
 	require.Equal(t, float64(1337), hdr["packet_number"])
 	require.Equal(t, "04030201", hdr["scid"])
 	require.Contains(t, ev, "frames")
 	require.Equal(t, "CE", ev["ecn"])
-	frames := ev["frames"].([]interface{})
+	frames := ev["frames"].([]any)
 	require.Len(t, frames, 2)
-	require.Equal(t, "max_stream_data", frames[0].(map[string]interface{})["frame_type"])
-	require.Equal(t, "stream", frames[1].(map[string]interface{})["frame_type"])
+	require.Equal(t, "max_stream_data", frames[0].(map[string]any)["frame_type"])
+	require.Equal(t, "stream", frames[1].(map[string]any)["frame_type"])
 }
 
 func TestSentShortHeaderPacket(t *testing.T) {
@@ -430,19 +430,19 @@ func TestSentShortHeaderPacket(t *testing.T) {
 	tracer.Close()
 	entry := exportAndParseSingle(t, buf)
 	ev := entry.Event
-	raw := ev["raw"].(map[string]interface{})
+	raw := ev["raw"].(map[string]any)
 	require.Equal(t, float64(123), raw["length"])
 	require.NotContains(t, raw, "payload_length")
 	require.Contains(t, ev, "header")
 	require.NotContains(t, ev, "ecn")
-	hdr := ev["header"].(map[string]interface{})
+	hdr := ev["header"].(map[string]any)
 	require.Equal(t, "1RTT", hdr["packet_type"])
 	require.Equal(t, float64(1337), hdr["packet_number"])
 	require.Contains(t, ev, "frames")
-	frames := ev["frames"].([]interface{})
+	frames := ev["frames"].([]any)
 	require.Len(t, frames, 2)
-	require.Equal(t, "ack", frames[0].(map[string]interface{})["frame_type"])
-	require.Equal(t, "max_data", frames[1].(map[string]interface{})["frame_type"])
+	require.Equal(t, "ack", frames[0].(map[string]any)["frame_type"])
+	require.Equal(t, "max_data", frames[1].(map[string]any)["frame_type"])
 }
 
 func TestReceivedLongHeaderPacket(t *testing.T) {
@@ -472,20 +472,20 @@ func TestReceivedLongHeaderPacket(t *testing.T) {
 	require.Equal(t, "transport:packet_received", entry.Name)
 	ev := entry.Event
 	require.Contains(t, ev, "raw")
-	raw := ev["raw"].(map[string]interface{})
+	raw := ev["raw"].(map[string]any)
 	require.Equal(t, float64(789), raw["length"])
 	require.Equal(t, float64(1234), raw["payload_length"])
 	require.Equal(t, "ECT(0)", ev["ecn"])
 	require.Contains(t, ev, "header")
-	hdr := ev["header"].(map[string]interface{})
+	hdr := ev["header"].(map[string]any)
 	require.Equal(t, "initial", hdr["packet_type"])
 	require.Equal(t, float64(1337), hdr["packet_number"])
 	require.Equal(t, "04030201", hdr["scid"])
 	require.Contains(t, hdr, "token")
-	token := hdr["token"].(map[string]interface{})
+	token := hdr["token"].(map[string]any)
 	require.Equal(t, "deadbeef", token["data"])
 	require.Contains(t, ev, "frames")
-	require.Len(t, ev["frames"].([]interface{}), 2)
+	require.Len(t, ev["frames"].([]any), 2)
 }
 
 func TestReceivedShortHeaderPacket(t *testing.T) {
@@ -511,17 +511,17 @@ func TestReceivedShortHeaderPacket(t *testing.T) {
 	require.Equal(t, "transport:packet_received", entry.Name)
 	ev := entry.Event
 	require.Contains(t, ev, "raw")
-	raw := ev["raw"].(map[string]interface{})
+	raw := ev["raw"].(map[string]any)
 	require.Equal(t, float64(789), raw["length"])
 	require.Equal(t, float64(789-(1+8+3)), raw["payload_length"])
 	require.Equal(t, "ECT(1)", ev["ecn"])
 	require.Contains(t, ev, "header")
-	hdr := ev["header"].(map[string]interface{})
+	hdr := ev["header"].(map[string]any)
 	require.Equal(t, "1RTT", hdr["packet_type"])
 	require.Equal(t, float64(1337), hdr["packet_number"])
 	require.Equal(t, "0", hdr["key_phase_bit"])
 	require.Contains(t, ev, "frames")
-	require.Len(t, ev["frames"].([]interface{}), 2)
+	require.Len(t, ev["frames"].([]any), 2)
 }
 
 func TestReceivedRetryPacket(t *testing.T) {
@@ -542,14 +542,14 @@ func TestReceivedRetryPacket(t *testing.T) {
 	ev := entry.Event
 	require.NotContains(t, ev, "raw")
 	require.Contains(t, ev, "header")
-	header := ev["header"].(map[string]interface{})
+	header := ev["header"].(map[string]any)
 	require.Equal(t, "retry", header["packet_type"])
 	require.NotContains(t, header, "packet_number")
 	require.Contains(t, header, "version")
 	require.Contains(t, header, "dcid")
 	require.Contains(t, header, "scid")
 	require.Contains(t, header, "token")
-	token := header["token"].(map[string]interface{})
+	token := header["token"].(map[string]any)
 	require.Equal(t, "deadbeef", token["data"])
 	require.NotContains(t, ev, "frames")
 }
@@ -569,8 +569,8 @@ func TestReceivedVersionNegotiationPacket(t *testing.T) {
 	require.Contains(t, ev, "header")
 	require.NotContains(t, ev, "frames")
 	require.Contains(t, ev, "supported_versions")
-	require.Equal(t, []interface{}{"deadbeef", "decafbad"}, ev["supported_versions"])
-	header := ev["header"].(map[string]interface{})
+	require.Equal(t, []any{"deadbeef", "decafbad"}, ev["supported_versions"])
+	header := ev["header"].(map[string]any)
 	require.Equal(t, "version_negotiation", header["packet_type"])
 	require.NotContains(t, header, "packet_number")
 	require.NotContains(t, header, "version")
@@ -587,11 +587,11 @@ func TestBufferedPacket(t *testing.T) {
 	require.Equal(t, "transport:packet_buffered", entry.Name)
 	ev := entry.Event
 	require.Contains(t, ev, "header")
-	hdr := ev["header"].(map[string]interface{})
+	hdr := ev["header"].(map[string]any)
 	require.Len(t, hdr, 1)
 	require.Equal(t, "handshake", hdr["packet_type"])
 	require.Contains(t, ev, "raw")
-	require.Equal(t, float64(1337), ev["raw"].(map[string]interface{})["length"])
+	require.Equal(t, float64(1337), ev["raw"].(map[string]any)["length"])
 	require.Equal(t, "keys_unavailable", ev["trigger"])
 }
 
@@ -604,9 +604,9 @@ func TestDroppedPacket(t *testing.T) {
 	require.Equal(t, "transport:packet_dropped", entry.Name)
 	ev := entry.Event
 	require.Contains(t, ev, "raw")
-	require.Equal(t, float64(1337), ev["raw"].(map[string]interface{})["length"])
+	require.Equal(t, float64(1337), ev["raw"].(map[string]any)["length"])
 	require.Contains(t, ev, "header")
-	hdr := ev["header"].(map[string]interface{})
+	hdr := ev["header"].(map[string]any)
 	require.Len(t, hdr, 1)
 	require.Equal(t, "retry", hdr["packet_type"])
 	require.Equal(t, "payload_decrypt_error", ev["trigger"])
@@ -621,9 +621,9 @@ func TestDroppedPacketWithPacketNumber(t *testing.T) {
 	require.Equal(t, "transport:packet_dropped", entry.Name)
 	ev := entry.Event
 	require.Contains(t, ev, "raw")
-	require.Equal(t, float64(1337), ev["raw"].(map[string]interface{})["length"])
+	require.Equal(t, float64(1337), ev["raw"].(map[string]any)["length"])
 	require.Contains(t, ev, "header")
-	hdr := ev["header"].(map[string]interface{})
+	hdr := ev["header"].(map[string]any)
 	require.Len(t, hdr, 2)
 	require.Equal(t, "handshake", hdr["packet_type"])
 	require.Equal(t, float64(42), hdr["packet_number"])
@@ -700,7 +700,7 @@ func TestLostPackets(t *testing.T) {
 	require.Equal(t, "recovery:packet_lost", entry.Name)
 	ev := entry.Event
 	require.Contains(t, ev, "header")
-	hdr := ev["header"].(map[string]interface{})
+	hdr := ev["header"].(map[string]any)
 	require.Len(t, hdr, 2)
 	require.Equal(t, "handshake", hdr["packet_type"])
 	require.Equal(t, float64(42), hdr["packet_number"])

--- a/qlog/event_test.go
+++ b/qlog/event_test.go
@@ -28,7 +28,7 @@ func TestEventMarshaling(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var decoded map[string]interface{}
+	var decoded map[string]any
 	err = json.Unmarshal(buf.Bytes(), &decoded)
 	require.NoError(t, err)
 	require.Len(t, decoded, 3)
@@ -37,7 +37,7 @@ func TestEventMarshaling(t *testing.T) {
 	require.Equal(t, "connectivity:mevent", decoded["name"])
 	require.Contains(t, decoded, "data")
 
-	data, ok := decoded["data"].(map[string]interface{})
+	data, ok := decoded["data"].(map[string]any)
 	require.True(t, ok)
 	require.Len(t, data, 1)
 	require.Equal(t, "details", data["event"])

--- a/qlog/frame_test.go
+++ b/qlog/frame_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func check(t *testing.T, f logging.Frame, expected map[string]interface{}) {
+func check(t *testing.T, f logging.Frame, expected map[string]any) {
 	buf := &bytes.Buffer{}
 	enc := gojay.NewEncoder(buf)
 	err := enc.Encode(frame{Frame: f})
@@ -26,7 +26,7 @@ func check(t *testing.T, f logging.Frame, expected map[string]interface{}) {
 func TestPingFrame(t *testing.T) {
 	check(t,
 		&logging.PingFrame{},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "ping",
 		},
 	)
@@ -36,7 +36,7 @@ func TestAckFrame(t *testing.T) {
 	tests := []struct {
 		name     string
 		frame    *logging.AckFrame
-		expected map[string]interface{}
+		expected map[string]any
 	}{
 		{
 			name: "with delay and single packet range",
@@ -44,7 +44,7 @@ func TestAckFrame(t *testing.T) {
 				DelayTime: 86 * time.Millisecond,
 				AckRanges: []logging.AckRange{{Smallest: 120, Largest: 120}},
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"frame_type":   "ack",
 				"ack_delay":    86,
 				"acked_ranges": [][]float64{{120}},
@@ -55,7 +55,7 @@ func TestAckFrame(t *testing.T) {
 			frame: &logging.AckFrame{
 				AckRanges: []logging.AckRange{{Smallest: 120, Largest: 120}},
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"frame_type":   "ack",
 				"acked_ranges": [][]float64{{120}},
 			},
@@ -68,7 +68,7 @@ func TestAckFrame(t *testing.T) {
 				ECT1:      100,
 				ECNCE:     1000,
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"frame_type":   "ack",
 				"acked_ranges": [][]float64{{120}},
 				"ect0":         10,
@@ -85,7 +85,7 @@ func TestAckFrame(t *testing.T) {
 					{Smallest: 100, Largest: 120},
 				},
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"frame_type": "ack",
 				"ack_delay":  86,
 				"acked_ranges": [][]float64{
@@ -110,7 +110,7 @@ func TestResetStreamFrame(t *testing.T) {
 			FinalSize: 1234,
 			ErrorCode: 42,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "reset_stream",
 			"stream_id":  987,
 			"error_code": 42,
@@ -127,7 +127,7 @@ func TestResetStreamAtFrame(t *testing.T) {
 			ErrorCode:    42,
 			ReliableSize: 999,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type":    "reset_stream_at",
 			"stream_id":     987,
 			"error_code":    42,
@@ -145,7 +145,7 @@ func TestAckFrequencyFrame(t *testing.T) {
 			RequestMaxAckDelay:    42 * time.Millisecond,
 			ReorderingThreshold:   1234,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type":              "ack_frequency",
 			"sequence_number":         1337,
 			"ack_eliciting_threshold": 123,
@@ -158,7 +158,7 @@ func TestAckFrequencyFrame(t *testing.T) {
 func TestImmediateAckFrame(t *testing.T) {
 	check(t,
 		&logging.ImmediateAckFrame{},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "immediate_ack",
 		},
 	)
@@ -170,7 +170,7 @@ func TestStopSendingFrame(t *testing.T) {
 			StreamID:  987,
 			ErrorCode: 42,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "stop_sending",
 			"stream_id":  987,
 			"error_code": 42,
@@ -184,7 +184,7 @@ func TestCryptoFrame(t *testing.T) {
 			Offset: 1337,
 			Length: 6,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "crypto",
 			"offset":     1337,
 			"length":     6,
@@ -197,9 +197,9 @@ func TestNewTokenFrame(t *testing.T) {
 		&logging.NewTokenFrame{
 			Token: []byte{0xde, 0xad, 0xbe, 0xef},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "new_token",
-			"token":      map[string]interface{}{"data": "deadbeef"},
+			"token":      map[string]any{"data": "deadbeef"},
 		},
 	)
 }
@@ -208,7 +208,7 @@ func TestStreamFrame(t *testing.T) {
 	tests := []struct {
 		name     string
 		frame    *logging.StreamFrame
-		expected map[string]interface{}
+		expected map[string]any
 	}{
 		{
 			name: "with FIN",
@@ -218,7 +218,7 @@ func TestStreamFrame(t *testing.T) {
 				Fin:      true,
 				Length:   9876,
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"frame_type": "stream",
 				"stream_id":  42,
 				"offset":     1337,
@@ -233,7 +233,7 @@ func TestStreamFrame(t *testing.T) {
 				Offset:   1337,
 				Length:   3,
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"frame_type": "stream",
 				"stream_id":  42,
 				"offset":     1337,
@@ -254,7 +254,7 @@ func TestMaxDataFrame(t *testing.T) {
 		&logging.MaxDataFrame{
 			MaximumData: 1337,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "max_data",
 			"maximum":    1337,
 		},
@@ -267,7 +267,7 @@ func TestMaxStreamDataFrame(t *testing.T) {
 			StreamID:          1234,
 			MaximumStreamData: 1337,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "max_stream_data",
 			"stream_id":  1234,
 			"maximum":    1337,
@@ -281,7 +281,7 @@ func TestMaxStreamsFrame(t *testing.T) {
 			Type:         protocol.StreamTypeBidi,
 			MaxStreamNum: 42,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type":  "max_streams",
 			"stream_type": "bidirectional",
 			"maximum":     42,
@@ -294,7 +294,7 @@ func TestDataBlockedFrame(t *testing.T) {
 		&logging.DataBlockedFrame{
 			MaximumData: 1337,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "data_blocked",
 			"limit":      1337,
 		},
@@ -307,7 +307,7 @@ func TestStreamDataBlockedFrame(t *testing.T) {
 			StreamID:          42,
 			MaximumStreamData: 1337,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "stream_data_blocked",
 			"stream_id":  42,
 			"limit":      1337,
@@ -321,7 +321,7 @@ func TestStreamsBlockedFrame(t *testing.T) {
 			Type:        protocol.StreamTypeUni,
 			StreamLimit: 123,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type":  "streams_blocked",
 			"stream_type": "unidirectional",
 			"limit":       123,
@@ -337,7 +337,7 @@ func TestNewConnectionIDFrame(t *testing.T) {
 			ConnectionID:        protocol.ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef}),
 			StatelessResetToken: protocol.StatelessResetToken{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type":            "new_connection_id",
 			"sequence_number":       42,
 			"retire_prior_to":       24,
@@ -353,7 +353,7 @@ func TestRetireConnectionIDFrame(t *testing.T) {
 		&logging.RetireConnectionIDFrame{
 			SequenceNumber: 1337,
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type":      "retire_connection_id",
 			"sequence_number": 1337,
 		},
@@ -365,7 +365,7 @@ func TestPathChallengeFrame(t *testing.T) {
 		&logging.PathChallengeFrame{
 			Data: [8]byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xc0, 0x01},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "path_challenge",
 			"data":       "deadbeefcafec001",
 		},
@@ -377,7 +377,7 @@ func TestPathResponseFrame(t *testing.T) {
 		&logging.PathResponseFrame{
 			Data: [8]byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xc0, 0x01},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "path_response",
 			"data":       "deadbeefcafec001",
 		},
@@ -388,7 +388,7 @@ func TestConnectionCloseFrame(t *testing.T) {
 	tests := []struct {
 		name     string
 		frame    *logging.ConnectionCloseFrame
-		expected map[string]interface{}
+		expected map[string]any
 	}{
 		{
 			name: "application error code",
@@ -397,7 +397,7 @@ func TestConnectionCloseFrame(t *testing.T) {
 				ErrorCode:          1337,
 				ReasonPhrase:       "lorem ipsum",
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"frame_type":     "connection_close",
 				"error_space":    "application",
 				"error_code":     1337,
@@ -411,7 +411,7 @@ func TestConnectionCloseFrame(t *testing.T) {
 				ErrorCode:    uint64(qerr.FlowControlError),
 				ReasonPhrase: "lorem ipsum",
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"frame_type":     "connection_close",
 				"error_space":    "transport",
 				"error_code":     "flow_control_error",
@@ -431,7 +431,7 @@ func TestConnectionCloseFrame(t *testing.T) {
 func TestHandshakeDoneFrame(t *testing.T) {
 	check(t,
 		&logging.HandshakeDoneFrame{},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "handshake_done",
 		},
 	)
@@ -440,7 +440,7 @@ func TestHandshakeDoneFrame(t *testing.T) {
 func TestDatagramFrame(t *testing.T) {
 	check(t,
 		&logging.DatagramFrame{Length: 1337},
-		map[string]interface{}{
+		map[string]any{
 			"frame_type": "datagram",
 			"length":     1337,
 		},

--- a/qlog/packet_header_test.go
+++ b/qlog/packet_header_test.go
@@ -32,7 +32,7 @@ func TestPacketTypeFromEncryptionLevel(t *testing.T) {
 	}
 }
 
-func checkHeader(t *testing.T, hdr *wire.ExtendedHeader, expected map[string]interface{}) {
+func checkHeader(t *testing.T, hdr *wire.ExtendedHeader, expected map[string]any) {
 	buf := &bytes.Buffer{}
 	enc := gojay.NewEncoder(buf)
 	require.NoError(t, enc.Encode(transformLongHeader(hdr)))
@@ -51,7 +51,7 @@ func TestMarshalHeaderWithPayloadLength(t *testing.T) {
 				Version: protocol.Version(0xdecafbad),
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"packet_type":   "initial",
 			"packet_number": 42,
 			"dcil":          0,
@@ -72,13 +72,13 @@ func TestMarshalInitialWithToken(t *testing.T) {
 				Token:   []byte{0xde, 0xad, 0xbe, 0xef},
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"packet_type":   "initial",
 			"packet_number": 4242,
 			"dcil":          0,
 			"scil":          0,
 			"version":       "decafbad",
-			"token":         map[string]interface{}{"data": "deadbeef"},
+			"token":         map[string]any{"data": "deadbeef"},
 		},
 	)
 }
@@ -93,12 +93,12 @@ func TestMarshalRetryPacket(t *testing.T) {
 				Token:           []byte{0xde, 0xad, 0xbe, 0xef},
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"packet_type": "retry",
 			"dcil":        0,
 			"scil":        4,
 			"scid":        "11223344",
-			"token":       map[string]interface{}{"data": "deadbeef"},
+			"token":       map[string]any{"data": "deadbeef"},
 			"version":     "decafbad",
 		},
 	)
@@ -113,7 +113,7 @@ func TestMarshalPacketWithPacketNumber0(t *testing.T) {
 				Version: protocol.Version(0xdecafbad),
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"packet_type":   "handshake",
 			"packet_number": 0,
 			"dcil":          0,
@@ -133,7 +133,7 @@ func TestMarshalHeaderWithSourceConnectionID(t *testing.T) {
 				Version:         protocol.Version(0xdecafbad),
 			},
 		},
-		map[string]interface{}{
+		map[string]any{
 			"packet_type":   "handshake",
 			"packet_number": 42,
 			"dcil":          0,

--- a/qlog/tracer_test.go
+++ b/qlog/tracer_test.go
@@ -21,15 +21,15 @@ func TestTraceMetadata(t *testing.T) {
 	tracer, buf := newTracer()
 	tracer.Close()
 
-	var m map[string]interface{}
+	var m map[string]any
 	err := unmarshal(buf.Bytes(), &m)
 	require.NoError(t, err)
 	require.Equal(t, "0.3", m["qlog_version"])
 	require.Contains(t, m, "title")
 	require.Contains(t, m, "trace")
-	trace := m["trace"].(map[string]interface{})
+	trace := m["trace"].(map[string]any)
 	require.Contains(t, trace, "common_fields")
-	commonFields := trace["common_fields"].(map[string]interface{})
+	commonFields := trace["common_fields"].(map[string]any)
 	require.NotContains(t, commonFields, "ODCID")
 	require.NotContains(t, commonFields, "group_id")
 	require.Contains(t, commonFields, "reference_time")
@@ -37,7 +37,7 @@ func TestTraceMetadata(t *testing.T) {
 	require.WithinDuration(t, time.Now(), referenceTime, scaleDuration(10*time.Millisecond))
 	require.Equal(t, "relative", commonFields["time_format"])
 	require.Contains(t, trace, "vantage_point")
-	vantagePoint := trace["vantage_point"].(map[string]interface{})
+	vantagePoint := trace["vantage_point"].(map[string]any)
 	require.Equal(t, "transport", vantagePoint["type"])
 }
 
@@ -64,17 +64,17 @@ func TestTracerSentLongHeaderPacket(t *testing.T) {
 	require.Equal(t, "transport:packet_sent", entry.Name)
 	ev := entry.Event
 	require.Contains(t, ev, "raw")
-	raw := ev["raw"].(map[string]interface{})
+	raw := ev["raw"].(map[string]any)
 	require.Equal(t, float64(1234), raw["length"])
 	require.Contains(t, ev, "header")
-	hdr := ev["header"].(map[string]interface{})
+	hdr := ev["header"].(map[string]any)
 	require.Equal(t, "handshake", hdr["packet_type"])
 	require.Equal(t, "04030201", hdr["scid"])
 	require.Contains(t, ev, "frames")
-	frames := ev["frames"].([]interface{})
+	frames := ev["frames"].([]any)
 	require.Len(t, frames, 2)
-	require.Equal(t, "max_stream_data", frames[0].(map[string]interface{})["frame_type"])
-	require.Equal(t, "stream", frames[1].(map[string]interface{})["frame_type"])
+	require.Equal(t, "max_stream_data", frames[0].(map[string]any)["frame_type"])
+	require.Equal(t, "stream", frames[1].(map[string]any)["frame_type"])
 }
 
 func TestSendingVersionNegotiationPacket(t *testing.T) {
@@ -93,13 +93,13 @@ func TestSendingVersionNegotiationPacket(t *testing.T) {
 	require.Contains(t, ev, "header")
 	require.NotContains(t, ev, "frames")
 	require.Contains(t, ev, "supported_versions")
-	require.Equal(t, []interface{}{"deadbeef", "decafbad"}, ev["supported_versions"].([]interface{}))
+	require.Equal(t, []any{"deadbeef", "decafbad"}, ev["supported_versions"].([]any))
 	header := ev["header"]
-	require.Equal(t, "version_negotiation", header.(map[string]interface{})["packet_type"])
+	require.Equal(t, "version_negotiation", header.(map[string]any)["packet_type"])
 	require.NotContains(t, header, "packet_number")
 	require.NotContains(t, header, "version")
-	require.Equal(t, "0102030405060708", header.(map[string]interface{})["dcid"])
-	require.Equal(t, "04030201", header.(map[string]interface{})["scid"])
+	require.Equal(t, "0102030405060708", header.(map[string]any)["dcid"])
+	require.Equal(t, "04030201", header.(map[string]any)["scid"])
 }
 
 func TestDroppedPackets(t *testing.T) {
@@ -112,9 +112,9 @@ func TestDroppedPackets(t *testing.T) {
 	require.Equal(t, "transport:packet_dropped", entry.Name)
 	ev := entry.Event
 	require.Contains(t, ev, "raw")
-	require.Equal(t, float64(1337), ev["raw"].(map[string]interface{})["length"])
+	require.Equal(t, float64(1337), ev["raw"].(map[string]any)["length"])
 	require.Contains(t, ev, "header")
-	hdr := ev["header"].(map[string]interface{})
+	hdr := ev["header"].(map[string]any)
 	require.Len(t, hdr, 1)
 	require.Equal(t, "initial", hdr["packet_type"])
 	require.Equal(t, "payload_decrypt_error", ev["trigger"])


### PR DESCRIPTION
No functional change expected.

Replacement done using `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -category=efaceany -fix -test ./...`.