### PR TITLE
qlog: merge event category and name

### DIFF
--- a/qlog/event.go
+++ b/qlog/event.go
@@ -17,7 +17,6 @@ import (
 func milliseconds(dur time.Duration) float64 { return float64(dur.Nanoseconds()) / 1e6 }
 
 type eventDetails interface {
-	Category() category
 	Name() string
 	gojay.MarshalerJSONObject
 }
@@ -32,7 +31,7 @@ var _ gojay.MarshalerJSONObject = event{}
 func (e event) IsNil() bool { return false }
 func (e event) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.Float64Key("time", milliseconds(e.RelativeTime))
-	enc.StringKey("name", e.Category().String()+":"+e.Name())
+	enc.StringKey("name", e.Name())
 	enc.ObjectKey("data", e.eventDetails)
 }
 
@@ -66,9 +65,8 @@ type eventConnectionStarted struct {
 
 var _ eventDetails = &eventConnectionStarted{}
 
-func (e eventConnectionStarted) Category() category { return categoryTransport }
-func (e eventConnectionStarted) Name() string       { return "connection_started" }
-func (e eventConnectionStarted) IsNil() bool        { return false }
+func (e eventConnectionStarted) Name() string { return "transport:connection_started" }
+func (e eventConnectionStarted) IsNil() bool  { return false }
 
 func (e eventConnectionStarted) MarshalJSONObject(enc *gojay.Encoder) {
 	if e.SrcAddr.IP.To4() != nil {
@@ -89,9 +87,8 @@ type eventVersionNegotiated struct {
 	chosenVersion                  version
 }
 
-func (e eventVersionNegotiated) Category() category { return categoryTransport }
-func (e eventVersionNegotiated) Name() string       { return "version_information" }
-func (e eventVersionNegotiated) IsNil() bool        { return false }
+func (e eventVersionNegotiated) Name() string { return "transport:version_information" }
+func (e eventVersionNegotiated) IsNil() bool  { return false }
 
 func (e eventVersionNegotiated) MarshalJSONObject(enc *gojay.Encoder) {
 	if len(e.clientVersions) > 0 {
@@ -107,9 +104,8 @@ type eventConnectionClosed struct {
 	e error
 }
 
-func (e eventConnectionClosed) Category() category { return categoryTransport }
-func (e eventConnectionClosed) Name() string       { return "connection_closed" }
-func (e eventConnectionClosed) IsNil() bool        { return false }
+func (e eventConnectionClosed) Name() string { return "transport:connection_closed" }
+func (e eventConnectionClosed) IsNil() bool  { return false }
 
 func (e eventConnectionClosed) MarshalJSONObject(enc *gojay.Encoder) {
 	var (
@@ -163,9 +159,8 @@ type eventPacketSent struct {
 
 var _ eventDetails = eventPacketSent{}
 
-func (e eventPacketSent) Category() category { return categoryTransport }
-func (e eventPacketSent) Name() string       { return "packet_sent" }
-func (e eventPacketSent) IsNil() bool        { return false }
+func (e eventPacketSent) Name() string { return "transport:packet_sent" }
+func (e eventPacketSent) IsNil() bool  { return false }
 
 func (e eventPacketSent) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.ObjectKey("header", e.Header)
@@ -190,9 +185,8 @@ type eventPacketReceived struct {
 
 var _ eventDetails = eventPacketReceived{}
 
-func (e eventPacketReceived) Category() category { return categoryTransport }
-func (e eventPacketReceived) Name() string       { return "packet_received" }
-func (e eventPacketReceived) IsNil() bool        { return false }
+func (e eventPacketReceived) Name() string { return "transport:packet_received" }
+func (e eventPacketReceived) IsNil() bool  { return false }
 
 func (e eventPacketReceived) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.ObjectKey("header", e.Header)
@@ -209,9 +203,8 @@ type eventRetryReceived struct {
 	Header packetHeader
 }
 
-func (e eventRetryReceived) Category() category { return categoryTransport }
-func (e eventRetryReceived) Name() string       { return "packet_received" }
-func (e eventRetryReceived) IsNil() bool        { return false }
+func (e eventRetryReceived) Name() string { return "transport:packet_received" }
+func (e eventRetryReceived) IsNil() bool  { return false }
 
 func (e eventRetryReceived) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.ObjectKey("header", e.Header)
@@ -222,9 +215,8 @@ type eventVersionNegotiationReceived struct {
 	SupportedVersions []version
 }
 
-func (e eventVersionNegotiationReceived) Category() category { return categoryTransport }
-func (e eventVersionNegotiationReceived) Name() string       { return "packet_received" }
-func (e eventVersionNegotiationReceived) IsNil() bool        { return false }
+func (e eventVersionNegotiationReceived) Name() string { return "transport:packet_received" }
+func (e eventVersionNegotiationReceived) IsNil() bool  { return false }
 
 func (e eventVersionNegotiationReceived) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.ObjectKey("header", e.Header)
@@ -236,9 +228,8 @@ type eventVersionNegotiationSent struct {
 	SupportedVersions []version
 }
 
-func (e eventVersionNegotiationSent) Category() category { return categoryTransport }
-func (e eventVersionNegotiationSent) Name() string       { return "packet_sent" }
-func (e eventVersionNegotiationSent) IsNil() bool        { return false }
+func (e eventVersionNegotiationSent) Name() string { return "transport:packet_sent" }
+func (e eventVersionNegotiationSent) IsNil() bool  { return false }
 
 func (e eventVersionNegotiationSent) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.ObjectKey("header", e.Header)
@@ -250,9 +241,8 @@ type eventPacketBuffered struct {
 	PacketSize protocol.ByteCount
 }
 
-func (e eventPacketBuffered) Category() category { return categoryTransport }
-func (e eventPacketBuffered) Name() string       { return "packet_buffered" }
-func (e eventPacketBuffered) IsNil() bool        { return false }
+func (e eventPacketBuffered) Name() string { return "transport:packet_buffered" }
+func (e eventPacketBuffered) IsNil() bool  { return false }
 
 func (e eventPacketBuffered) MarshalJSONObject(enc *gojay.Encoder) {
 	//nolint:gosimple
@@ -268,9 +258,8 @@ type eventPacketDropped struct {
 	Trigger      packetDropReason
 }
 
-func (e eventPacketDropped) Category() category { return categoryTransport }
-func (e eventPacketDropped) Name() string       { return "packet_dropped" }
-func (e eventPacketDropped) IsNil() bool        { return false }
+func (e eventPacketDropped) Name() string { return "transport:packet_dropped" }
+func (e eventPacketDropped) IsNil() bool  { return false }
 
 func (e eventPacketDropped) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.ObjectKey("header", packetHeaderWithType{
@@ -297,9 +286,8 @@ type eventMTUUpdated struct {
 	done bool
 }
 
-func (e eventMTUUpdated) Category() category { return categoryRecovery }
-func (e eventMTUUpdated) Name() string       { return "mtu_updated" }
-func (e eventMTUUpdated) IsNil() bool        { return false }
+func (e eventMTUUpdated) Name() string { return "recovery:mtu_updated" }
+func (e eventMTUUpdated) IsNil() bool  { return false }
 
 func (e eventMTUUpdated) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.Uint64Key("mtu", uint64(e.mtu))
@@ -311,9 +299,8 @@ type eventMetricsUpdated struct {
 	Current *metrics
 }
 
-func (e eventMetricsUpdated) Category() category { return categoryRecovery }
-func (e eventMetricsUpdated) Name() string       { return "metrics_updated" }
-func (e eventMetricsUpdated) IsNil() bool        { return false }
+func (e eventMetricsUpdated) Name() string { return "recovery:metrics_updated" }
+func (e eventMetricsUpdated) IsNil() bool  { return false }
 
 func (e eventMetricsUpdated) MarshalJSONObject(enc *gojay.Encoder) {
 	if e.Last == nil || e.Last.MinRTT != e.Current.MinRTT {
@@ -344,9 +331,8 @@ type eventUpdatedPTO struct {
 	Value uint32
 }
 
-func (e eventUpdatedPTO) Category() category { return categoryRecovery }
-func (e eventUpdatedPTO) Name() string       { return "metrics_updated" }
-func (e eventUpdatedPTO) IsNil() bool        { return false }
+func (e eventUpdatedPTO) Name() string { return "recovery:metrics_updated" }
+func (e eventUpdatedPTO) IsNil() bool  { return false }
 
 func (e eventUpdatedPTO) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.Uint32Key("pto_count", e.Value)
@@ -358,9 +344,8 @@ type eventPacketLost struct {
 	Trigger      packetLossReason
 }
 
-func (e eventPacketLost) Category() category { return categoryRecovery }
-func (e eventPacketLost) Name() string       { return "packet_lost" }
-func (e eventPacketLost) IsNil() bool        { return false }
+func (e eventPacketLost) Name() string { return "recovery:packet_lost" }
+func (e eventPacketLost) IsNil() bool  { return false }
 
 func (e eventPacketLost) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.ObjectKey("header", packetHeaderWithTypeAndPacketNumber{
@@ -377,9 +362,8 @@ type eventKeyUpdated struct {
 	// we don't log the keys here, so we don't need `old` and `new`.
 }
 
-func (e eventKeyUpdated) Category() category { return categorySecurity }
-func (e eventKeyUpdated) Name() string       { return "key_updated" }
-func (e eventKeyUpdated) IsNil() bool        { return false }
+func (e eventKeyUpdated) Name() string { return "security:key_updated" }
+func (e eventKeyUpdated) IsNil() bool  { return false }
 
 func (e eventKeyUpdated) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("trigger", e.Trigger.String())
@@ -394,9 +378,8 @@ type eventKeyDiscarded struct {
 	KeyPhase protocol.KeyPhase
 }
 
-func (e eventKeyDiscarded) Category() category { return categorySecurity }
-func (e eventKeyDiscarded) Name() string       { return "key_discarded" }
-func (e eventKeyDiscarded) IsNil() bool        { return false }
+func (e eventKeyDiscarded) Name() string { return "security:key_discarded" }
+func (e eventKeyDiscarded) IsNil() bool  { return false }
 
 func (e eventKeyDiscarded) MarshalJSONObject(enc *gojay.Encoder) {
 	if e.KeyType != keyTypeClient1RTT && e.KeyType != keyTypeServer1RTT {
@@ -438,13 +421,13 @@ type eventTransportParameters struct {
 	EnableResetStreamAt  bool
 }
 
-func (e eventTransportParameters) Category() category { return categoryTransport }
 func (e eventTransportParameters) Name() string {
 	if e.Restore {
-		return "parameters_restored"
+		return "transport:parameters_restored"
 	}
-	return "parameters_set"
+	return "transport:parameters_set"
 }
+
 func (e eventTransportParameters) IsNil() bool { return false }
 
 func (e eventTransportParameters) MarshalJSONObject(enc *gojay.Encoder) {
@@ -514,9 +497,8 @@ type eventLossTimerSet struct {
 	Delta     time.Duration
 }
 
-func (e eventLossTimerSet) Category() category { return categoryRecovery }
-func (e eventLossTimerSet) Name() string       { return "loss_timer_updated" }
-func (e eventLossTimerSet) IsNil() bool        { return false }
+func (e eventLossTimerSet) Name() string { return "recovery:loss_timer_updated" }
+func (e eventLossTimerSet) IsNil() bool  { return false }
 
 func (e eventLossTimerSet) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("event_type", "set")
@@ -530,9 +512,8 @@ type eventLossTimerExpired struct {
 	EncLevel  protocol.EncryptionLevel
 }
 
-func (e eventLossTimerExpired) Category() category { return categoryRecovery }
-func (e eventLossTimerExpired) Name() string       { return "loss_timer_updated" }
-func (e eventLossTimerExpired) IsNil() bool        { return false }
+func (e eventLossTimerExpired) Name() string { return "recovery:loss_timer_updated" }
+func (e eventLossTimerExpired) IsNil() bool  { return false }
 
 func (e eventLossTimerExpired) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("event_type", "expired")
@@ -542,9 +523,8 @@ func (e eventLossTimerExpired) MarshalJSONObject(enc *gojay.Encoder) {
 
 type eventLossTimerCanceled struct{}
 
-func (e eventLossTimerCanceled) Category() category { return categoryRecovery }
-func (e eventLossTimerCanceled) Name() string       { return "loss_timer_updated" }
-func (e eventLossTimerCanceled) IsNil() bool        { return false }
+func (e eventLossTimerCanceled) Name() string { return "recovery:loss_timer_updated" }
+func (e eventLossTimerCanceled) IsNil() bool  { return false }
 
 func (e eventLossTimerCanceled) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("event_type", "cancelled")
@@ -554,9 +534,8 @@ type eventCongestionStateUpdated struct {
 	state congestionState
 }
 
-func (e eventCongestionStateUpdated) Category() category { return categoryRecovery }
-func (e eventCongestionStateUpdated) Name() string       { return "congestion_state_updated" }
-func (e eventCongestionStateUpdated) IsNil() bool        { return false }
+func (e eventCongestionStateUpdated) Name() string { return "recovery:congestion_state_updated" }
+func (e eventCongestionStateUpdated) IsNil() bool  { return false }
 
 func (e eventCongestionStateUpdated) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("new", e.state.String())
@@ -567,13 +546,23 @@ type eventECNStateUpdated struct {
 	trigger logging.ECNStateTrigger
 }
 
-func (e eventECNStateUpdated) Category() category { return categoryRecovery }
-func (e eventECNStateUpdated) Name() string       { return "ecn_state_updated" }
-func (e eventECNStateUpdated) IsNil() bool        { return false }
+func (e eventECNStateUpdated) Name() string { return "recovery:ecn_state_updated" }
+func (e eventECNStateUpdated) IsNil() bool  { return false }
 
 func (e eventECNStateUpdated) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("new", ecnState(e.state).String())
 	enc.StringKeyOmitEmpty("trigger", ecnStateTrigger(e.trigger).String())
+}
+
+type eventALPNInformation struct {
+	chosenALPN string
+}
+
+func (e eventALPNInformation) Name() string { return "transport:alpn_information" }
+func (e eventALPNInformation) IsNil() bool  { return false }
+
+func (e eventALPNInformation) MarshalJSONObject(enc *gojay.Encoder) {
+	enc.StringKey("chosen_alpn", e.chosenALPN)
 }
 
 type eventGeneric struct {
@@ -581,22 +570,9 @@ type eventGeneric struct {
 	msg  string
 }
 
-func (e eventGeneric) Category() category { return categoryTransport }
-func (e eventGeneric) Name() string       { return e.name }
-func (e eventGeneric) IsNil() bool        { return false }
+func (e eventGeneric) Name() string { return "transport:" + e.name }
+func (e eventGeneric) IsNil() bool  { return false }
 
 func (e eventGeneric) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.StringKey("details", e.msg)
-}
-
-type eventALPNInformation struct {
-	chosenALPN string
-}
-
-func (e eventALPNInformation) Category() category { return categoryTransport }
-func (e eventALPNInformation) Name() string       { return "alpn_information" }
-func (e eventALPNInformation) IsNil() bool        { return false }
-
-func (e eventALPNInformation) MarshalJSONObject(enc *gojay.Encoder) {
-	enc.StringKey("chosen_alpn", e.chosenALPN)
 }

--- a/qlog/event_test.go
+++ b/qlog/event_test.go
@@ -14,8 +14,7 @@ type mevent struct{}
 
 var _ eventDetails = mevent{}
 
-func (mevent) Category() category                   { return categoryConnectivity }
-func (mevent) Name() string                         { return "mevent" }
+func (mevent) Name() string                         { return "foobar:mevent" }
 func (mevent) IsNil() bool                          { return false }
 func (mevent) MarshalJSONObject(enc *gojay.Encoder) { enc.StringKey("event", "details") }
 
@@ -34,7 +33,7 @@ func TestEventMarshaling(t *testing.T) {
 	require.Len(t, decoded, 3)
 
 	require.Equal(t, 1.337, decoded["time"])
-	require.Equal(t, "connectivity:mevent", decoded["name"])
+	require.Equal(t, "foobar:mevent", decoded["name"])
 	require.Contains(t, decoded, "data")
 
 	data, ok := decoded["data"].(map[string]any)

--- a/qlog/types.go
+++ b/qlog/types.go
@@ -39,31 +39,6 @@ func (s streamType) String() string {
 	}
 }
 
-// category is the qlog event category.
-type category uint8
-
-const (
-	categoryConnectivity category = iota
-	categoryTransport
-	categorySecurity
-	categoryRecovery
-)
-
-func (c category) String() string {
-	switch c {
-	case categoryConnectivity:
-		return "connectivity"
-	case categoryTransport:
-		return "transport"
-	case categorySecurity:
-		return "security"
-	case categoryRecovery:
-		return "recovery"
-	default:
-		return "unknown category"
-	}
-}
-
 type version protocol.Version
 
 func (v version) String() string {

--- a/qlog/types_test.go
+++ b/qlog/types_test.go
@@ -29,22 +29,6 @@ func TestOwnerStringRepresentation(t *testing.T) {
 	}
 }
 
-func TestCategoryStringRepresentation(t *testing.T) {
-	testCases := []struct {
-		category category
-		expected string
-	}{
-		{categoryConnectivity, "connectivity"},
-		{categoryTransport, "transport"},
-		{categoryRecovery, "recovery"},
-		{categorySecurity, "security"},
-	}
-
-	for _, tc := range testCases {
-		require.Equal(t, tc.expected, tc.category.String())
-	}
-}
-
 func TestPacketTypeStringRepresentation(t *testing.T) {
 	testCases := []struct {
 		packetType logging.PacketType


### PR DESCRIPTION
This follows a (not so recent) change to the qlog specification.

Turns out this is even slightly more performant, probably since we don't need to do string concatenation for every qlog event:
```
name                  old time/op    new time/op    delta
ConnectionTracing-16    1.85µs ± 2%    1.78µs ± 1%  -3.54%  (p=0.000 n=15+14)

name                  old alloc/op   new alloc/op   delta
ConnectionTracing-16      832B ± 0%      832B ± 0%    ~     (all equal)

name                  old allocs/op  new allocs/op  delta
ConnectionTracing-16      32.0 ± 0%      32.0 ± 0%    ~     (all equal)
```