### PR TITLE
ackhandler: account for skipped packets in packet threshold calculation

### DIFF
--- a/internal/ackhandler/sent_packet_handler.go
+++ b/internal/ackhandler/sent_packet_handler.go
@@ -710,7 +710,7 @@ func (h *sentPacketHandler) detectLostPackets(now time.Time, encLevel protocol.E
 					h.tracer.LostPacket(p.EncryptionLevel, pn, logging.PacketLossTimeThreshold)
 				}
 			}
-		} else if pnSpace.largestAcked >= pn+packetThreshold {
+		} else if pnSpace.history.Difference(pnSpace.largestAcked, pn) >= packetThreshold {
 			packetLost = true
 			if !p.isPathProbePacket {
 				if h.logger.Debug() {

--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -254,3 +254,24 @@ func (h *sentPacketHistory) DeclareLost(pn protocol.PacketNumber) {
 		h.cleanupStart()
 	}
 }
+
+// Difference returns the difference between two packet numbers a and b (a - b),
+// taking into account any skipped packet numbers between them.
+//
+// Note that old skipped packets are garbage collected at some point,
+// so this function is not guaranteed to return the correct result after a while.
+func (h *sentPacketHistory) Difference(a, b protocol.PacketNumber) protocol.PacketNumber {
+	diff := a - b
+	if len(h.skippedPackets) == 0 {
+		return diff
+	}
+	if a < h.skippedPackets[0] || b > h.skippedPackets[len(h.skippedPackets)-1] {
+		return diff
+	}
+	for _, p := range h.skippedPackets {
+		if p > b && p < a {
+			diff--
+		}
+	}
+	return diff
+}


### PR DESCRIPTION
Packet-threshold based loss detection declares packets lost if the difference between a sent packet and the largest acknowledged packet exceed the reordering threshold.

When we skip packet numbers, we should exclude those skipped packet numbers from the calculation of the difference, otherwise we'll declare a packet lost too aggressively.

This was also the cause of two flaky tests. Fixes #4903. Fixes #5000. Closes #5190.

Depends on #5314.