### PR TITLE
ackhandler: store skipped packet numbers separately

### DIFF
--- a/internal/ackhandler/packet.go
+++ b/internal/ackhandler/packet.go
@@ -25,12 +25,11 @@ type packet struct {
 
 	includedInBytesInFlight bool
 	declaredLost            bool
-	skippedPacket           bool
 	isPathProbePacket       bool
 }
 
 func (p *packet) outstanding() bool {
-	return !p.declaredLost && !p.skippedPacket && !p.IsPathMTUProbePacket && !p.isPathProbePacket
+	return !p.declaredLost && !p.IsPathMTUProbePacket && !p.isPathProbePacket
 }
 
 var packetPool = sync.Pool{New: func() any { return &packet{} }}
@@ -46,7 +45,6 @@ func getPacket() *packet {
 	p.IsPathMTUProbePacket = false
 	p.includedInBytesInFlight = false
 	p.declaredLost = false
-	p.skippedPacket = false
 	p.isPathProbePacket = false
 	return p
 }


### PR DESCRIPTION
~~Depends on #5312.~~

It doesn't actually decrease the size of the struct, but removing a boolean from the `packet` struct should probably still count as being part of https://github.com/quic-go/quic-go/issues/3846.