### PR TITLE
implement a memory-optimized time.Time replacement

### DIFF
--- a/connection_timer.go
+++ b/connection_timer.go
@@ -3,14 +3,15 @@ package quic
 import (
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/utils"
 )
 
-var deadlineSendImmediately = time.Time{}.Add(42 * time.Millisecond) // any value > time.Time{} and before time.Now() is fine
+var deadlineSendImmediately = monotime.Time(42 * time.Millisecond) // any value > time.Time{} and before time.Now() is fine
 
 type connectionTimer struct {
 	timer *utils.Timer
-	last  time.Time
+	last  monotime.Time
 }
 
 func newTimer() *connectionTimer {
@@ -32,7 +33,7 @@ func (t *connectionTimer) Chan() <-chan time.Time {
 // It makes sure that the deadline is strictly increasing.
 // This prevents busy-looping in cases where the timer fires, but we can't actually send out a packet.
 // This doesn't apply to the pacing deadline, which can be set multiple times to deadlineSendImmediately.
-func (t *connectionTimer) SetTimer(idleTimeoutOrKeepAlive, connIDRetirement, ackAlarm, lossTime, pacing time.Time) {
+func (t *connectionTimer) SetTimer(idleTimeoutOrKeepAlive, connIDRetirement, ackAlarm, lossTime, pacing monotime.Time) {
 	deadline := idleTimeoutOrKeepAlive
 	if !connIDRetirement.IsZero() && connIDRetirement.Before(deadline) && connIDRetirement.After(t.last) {
 		deadline = connIDRetirement

--- a/connection_timer_test.go
+++ b/connection_timer_test.go
@@ -4,52 +4,53 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/stretchr/testify/require"
 )
 
-func (t *connectionTimer) Deadline() time.Time { return t.timer.Deadline() }
+func (t *connectionTimer) Deadline() monotime.Time { return t.timer.Deadline() }
 
 func TestConnectionTimerModes(t *testing.T) {
-	now := time.Now()
+	now := monotime.Now()
 
 	t.Run("idle timeout", func(t *testing.T) {
 		timer := newTimer()
-		timer.SetTimer(now.Add(time.Hour), time.Time{}, time.Time{}, time.Time{}, time.Time{})
+		timer.SetTimer(now.Add(time.Hour), 0, 0, 0, 0)
 		require.Equal(t, now.Add(time.Hour), timer.Deadline())
 	})
 
 	t.Run("connection ID expiry", func(t *testing.T) {
 		timer := newTimer()
-		timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), time.Time{}, time.Time{}, time.Time{})
+		timer.SetTimer(now.Add(time.Hour), now.Add(time.Minute), 0, 0, 0)
 		require.Equal(t, now.Add(time.Minute), timer.Deadline())
 	})
 
 	t.Run("ACK timer", func(t *testing.T) {
 		timer := newTimer()
-		timer.SetTimer(now.Add(time.Hour), time.Time{}, now.Add(time.Minute), time.Time{}, time.Time{})
+		timer.SetTimer(now.Add(time.Hour), 0, now.Add(time.Minute), 0, 0)
 		require.Equal(t, now.Add(time.Minute), timer.Deadline())
 	})
 
 	t.Run("loss timer", func(t *testing.T) {
 		timer := newTimer()
-		timer.SetTimer(now.Add(time.Hour), time.Time{}, now.Add(time.Minute), now.Add(time.Second), time.Time{})
+		timer.SetTimer(now.Add(time.Hour), 0, now.Add(time.Minute), now.Add(time.Second), 0)
 		require.Equal(t, now.Add(time.Second), timer.Deadline())
 	})
 
 	t.Run("pacing timer", func(t *testing.T) {
 		timer := newTimer()
-		timer.SetTimer(now.Add(time.Hour), time.Time{}, now.Add(time.Minute), now.Add(time.Second), now.Add(time.Millisecond))
+		timer.SetTimer(now.Add(time.Hour), 0, now.Add(time.Minute), now.Add(time.Second), now.Add(time.Millisecond))
 		require.Equal(t, now.Add(time.Millisecond), timer.Deadline())
 	})
 }
 
 func TestConnectionTimerReset(t *testing.T) {
-	now := time.Now()
+	now := monotime.Now()
 	timer := newTimer()
-	timer.SetTimer(now.Add(time.Hour), time.Time{}, now.Add(time.Minute), time.Time{}, time.Time{})
+	timer.SetTimer(now.Add(time.Hour), 0, now.Add(time.Minute), 0, 0)
 	require.Equal(t, now.Add(time.Minute), timer.Deadline())
 	timer.SetRead()
 
-	timer.SetTimer(now.Add(time.Hour), time.Time{}, now.Add(time.Minute), time.Time{}, time.Time{})
+	timer.SetTimer(now.Add(time.Hour), 0, now.Add(time.Minute), 0, 0)
 	require.Equal(t, now.Add(time.Hour), timer.Deadline())
 }

--- a/framer.go
+++ b/framer.go
@@ -3,10 +3,10 @@ package quic
 import (
 	"slices"
 	"sync"
-	"time"
 
 	"github.com/quic-go/quic-go/internal/ackhandler"
 	"github.com/quic-go/quic-go/internal/flowcontrol"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils/ringbuffer"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -27,7 +27,7 @@ type streamFrameGetter interface {
 }
 
 type streamControlFrameGetter interface {
-	getControlFrame(time.Time) (_ ackhandler.Frame, ok, hasMore bool)
+	getControlFrame(monotime.Time) (_ ackhandler.Frame, ok, hasMore bool)
 }
 
 type framer struct {
@@ -90,7 +90,7 @@ func (f *framer) Append(
 	frames []ackhandler.Frame,
 	streamFrames []ackhandler.StreamFrame,
 	maxLen protocol.ByteCount,
-	now time.Time,
+	now monotime.Time,
 	v protocol.Version,
 ) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount) {
 	f.controlFrameMutex.Lock()
@@ -157,7 +157,7 @@ func (f *framer) Append(
 func (f *framer) appendControlFrames(
 	frames []ackhandler.Frame,
 	maxLen protocol.ByteCount,
-	now time.Time,
+	now monotime.Time,
 	v protocol.Version,
 ) ([]ackhandler.Frame, protocol.ByteCount) {
 	var length protocol.ByteCount

--- a/fuzzing/handshake/fuzz.go
+++ b/fuzzing/handshake/fuzz.go
@@ -13,7 +13,6 @@ import (
 	"math"
 	mrand "math/rand/v2"
 	"net"
-	"time"
 
 	"github.com/quic-go/quic-go/fuzzing/internal/helper"
 	"github.com/quic-go/quic-go/internal/handshake"
@@ -391,7 +390,7 @@ func runHandshake(runConfig [confLen]byte, messageConfig uint8, clientConf *tls.
 	}
 	const msg = "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
 	encrypted := sealer.Seal(nil, []byte(msg), 1337, []byte("foobar"))
-	decrypted, err := opener.Open(nil, encrypted, time.Time{}, 1337, protocol.KeyPhaseZero, []byte("foobar"))
+	decrypted, err := opener.Open(nil, encrypted, 0, 1337, protocol.KeyPhaseZero, []byte("foobar"))
 	if err != nil {
 		panic(fmt.Sprintf("Decrypting message failed: %s", err.Error()))
 	}

--- a/integrationtests/tools/proxy/proxy.go
+++ b/integrationtests/tools/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 )
@@ -27,7 +28,7 @@ type connection struct {
 	Outgoing *queue
 }
 
-func (c *connection) queuePacket(t time.Time, b []byte) {
+func (c *connection) queuePacket(t monotime.Time, b []byte) {
 	c.incomingPackets <- packetEntry{Time: t, Raw: b}
 }
 
@@ -60,7 +61,7 @@ const (
 )
 
 type packetEntry struct {
-	Time time.Time
+	Time monotime.Time
 	Raw  []byte
 }
 
@@ -286,7 +287,7 @@ func (p *Proxy) runProxy() error {
 				return err
 			}
 		} else {
-			now := time.Now()
+			now := monotime.Now()
 			if p.logger.Debug() {
 				p.logger.Debugf("delaying incoming packet (%d bytes) to %s by %s", len(raw), conn.ServerAddr, delay)
 			}
@@ -331,7 +332,7 @@ func (p *Proxy) runOutgoingConnection(conn *connection) error {
 					return
 				}
 			} else {
-				now := time.Now()
+				now := monotime.Now()
 				if p.logger.Debug() {
 					p.logger.Debugf("delaying outgoing packet (%d bytes) to %s by %s", len(raw), conn.ClientAddr, delay)
 				}

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/wire"
 
@@ -25,7 +26,7 @@ func TestPacketQueue(t *testing.T) {
 	}
 
 	require.Empty(t, getPackets())
-	now := time.Now()
+	now := monotime.Now()
 
 	q.Add(packetEntry{Time: now, Raw: []byte("p3")})
 	require.Equal(t, []string{"p3"}, getPackets())

--- a/internal/ackhandler/mock_sent_packet_tracker_test.go
+++ b/internal/ackhandler/mock_sent_packet_tracker_test.go
@@ -11,8 +11,8 @@ package ackhandler
 
 import (
 	reflect "reflect"
-	time "time"
 
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -80,7 +80,7 @@ func (c *MockSentPacketTrackerGetLowestPacketNotConfirmedAckedCall) DoAndReturn(
 }
 
 // ReceivedPacket mocks base method.
-func (m *MockSentPacketTracker) ReceivedPacket(arg0 protocol.EncryptionLevel, rcvTime time.Time) {
+func (m *MockSentPacketTracker) ReceivedPacket(arg0 protocol.EncryptionLevel, rcvTime monotime.Time) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReceivedPacket", arg0, rcvTime)
 }
@@ -104,13 +104,13 @@ func (c *MockSentPacketTrackerReceivedPacketCall) Return() *MockSentPacketTracke
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketTrackerReceivedPacketCall) Do(f func(protocol.EncryptionLevel, time.Time)) *MockSentPacketTrackerReceivedPacketCall {
+func (c *MockSentPacketTrackerReceivedPacketCall) Do(f func(protocol.EncryptionLevel, monotime.Time)) *MockSentPacketTrackerReceivedPacketCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketTrackerReceivedPacketCall) DoAndReturn(f func(protocol.EncryptionLevel, time.Time)) *MockSentPacketTrackerReceivedPacketCall {
+func (c *MockSentPacketTrackerReceivedPacketCall) DoAndReturn(f func(protocol.EncryptionLevel, monotime.Time)) *MockSentPacketTrackerReceivedPacketCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/ackhandler/packet.go
+++ b/internal/ackhandler/packet.go
@@ -2,8 +2,8 @@ package ackhandler
 
 import (
 	"sync"
-	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
@@ -14,7 +14,7 @@ type packetWithPacketNumber struct {
 
 // A Packet is a packet
 type packet struct {
-	SendTime        time.Time
+	SendTime        monotime.Time
 	StreamFrames    []StreamFrame
 	Frames          []Frame
 	LargestAcked    protocol.PacketNumber // InvalidPacketNumber if the packet doesn't contain an ACK
@@ -41,7 +41,7 @@ func getPacket() *packet {
 	p.LargestAcked = 0
 	p.Length = 0
 	p.EncryptionLevel = protocol.EncryptionLevel(0)
-	p.SendTime = time.Time{}
+	p.SendTime = 0
 	p.IsPathMTUProbePacket = false
 	p.includedInBytesInFlight = false
 	p.declaredLost = false

--- a/internal/ackhandler/received_packet_handler.go
+++ b/internal/ackhandler/received_packet_handler.go
@@ -2,8 +2,8 @@ package ackhandler
 
 import (
 	"fmt"
-	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -35,7 +35,7 @@ func (h *receivedPacketHandler) ReceivedPacket(
 	pn protocol.PacketNumber,
 	ecn protocol.ECN,
 	encLevel protocol.EncryptionLevel,
-	rcvTime time.Time,
+	rcvTime monotime.Time,
 	ackEliciting bool,
 ) error {
 	h.sentPackets.ReceivedPacket(encLevel, rcvTime)
@@ -83,11 +83,11 @@ func (h *receivedPacketHandler) DropPackets(encLevel protocol.EncryptionLevel) {
 	}
 }
 
-func (h *receivedPacketHandler) GetAlarmTimeout() time.Time {
+func (h *receivedPacketHandler) GetAlarmTimeout() monotime.Time {
 	return h.appDataPackets.GetAlarmTimeout()
 }
 
-func (h *receivedPacketHandler) GetAckFrame(encLevel protocol.EncryptionLevel, now time.Time, onlyIfQueued bool) *wire.AckFrame {
+func (h *receivedPacketHandler) GetAckFrame(encLevel protocol.EncryptionLevel, now monotime.Time, onlyIfQueued bool) *wire.AckFrame {
 	//nolint:exhaustive // 0-RTT packets can't contain ACK frames.
 	switch encLevel {
 	case protocol.EncryptionInitial:

--- a/internal/ackhandler/received_packet_tracker.go
+++ b/internal/ackhandler/received_packet_tracker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -82,7 +83,7 @@ const packetsBeforeAck = 2
 type appDataReceivedPacketTracker struct {
 	receivedPacketTracker
 
-	largestObservedRcvdTime time.Time
+	largestObservedRcvdTime monotime.Time
 
 	largestObserved protocol.PacketNumber
 	ignoreBelow     protocol.PacketNumber
@@ -91,7 +92,7 @@ type appDataReceivedPacketTracker struct {
 	ackQueued   bool // true if we need send a new ACK
 
 	ackElicitingPacketsReceivedSinceLastAck int
-	ackAlarm                                time.Time
+	ackAlarm                                monotime.Time
 
 	logger utils.Logger
 }
@@ -105,7 +106,7 @@ func newAppDataReceivedPacketTracker(logger utils.Logger) *appDataReceivedPacket
 	return h
 }
 
-func (h *appDataReceivedPacketTracker) ReceivedPacket(pn protocol.PacketNumber, ecn protocol.ECN, rcvTime time.Time, ackEliciting bool) error {
+func (h *appDataReceivedPacketTracker) ReceivedPacket(pn protocol.PacketNumber, ecn protocol.ECN, rcvTime monotime.Time, ackEliciting bool) error {
 	if err := h.receivedPacketTracker.ReceivedPacket(pn, ecn, ackEliciting); err != nil {
 		return err
 	}
@@ -120,7 +121,7 @@ func (h *appDataReceivedPacketTracker) ReceivedPacket(pn protocol.PacketNumber, 
 	isMissing := h.isMissing(pn)
 	if !h.ackQueued && h.shouldQueueACK(pn, ecn, isMissing) {
 		h.ackQueued = true
-		h.ackAlarm = time.Time{} // cancel the ack alarm
+		h.ackAlarm = 0 // cancel the ack alarm
 	}
 	if !h.ackQueued {
 		// No ACK queued, but we'll need to acknowledge the packet after max_ack_delay.
@@ -207,7 +208,7 @@ func (h *appDataReceivedPacketTracker) shouldQueueACK(pn protocol.PacketNumber, 
 	return false
 }
 
-func (h *appDataReceivedPacketTracker) GetAckFrame(now time.Time, onlyIfQueued bool) *wire.AckFrame {
+func (h *appDataReceivedPacketTracker) GetAckFrame(now monotime.Time, onlyIfQueued bool) *wire.AckFrame {
 	if onlyIfQueued && !h.ackQueued {
 		if h.ackAlarm.IsZero() || h.ackAlarm.After(now) {
 			return nil
@@ -222,9 +223,9 @@ func (h *appDataReceivedPacketTracker) GetAckFrame(now time.Time, onlyIfQueued b
 	}
 	ack.DelayTime = max(0, now.Sub(h.largestObservedRcvdTime))
 	h.ackQueued = false
-	h.ackAlarm = time.Time{}
+	h.ackAlarm = 0
 	h.ackElicitingPacketsReceivedSinceLastAck = 0
 	return ack
 }
 
-func (h *appDataReceivedPacketTracker) GetAlarmTimeout() time.Time { return h.ackAlarm }
+func (h *appDataReceivedPacketTracker) GetAlarmTimeout() monotime.Time { return h.ackAlarm }

--- a/internal/ackhandler/received_packet_tracker_test.go
+++ b/internal/ackhandler/received_packet_tracker_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -52,17 +53,17 @@ func TestReceivedPacketTrackerGenerateACKs(t *testing.T) {
 func TestAppDataReceivedPacketTrackerECN(t *testing.T) {
 	tr := newAppDataReceivedPacketTracker(utils.DefaultLogger)
 
-	require.NoError(t, tr.ReceivedPacket(0, protocol.ECT0, time.Now(), true))
+	require.NoError(t, tr.ReceivedPacket(0, protocol.ECT0, monotime.Now(), true))
 	pn := protocol.PacketNumber(1)
 	for range 2 {
-		require.NoError(t, tr.ReceivedPacket(pn, protocol.ECT1, time.Now(), true))
+		require.NoError(t, tr.ReceivedPacket(pn, protocol.ECT1, monotime.Now(), true))
 		pn++
 	}
 	for range 3 {
-		require.NoError(t, tr.ReceivedPacket(pn, protocol.ECNCE, time.Now(), true))
+		require.NoError(t, tr.ReceivedPacket(pn, protocol.ECNCE, monotime.Now(), true))
 		pn++
 	}
-	ack := tr.GetAckFrame(time.Now(), false)
+	ack := tr.GetAckFrame(monotime.Now(), false)
 	require.Equal(t, uint64(1), ack.ECT0)
 	require.Equal(t, uint64(2), ack.ECT1)
 	require.Equal(t, uint64(3), ack.ECNCE)
@@ -71,15 +72,15 @@ func TestAppDataReceivedPacketTrackerECN(t *testing.T) {
 func TestAppDataReceivedPacketTrackerAckEverySecondPacket(t *testing.T) {
 	tr := newAppDataReceivedPacketTracker(utils.DefaultLogger)
 	// the first packet is always acknowledged
-	require.NoError(t, tr.ReceivedPacket(0, protocol.ECNNon, time.Now(), true))
-	require.NotNil(t, tr.GetAckFrame(time.Now(), true))
+	require.NoError(t, tr.ReceivedPacket(0, protocol.ECNNon, monotime.Now(), true))
+	require.NotNil(t, tr.GetAckFrame(monotime.Now(), true))
 	for p := protocol.PacketNumber(1); p <= 20; p++ {
-		require.NoError(t, tr.ReceivedPacket(p, protocol.ECNNon, time.Now(), true))
+		require.NoError(t, tr.ReceivedPacket(p, protocol.ECNNon, monotime.Now(), true))
 		switch p % 2 {
 		case 0:
-			require.NotNil(t, tr.GetAckFrame(time.Now(), true))
+			require.NotNil(t, tr.GetAckFrame(monotime.Now(), true))
 		case 1:
-			require.Nil(t, tr.GetAckFrame(time.Now(), true))
+			require.Nil(t, tr.GetAckFrame(monotime.Now(), true))
 		}
 	}
 }
@@ -88,21 +89,21 @@ func TestAppDataReceivedPacketTrackerAlarmTimeout(t *testing.T) {
 	tr := newAppDataReceivedPacketTracker(utils.DefaultLogger)
 
 	// the first packet is always acknowledged
-	require.NoError(t, tr.ReceivedPacket(0, protocol.ECNNon, time.Now(), true))
-	require.NotNil(t, tr.GetAckFrame(time.Now(), true))
+	require.NoError(t, tr.ReceivedPacket(0, protocol.ECNNon, monotime.Now(), true))
+	require.NotNil(t, tr.GetAckFrame(monotime.Now(), true))
 
-	now := time.Now()
+	now := monotime.Now()
 	require.NoError(t, tr.ReceivedPacket(1, protocol.ECNNon, now, false))
-	require.Nil(t, tr.GetAckFrame(time.Now(), true))
+	require.Nil(t, tr.GetAckFrame(monotime.Now(), true))
 	require.Zero(t, tr.GetAlarmTimeout())
 
 	rcvTime := now.Add(10 * time.Millisecond)
 	require.NoError(t, tr.ReceivedPacket(2, protocol.ECNNon, rcvTime, true))
 	require.Equal(t, rcvTime.Add(protocol.MaxAckDelay), tr.GetAlarmTimeout())
-	require.Nil(t, tr.GetAckFrame(time.Now(), true))
+	require.Nil(t, tr.GetAckFrame(monotime.Now(), true))
 
 	// no timeout after the ACK has been dequeued
-	require.NotNil(t, tr.GetAckFrame(time.Now(), false))
+	require.NotNil(t, tr.GetAckFrame(monotime.Now(), false))
 	require.Zero(t, tr.GetAlarmTimeout())
 }
 
@@ -110,11 +111,11 @@ func TestAppDataReceivedPacketTrackerQueuesECNCE(t *testing.T) {
 	tr := newAppDataReceivedPacketTracker(utils.DefaultLogger)
 
 	// the first packet is always acknowledged
-	require.NoError(t, tr.ReceivedPacket(0, protocol.ECNNon, time.Now(), true))
-	require.NotNil(t, tr.GetAckFrame(time.Now(), true))
+	require.NoError(t, tr.ReceivedPacket(0, protocol.ECNNon, monotime.Now(), true))
+	require.NotNil(t, tr.GetAckFrame(monotime.Now(), true))
 
-	require.NoError(t, tr.ReceivedPacket(1, protocol.ECNCE, time.Now(), true))
-	ack := tr.GetAckFrame(time.Now(), true)
+	require.NoError(t, tr.ReceivedPacket(1, protocol.ECNCE, monotime.Now(), true))
+	ack := tr.GetAckFrame(monotime.Now(), true)
 	require.NotNil(t, ack)
 	require.Equal(t, protocol.PacketNumber(1), ack.LargestAcked())
 	require.EqualValues(t, 1, ack.ECNCE)
@@ -123,7 +124,7 @@ func TestAppDataReceivedPacketTrackerQueuesECNCE(t *testing.T) {
 func TestAppDataReceivedPacketTrackerMissingPackets(t *testing.T) {
 	tr := newAppDataReceivedPacketTracker(utils.DefaultLogger)
 
-	now := time.Now()
+	now := monotime.Now()
 	// the first packet is always acknowledged
 	require.NoError(t, tr.ReceivedPacket(0, protocol.ECNNon, now, true))
 	require.NotNil(t, tr.GetAckFrame(now, true))
@@ -152,7 +153,7 @@ func TestAppDataReceivedPacketTrackerMissingPackets(t *testing.T) {
 func TestAppDataReceivedPacketTrackerDelayTime(t *testing.T) {
 	tr := newAppDataReceivedPacketTracker(utils.DefaultLogger)
 
-	now := time.Now()
+	now := monotime.Now()
 	require.NoError(t, tr.ReceivedPacket(1, protocol.ECNNon, now, true))
 	require.NoError(t, tr.ReceivedPacket(2, protocol.ECNNon, now.Add(-1337*time.Millisecond), true))
 	ack := tr.GetAckFrame(now, true)
@@ -175,23 +176,23 @@ func TestAppDataReceivedPacketTrackerIgnoreBelow(t *testing.T) {
 	require.False(t, tr.IsPotentiallyDuplicate(4))
 
 	for i := 5; i <= 10; i++ {
-		require.NoError(t, tr.ReceivedPacket(protocol.PacketNumber(i), protocol.ECNNon, time.Now(), true))
+		require.NoError(t, tr.ReceivedPacket(protocol.PacketNumber(i), protocol.ECNNon, monotime.Now(), true))
 	}
-	ack := tr.GetAckFrame(time.Now(), true)
+	ack := tr.GetAckFrame(monotime.Now(), true)
 	require.NotNil(t, ack)
 	require.Equal(t, []wire.AckRange{{Smallest: 5, Largest: 10}}, ack.AckRanges)
 
 	tr.IgnoreBelow(7)
 
-	require.NoError(t, tr.ReceivedPacket(11, protocol.ECNNon, time.Now(), true))
-	require.NoError(t, tr.ReceivedPacket(12, protocol.ECNNon, time.Now(), true))
-	ack = tr.GetAckFrame(time.Now(), true)
+	require.NoError(t, tr.ReceivedPacket(11, protocol.ECNNon, monotime.Now(), true))
+	require.NoError(t, tr.ReceivedPacket(12, protocol.ECNNon, monotime.Now(), true))
+	ack = tr.GetAckFrame(monotime.Now(), true)
 	require.NotNil(t, ack)
 	require.Equal(t, []wire.AckRange{{Smallest: 7, Largest: 12}}, ack.AckRanges)
 
 	// make sure that old packets are not accepted
 	require.ErrorContains(t,
-		tr.ReceivedPacket(4, protocol.ECNNon, time.Now(), true),
+		tr.ReceivedPacket(4, protocol.ECNNon, monotime.Now(), true),
 		"receivedPacketTracker BUG: ReceivedPacket called for old / duplicate packet 4",
 	)
 }

--- a/internal/ackhandler/sent_packet_history_test.go
+++ b/internal/ackhandler/sent_packet_history_test.go
@@ -3,8 +3,8 @@ package ackhandler
 import (
 	"slices"
 	"testing"
-	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 
 	"github.com/stretchr/testify/require"
@@ -29,7 +29,7 @@ func TestSentPacketHistoryPacketTracking(t *testing.T) {
 
 func testSentPacketHistoryPacketTracking(t *testing.T, firstPacketAckEliciting bool) {
 	hist := newSentPacketHistory(true)
-	now := time.Now()
+	now := monotime.Now()
 
 	var firstPacketNumber []protocol.PacketNumber
 	require.False(t, hist.HasOutstandingPackets())

--- a/internal/congestion/clock.go
+++ b/internal/congestion/clock.go
@@ -1,10 +1,12 @@
 package congestion
 
-import "time"
+import (
+	"github.com/quic-go/quic-go/internal/monotime"
+)
 
 // A Clock returns the current time
 type Clock interface {
-	Now() time.Time
+	Now() monotime.Time
 }
 
 // DefaultClock implements the Clock interface using the Go stdlib clock.
@@ -13,6 +15,6 @@ type DefaultClock struct{}
 var _ Clock = DefaultClock{}
 
 // Now gets the current time
-func (DefaultClock) Now() time.Time {
-	return time.Now()
+func (DefaultClock) Now() monotime.Time {
+	return monotime.Now()
 }

--- a/internal/congestion/cubic_test.go
+++ b/internal/congestion/cubic_test.go
@@ -28,7 +28,7 @@ func cubicConvexCwnd(initialCwnd protocol.ByteCount, rtt, elapsedTime time.Durat
 }
 
 func TestCubicAboveOriginWithTighterBounds(t *testing.T) {
-	clock := mockClock{}
+	var clock mockClock
 	cubic := NewCubic(&clock)
 	cubic.SetNumConnections(int(numConnections))
 
@@ -79,7 +79,7 @@ func TestCubicAboveOriginWithTighterBounds(t *testing.T) {
 }
 
 func TestCubicAboveOriginWithFineGrainedCubing(t *testing.T) {
-	clock := mockClock{}
+	var clock mockClock
 	cubic := NewCubic(&clock)
 	cubic.SetNumConnections(int(numConnections))
 
@@ -106,7 +106,7 @@ func TestCubicAboveOriginWithFineGrainedCubing(t *testing.T) {
 }
 
 func TestCubicHandlesPerAckUpdates(t *testing.T) {
-	clock := mockClock{}
+	var clock mockClock
 	cubic := NewCubic(&clock)
 	cubic.SetNumConnections(int(numConnections))
 
@@ -140,7 +140,7 @@ func TestCubicHandlesPerAckUpdates(t *testing.T) {
 }
 
 func TestCubicHandlesLossEvents(t *testing.T) {
-	clock := mockClock{}
+	var clock mockClock
 	cubic := NewCubic(&clock)
 	cubic.SetNumConnections(int(numConnections))
 
@@ -179,7 +179,7 @@ func TestCubicHandlesLossEvents(t *testing.T) {
 }
 
 func TestCubicBelowOrigin(t *testing.T) {
-	clock := mockClock{}
+	var clock mockClock
 	cubic := NewCubic(&clock)
 	cubic.SetNumConnections(int(numConnections))
 

--- a/internal/congestion/interface.go
+++ b/internal/congestion/interface.go
@@ -1,19 +1,18 @@
 package congestion
 
 import (
-	"time"
-
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
 // A SendAlgorithm performs congestion control
 type SendAlgorithm interface {
-	TimeUntilSend(bytesInFlight protocol.ByteCount) time.Time
-	HasPacingBudget(now time.Time) bool
-	OnPacketSent(sentTime time.Time, bytesInFlight protocol.ByteCount, packetNumber protocol.PacketNumber, bytes protocol.ByteCount, isRetransmittable bool)
+	TimeUntilSend(bytesInFlight protocol.ByteCount) monotime.Time
+	HasPacingBudget(now monotime.Time) bool
+	OnPacketSent(sentTime monotime.Time, bytesInFlight protocol.ByteCount, packetNumber protocol.PacketNumber, bytes protocol.ByteCount, isRetransmittable bool)
 	CanSend(bytesInFlight protocol.ByteCount) bool
 	MaybeExitSlowStart()
-	OnPacketAcked(number protocol.PacketNumber, ackedBytes protocol.ByteCount, priorInFlight protocol.ByteCount, eventTime time.Time)
+	OnPacketAcked(number protocol.PacketNumber, ackedBytes protocol.ByteCount, priorInFlight protocol.ByteCount, eventTime monotime.Time)
 	OnCongestionEvent(number protocol.PacketNumber, lostBytes protocol.ByteCount, priorInFlight protocol.ByteCount)
 	OnRetransmissionTimeout(packetsRetransmitted bool)
 	SetMaxDatagramSize(protocol.ByteCount)

--- a/internal/flowcontrol/base_flow_controller.go
+++ b/internal/flowcontrol/base_flow_controller.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 )
@@ -25,7 +26,7 @@ type baseFlowController struct {
 
 	allowWindowIncrease func(size protocol.ByteCount) bool
 
-	epochStartTime   time.Time
+	epochStartTime   monotime.Time
 	epochStartOffset protocol.ByteCount
 	rttStats         *utils.RTTStats
 
@@ -77,7 +78,7 @@ func (c *baseFlowController) hasWindowUpdate() bool {
 
 // getWindowUpdate updates the receive window, if necessary
 // it returns the new offset
-func (c *baseFlowController) getWindowUpdate(now time.Time) protocol.ByteCount {
+func (c *baseFlowController) getWindowUpdate(now monotime.Time) protocol.ByteCount {
 	if !c.hasWindowUpdate() {
 		return 0
 	}
@@ -89,7 +90,7 @@ func (c *baseFlowController) getWindowUpdate(now time.Time) protocol.ByteCount {
 
 // maybeAdjustWindowSize increases the receiveWindowSize if we're sending updates too often.
 // For details about auto-tuning, see https://docs.google.com/document/d/1SExkMmGiz8VYzV3s9E35JQlJ73vhzCekKkDi85F1qCE/edit?usp=sharing.
-func (c *baseFlowController) maybeAdjustWindowSize(now time.Time) {
+func (c *baseFlowController) maybeAdjustWindowSize(now monotime.Time) {
 	bytesReadInEpoch := c.bytesRead - c.epochStartOffset
 	// don't do anything if less than half the window has been consumed
 	if bytesReadInEpoch <= c.receiveWindowSize/2 {
@@ -111,7 +112,7 @@ func (c *baseFlowController) maybeAdjustWindowSize(now time.Time) {
 	c.startNewAutoTuningEpoch(now)
 }
 
-func (c *baseFlowController) startNewAutoTuningEpoch(now time.Time) {
+func (c *baseFlowController) startNewAutoTuningEpoch(now monotime.Time) {
 	c.epochStartTime = now
 	c.epochStartOffset = c.bytesRead
 }

--- a/internal/flowcontrol/connection_flow_controller.go
+++ b/internal/flowcontrol/connection_flow_controller.go
@@ -3,8 +3,8 @@ package flowcontrol
 import (
 	"errors"
 	"fmt"
-	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/utils"
@@ -38,7 +38,7 @@ func NewConnectionFlowController(
 }
 
 // IncrementHighestReceived adds an increment to the highestReceived value
-func (c *connectionFlowController) IncrementHighestReceived(increment protocol.ByteCount, now time.Time) error {
+func (c *connectionFlowController) IncrementHighestReceived(increment protocol.ByteCount, now monotime.Time) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -65,7 +65,7 @@ func (c *connectionFlowController) AddBytesRead(n protocol.ByteCount) (hasWindow
 	return c.hasWindowUpdate()
 }
 
-func (c *connectionFlowController) GetWindowUpdate(now time.Time) protocol.ByteCount {
+func (c *connectionFlowController) GetWindowUpdate(now monotime.Time) protocol.ByteCount {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -79,7 +79,7 @@ func (c *connectionFlowController) GetWindowUpdate(now time.Time) protocol.ByteC
 
 // EnsureMinimumWindowSize sets a minimum window size
 // it should make sure that the connection-level window is increased when a stream-level window grows
-func (c *connectionFlowController) EnsureMinimumWindowSize(inc protocol.ByteCount, now time.Time) {
+func (c *connectionFlowController) EnsureMinimumWindowSize(inc protocol.ByteCount, now monotime.Time) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 

--- a/internal/flowcontrol/connection_flow_controller_test.go
+++ b/internal/flowcontrol/connection_flow_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/utils"
@@ -20,9 +21,9 @@ func TestConnectionFlowControlWindowUpdate(t *testing.T) {
 		utils.DefaultLogger,
 	)
 	require.False(t, fc.AddBytesRead(1))
-	require.Zero(t, fc.GetWindowUpdate(time.Now()))
+	require.Zero(t, fc.GetWindowUpdate(monotime.Now()))
 	require.True(t, fc.AddBytesRead(99))
-	require.Equal(t, protocol.ByteCount(200), fc.GetWindowUpdate(time.Now()))
+	require.Equal(t, protocol.ByteCount(200), fc.GetWindowUpdate(monotime.Now()))
 }
 
 func TestConnectionWindowAutoTuningNotAllowed(t *testing.T) {
@@ -42,7 +43,7 @@ func TestConnectionWindowAutoTuningNotAllowed(t *testing.T) {
 		rttStats,
 		utils.DefaultLogger,
 	)
-	now := time.Now()
+	now := monotime.Now()
 	require.NoError(t, fc.IncrementHighestReceived(100, now))
 	fc.AddBytesRead(90)
 	require.Equal(t, protocol.InvalidByteCount, callbackCalledWith)
@@ -52,9 +53,9 @@ func TestConnectionWindowAutoTuningNotAllowed(t *testing.T) {
 
 func TestConnectionFlowControlViolation(t *testing.T) {
 	fc := NewConnectionFlowController(100, 100, nil, &utils.RTTStats{}, utils.DefaultLogger)
-	require.NoError(t, fc.IncrementHighestReceived(40, time.Now()))
-	require.NoError(t, fc.IncrementHighestReceived(60, time.Now()))
-	err := fc.IncrementHighestReceived(1, time.Now())
+	require.NoError(t, fc.IncrementHighestReceived(40, monotime.Now()))
+	require.NoError(t, fc.IncrementHighestReceived(60, monotime.Now()))
+	err := fc.IncrementHighestReceived(1, monotime.Now())
 	var terr *qerr.TransportError
 	require.ErrorAs(t, err, &terr)
 	require.Equal(t, qerr.FlowControlError, terr.ErrorCode)

--- a/internal/flowcontrol/interface.go
+++ b/internal/flowcontrol/interface.go
@@ -1,8 +1,7 @@
 package flowcontrol
 
 import (
-	"time"
-
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 )
 
@@ -12,7 +11,7 @@ type flowController interface {
 	UpdateSendWindow(protocol.ByteCount) (updated bool)
 	AddBytesSent(protocol.ByteCount)
 	// for receiving
-	GetWindowUpdate(time.Time) protocol.ByteCount // returns 0 if no update is necessary
+	GetWindowUpdate(monotime.Time) protocol.ByteCount // returns 0 if no update is necessary
 }
 
 // A StreamFlowController is a flow controller for a QUIC stream.
@@ -22,7 +21,7 @@ type StreamFlowController interface {
 	// UpdateHighestReceived is called when a new highest offset is received
 	// final has to be to true if this is the final offset of the stream,
 	// as contained in a STREAM frame with FIN bit, and the RESET_STREAM frame
-	UpdateHighestReceived(offset protocol.ByteCount, final bool, now time.Time) error
+	UpdateHighestReceived(offset protocol.ByteCount, final bool, now monotime.Time) error
 	// Abandon is called when reading from the stream is aborted early,
 	// and there won't be any further calls to AddBytesRead.
 	Abandon()
@@ -41,7 +40,7 @@ type connectionFlowControllerI interface {
 	ConnectionFlowController
 	// The following two methods are not supposed to be called from outside this packet, but are needed internally
 	// for sending
-	EnsureMinimumWindowSize(protocol.ByteCount, time.Time)
+	EnsureMinimumWindowSize(protocol.ByteCount, monotime.Time)
 	// for receiving
-	IncrementHighestReceived(protocol.ByteCount, time.Time) error
+	IncrementHighestReceived(protocol.ByteCount, monotime.Time) error
 }

--- a/internal/flowcontrol/stream_flow_controller.go
+++ b/internal/flowcontrol/stream_flow_controller.go
@@ -2,8 +2,8 @@ package flowcontrol
 
 import (
 	"fmt"
-	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/utils"
@@ -46,7 +46,7 @@ func NewStreamFlowController(
 }
 
 // UpdateHighestReceived updates the highestReceived value, if the offset is higher.
-func (c *streamFlowController) UpdateHighestReceived(offset protocol.ByteCount, final bool, now time.Time) error {
+func (c *streamFlowController) UpdateHighestReceived(offset protocol.ByteCount, final bool, now monotime.Time) error {
 	// If the final offset for this stream is already known, check for consistency.
 	if c.receivedFinalOffset {
 		// If we receive another final offset, check that it's the same.
@@ -135,7 +135,7 @@ func (c *streamFlowController) shouldQueueWindowUpdate() bool {
 	return !c.receivedFinalOffset && c.hasWindowUpdate()
 }
 
-func (c *streamFlowController) GetWindowUpdate(now time.Time) protocol.ByteCount {
+func (c *streamFlowController) GetWindowUpdate(now monotime.Time) protocol.ByteCount {
 	// If we already received the final offset for this stream, the peer won't need any additional flow control credit.
 	if c.receivedFinalOffset {
 		return 0

--- a/internal/flowcontrol/stream_flow_controller_test.go
+++ b/internal/flowcontrol/stream_flow_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/utils"
@@ -28,15 +29,15 @@ func TestStreamFlowControlReceiving(t *testing.T) {
 		utils.DefaultLogger,
 	)
 
-	require.NoError(t, fc.UpdateHighestReceived(50, false, time.Now()))
+	require.NoError(t, fc.UpdateHighestReceived(50, false, monotime.Now()))
 	// duplicates are fine
-	require.NoError(t, fc.UpdateHighestReceived(50, false, time.Now()))
+	require.NoError(t, fc.UpdateHighestReceived(50, false, monotime.Now()))
 	// reordering is fine
-	require.NoError(t, fc.UpdateHighestReceived(40, false, time.Now()))
-	require.NoError(t, fc.UpdateHighestReceived(60, false, time.Now()))
+	require.NoError(t, fc.UpdateHighestReceived(40, false, monotime.Now()))
+	require.NoError(t, fc.UpdateHighestReceived(60, false, monotime.Now()))
 
 	// exceeding the limit is not fine
-	err := fc.UpdateHighestReceived(101, false, time.Now())
+	err := fc.UpdateHighestReceived(101, false, monotime.Now())
 	var terr *qerr.TransportError
 	require.ErrorAs(t, err, &terr)
 	require.Equal(t, qerr.FlowControlError, terr.ErrorCode)
@@ -64,15 +65,15 @@ func TestStreamFlowControllerFinalOffset(t *testing.T) {
 
 	t.Run("duplicate final offset", func(t *testing.T) {
 		fc := newFC()
-		require.NoError(t, fc.UpdateHighestReceived(50, true, time.Now()))
+		require.NoError(t, fc.UpdateHighestReceived(50, true, monotime.Now()))
 		// it is valid to receive the same final offset multiple times
-		require.NoError(t, fc.UpdateHighestReceived(50, true, time.Now()))
+		require.NoError(t, fc.UpdateHighestReceived(50, true, monotime.Now()))
 	})
 
 	t.Run("inconsistent final offset", func(t *testing.T) {
 		fc := newFC()
-		require.NoError(t, fc.UpdateHighestReceived(50, true, time.Now()))
-		err := fc.UpdateHighestReceived(51, true, time.Now())
+		require.NoError(t, fc.UpdateHighestReceived(50, true, monotime.Now()))
+		err := fc.UpdateHighestReceived(51, true, monotime.Now())
 		require.Error(t, err)
 		var terr *qerr.TransportError
 		require.ErrorAs(t, err, &terr)
@@ -82,9 +83,9 @@ func TestStreamFlowControllerFinalOffset(t *testing.T) {
 
 	t.Run("non-final offset past final offset", func(t *testing.T) {
 		fc := newFC()
-		require.NoError(t, fc.UpdateHighestReceived(50, true, time.Now()))
+		require.NoError(t, fc.UpdateHighestReceived(50, true, monotime.Now()))
 		// No matter the ordering, it's never ok to receive an offset past the final offset.
-		err := fc.UpdateHighestReceived(60, false, time.Now())
+		err := fc.UpdateHighestReceived(60, false, monotime.Now())
 		var terr *qerr.TransportError
 		require.ErrorAs(t, err, &terr)
 		require.Equal(t, qerr.FinalSizeError, terr.ErrorCode)
@@ -93,9 +94,9 @@ func TestStreamFlowControllerFinalOffset(t *testing.T) {
 
 	t.Run("final offset smaller than previous offset", func(t *testing.T) {
 		fc := newFC()
-		require.NoError(t, fc.UpdateHighestReceived(50, false, time.Now()))
+		require.NoError(t, fc.UpdateHighestReceived(50, false, monotime.Now()))
 		// If we received offset already, it's invalid to receive a smaller final offset.
-		err := fc.UpdateHighestReceived(40, true, time.Now())
+		err := fc.UpdateHighestReceived(40, true, monotime.Now())
 		var terr *qerr.TransportError
 		require.ErrorAs(t, err, &terr)
 		require.Equal(t, qerr.FinalSizeError, terr.ErrorCode)
@@ -122,14 +123,14 @@ func TestStreamAbandoning(t *testing.T) {
 		utils.DefaultLogger,
 	)
 
-	require.NoError(t, fc.UpdateHighestReceived(50, true, time.Now()))
-	require.Zero(t, fc.GetWindowUpdate(time.Now()))
-	require.Zero(t, connFC.GetWindowUpdate(time.Now()))
+	require.NoError(t, fc.UpdateHighestReceived(50, true, monotime.Now()))
+	require.Zero(t, fc.GetWindowUpdate(monotime.Now()))
+	require.Zero(t, connFC.GetWindowUpdate(monotime.Now()))
 
 	// Abandon the stream.
 	// This marks all bytes as having been consumed.
 	fc.Abandon()
-	require.Equal(t, protocol.ByteCount(150), connFC.GetWindowUpdate(time.Now()))
+	require.Equal(t, protocol.ByteCount(150), connFC.GetWindowUpdate(monotime.Now()))
 }
 
 func TestStreamSendWindow(t *testing.T) {
@@ -191,28 +192,28 @@ func TestStreamWindowUpdate(t *testing.T) {
 		&utils.RTTStats{},
 		utils.DefaultLogger,
 	)
-	require.Zero(t, fc.GetWindowUpdate(time.Now()))
+	require.Zero(t, fc.GetWindowUpdate(monotime.Now()))
 	hasStreamWindowUpdate, _ := fc.AddBytesRead(24)
 	require.False(t, hasStreamWindowUpdate)
-	require.Zero(t, fc.GetWindowUpdate(time.Now()))
+	require.Zero(t, fc.GetWindowUpdate(monotime.Now()))
 	// the window is updated when it's 25% filled
 	hasStreamWindowUpdate, _ = fc.AddBytesRead(1)
 	require.True(t, hasStreamWindowUpdate)
-	require.Equal(t, protocol.ByteCount(125), fc.GetWindowUpdate(time.Now()))
+	require.Equal(t, protocol.ByteCount(125), fc.GetWindowUpdate(monotime.Now()))
 
 	hasStreamWindowUpdate, _ = fc.AddBytesRead(24)
 	require.False(t, hasStreamWindowUpdate)
-	require.Zero(t, fc.GetWindowUpdate(time.Now()))
+	require.Zero(t, fc.GetWindowUpdate(monotime.Now()))
 	// the window is updated when it's 25% filled
 	hasStreamWindowUpdate, _ = fc.AddBytesRead(1)
 	require.True(t, hasStreamWindowUpdate)
-	require.Equal(t, protocol.ByteCount(150), fc.GetWindowUpdate(time.Now()))
+	require.Equal(t, protocol.ByteCount(150), fc.GetWindowUpdate(monotime.Now()))
 
 	// Receive the final offset.
 	// We don't need to send any more flow control updates.
-	require.NoError(t, fc.UpdateHighestReceived(100, true, time.Now()))
+	require.NoError(t, fc.UpdateHighestReceived(100, true, monotime.Now()))
 	fc.AddBytesRead(50)
-	require.Zero(t, fc.GetWindowUpdate(time.Now()))
+	require.Zero(t, fc.GetWindowUpdate(monotime.Now()))
 }
 
 func TestStreamConnectionWindowUpdate(t *testing.T) {
@@ -235,9 +236,9 @@ func TestStreamConnectionWindowUpdate(t *testing.T) {
 
 	hasStreamWindowUpdate, hasConnWindowUpdate := fc.AddBytesRead(50)
 	require.False(t, hasStreamWindowUpdate)
-	require.Zero(t, fc.GetWindowUpdate(time.Now()))
+	require.Zero(t, fc.GetWindowUpdate(monotime.Now()))
 	require.True(t, hasConnWindowUpdate)
-	require.NotZero(t, connFC.GetWindowUpdate(time.Now()))
+	require.NotZero(t, connFC.GetWindowUpdate(monotime.Now()))
 }
 
 func TestStreamWindowAutoTuning(t *testing.T) {
@@ -263,7 +264,7 @@ func TestStreamWindowAutoTuning(t *testing.T) {
 		utils.DefaultLogger,
 	)
 
-	now := time.Now()
+	now := monotime.Now()
 	require.NoError(t, fc.UpdateHighestReceived(100, false, now))
 
 	// data consumption is too slow, window size is not increased

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -5,8 +5,8 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
-	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/wire"
 )
@@ -38,7 +38,7 @@ type LongHeaderOpener interface {
 type ShortHeaderOpener interface {
 	headerDecryptor
 	DecodePacketNumber(wirePN protocol.PacketNumber, wirePNLen protocol.PacketNumberLen) protocol.PacketNumber
-	Open(dst, src []byte, rcvTime time.Time, pn protocol.PacketNumber, kp protocol.KeyPhaseBit, associatedData []byte) ([]byte, error)
+	Open(dst, src []byte, rcvTime monotime.Time, pn protocol.PacketNumber, kp protocol.KeyPhaseBit, associatedData []byte) ([]byte, error)
 }
 
 // LongHeaderSealer seals a long header packet

--- a/internal/mocks/ackhandler/received_packet_handler.go
+++ b/internal/mocks/ackhandler/received_packet_handler.go
@@ -11,8 +11,8 @@ package mockackhandler
 
 import (
 	reflect "reflect"
-	time "time"
 
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	wire "github.com/quic-go/quic-go/internal/wire"
 	gomock "go.uber.org/mock/gomock"
@@ -79,7 +79,7 @@ func (c *MockReceivedPacketHandlerDropPacketsCall) DoAndReturn(f func(protocol.E
 }
 
 // GetAckFrame mocks base method.
-func (m *MockReceivedPacketHandler) GetAckFrame(arg0 protocol.EncryptionLevel, now time.Time, onlyIfQueued bool) *wire.AckFrame {
+func (m *MockReceivedPacketHandler) GetAckFrame(arg0 protocol.EncryptionLevel, now monotime.Time, onlyIfQueued bool) *wire.AckFrame {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAckFrame", arg0, now, onlyIfQueued)
 	ret0, _ := ret[0].(*wire.AckFrame)
@@ -105,22 +105,22 @@ func (c *MockReceivedPacketHandlerGetAckFrameCall) Return(arg0 *wire.AckFrame) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockReceivedPacketHandlerGetAckFrameCall) Do(f func(protocol.EncryptionLevel, time.Time, bool) *wire.AckFrame) *MockReceivedPacketHandlerGetAckFrameCall {
+func (c *MockReceivedPacketHandlerGetAckFrameCall) Do(f func(protocol.EncryptionLevel, monotime.Time, bool) *wire.AckFrame) *MockReceivedPacketHandlerGetAckFrameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockReceivedPacketHandlerGetAckFrameCall) DoAndReturn(f func(protocol.EncryptionLevel, time.Time, bool) *wire.AckFrame) *MockReceivedPacketHandlerGetAckFrameCall {
+func (c *MockReceivedPacketHandlerGetAckFrameCall) DoAndReturn(f func(protocol.EncryptionLevel, monotime.Time, bool) *wire.AckFrame) *MockReceivedPacketHandlerGetAckFrameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetAlarmTimeout mocks base method.
-func (m *MockReceivedPacketHandler) GetAlarmTimeout() time.Time {
+func (m *MockReceivedPacketHandler) GetAlarmTimeout() monotime.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAlarmTimeout")
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(monotime.Time)
 	return ret0
 }
 
@@ -137,19 +137,19 @@ type MockReceivedPacketHandlerGetAlarmTimeoutCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockReceivedPacketHandlerGetAlarmTimeoutCall) Return(arg0 time.Time) *MockReceivedPacketHandlerGetAlarmTimeoutCall {
+func (c *MockReceivedPacketHandlerGetAlarmTimeoutCall) Return(arg0 monotime.Time) *MockReceivedPacketHandlerGetAlarmTimeoutCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockReceivedPacketHandlerGetAlarmTimeoutCall) Do(f func() time.Time) *MockReceivedPacketHandlerGetAlarmTimeoutCall {
+func (c *MockReceivedPacketHandlerGetAlarmTimeoutCall) Do(f func() monotime.Time) *MockReceivedPacketHandlerGetAlarmTimeoutCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockReceivedPacketHandlerGetAlarmTimeoutCall) DoAndReturn(f func() time.Time) *MockReceivedPacketHandlerGetAlarmTimeoutCall {
+func (c *MockReceivedPacketHandlerGetAlarmTimeoutCall) DoAndReturn(f func() monotime.Time) *MockReceivedPacketHandlerGetAlarmTimeoutCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -193,7 +193,7 @@ func (c *MockReceivedPacketHandlerIsPotentiallyDuplicateCall) DoAndReturn(f func
 }
 
 // ReceivedPacket mocks base method.
-func (m *MockReceivedPacketHandler) ReceivedPacket(pn protocol.PacketNumber, ecn protocol.ECN, encLevel protocol.EncryptionLevel, rcvTime time.Time, ackEliciting bool) error {
+func (m *MockReceivedPacketHandler) ReceivedPacket(pn protocol.PacketNumber, ecn protocol.ECN, encLevel protocol.EncryptionLevel, rcvTime monotime.Time, ackEliciting bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReceivedPacket", pn, ecn, encLevel, rcvTime, ackEliciting)
 	ret0, _ := ret[0].(error)
@@ -219,13 +219,13 @@ func (c *MockReceivedPacketHandlerReceivedPacketCall) Return(arg0 error) *MockRe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockReceivedPacketHandlerReceivedPacketCall) Do(f func(protocol.PacketNumber, protocol.ECN, protocol.EncryptionLevel, time.Time, bool) error) *MockReceivedPacketHandlerReceivedPacketCall {
+func (c *MockReceivedPacketHandlerReceivedPacketCall) Do(f func(protocol.PacketNumber, protocol.ECN, protocol.EncryptionLevel, monotime.Time, bool) error) *MockReceivedPacketHandlerReceivedPacketCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockReceivedPacketHandlerReceivedPacketCall) DoAndReturn(f func(protocol.PacketNumber, protocol.ECN, protocol.EncryptionLevel, time.Time, bool) error) *MockReceivedPacketHandlerReceivedPacketCall {
+func (c *MockReceivedPacketHandlerReceivedPacketCall) DoAndReturn(f func(protocol.PacketNumber, protocol.ECN, protocol.EncryptionLevel, monotime.Time, bool) error) *MockReceivedPacketHandlerReceivedPacketCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/mocks/ackhandler/sent_packet_handler.go
+++ b/internal/mocks/ackhandler/sent_packet_handler.go
@@ -11,9 +11,9 @@ package mockackhandler
 
 import (
 	reflect "reflect"
-	time "time"
 
 	ackhandler "github.com/quic-go/quic-go/internal/ackhandler"
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	wire "github.com/quic-go/quic-go/internal/wire"
 	gomock "go.uber.org/mock/gomock"
@@ -44,7 +44,7 @@ func (m *MockSentPacketHandler) EXPECT() *MockSentPacketHandlerMockRecorder {
 }
 
 // DropPackets mocks base method.
-func (m *MockSentPacketHandler) DropPackets(arg0 protocol.EncryptionLevel, rcvTime time.Time) {
+func (m *MockSentPacketHandler) DropPackets(arg0 protocol.EncryptionLevel, rcvTime monotime.Time) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "DropPackets", arg0, rcvTime)
 }
@@ -68,13 +68,13 @@ func (c *MockSentPacketHandlerDropPacketsCall) Return() *MockSentPacketHandlerDr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerDropPacketsCall) Do(f func(protocol.EncryptionLevel, time.Time)) *MockSentPacketHandlerDropPacketsCall {
+func (c *MockSentPacketHandlerDropPacketsCall) Do(f func(protocol.EncryptionLevel, monotime.Time)) *MockSentPacketHandlerDropPacketsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerDropPacketsCall) DoAndReturn(f func(protocol.EncryptionLevel, time.Time)) *MockSentPacketHandlerDropPacketsCall {
+func (c *MockSentPacketHandlerDropPacketsCall) DoAndReturn(f func(protocol.EncryptionLevel, monotime.Time)) *MockSentPacketHandlerDropPacketsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -118,10 +118,10 @@ func (c *MockSentPacketHandlerECNModeCall) DoAndReturn(f func(bool) protocol.ECN
 }
 
 // GetLossDetectionTimeout mocks base method.
-func (m *MockSentPacketHandler) GetLossDetectionTimeout() time.Time {
+func (m *MockSentPacketHandler) GetLossDetectionTimeout() monotime.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLossDetectionTimeout")
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(monotime.Time)
 	return ret0
 }
 
@@ -138,25 +138,25 @@ type MockSentPacketHandlerGetLossDetectionTimeoutCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockSentPacketHandlerGetLossDetectionTimeoutCall) Return(arg0 time.Time) *MockSentPacketHandlerGetLossDetectionTimeoutCall {
+func (c *MockSentPacketHandlerGetLossDetectionTimeoutCall) Return(arg0 monotime.Time) *MockSentPacketHandlerGetLossDetectionTimeoutCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerGetLossDetectionTimeoutCall) Do(f func() time.Time) *MockSentPacketHandlerGetLossDetectionTimeoutCall {
+func (c *MockSentPacketHandlerGetLossDetectionTimeoutCall) Do(f func() monotime.Time) *MockSentPacketHandlerGetLossDetectionTimeoutCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerGetLossDetectionTimeoutCall) DoAndReturn(f func() time.Time) *MockSentPacketHandlerGetLossDetectionTimeoutCall {
+func (c *MockSentPacketHandlerGetLossDetectionTimeoutCall) DoAndReturn(f func() monotime.Time) *MockSentPacketHandlerGetLossDetectionTimeoutCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // MigratedPath mocks base method.
-func (m *MockSentPacketHandler) MigratedPath(now time.Time, initialMaxPacketSize protocol.ByteCount) {
+func (m *MockSentPacketHandler) MigratedPath(now monotime.Time, initialMaxPacketSize protocol.ByteCount) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "MigratedPath", now, initialMaxPacketSize)
 }
@@ -180,19 +180,19 @@ func (c *MockSentPacketHandlerMigratedPathCall) Return() *MockSentPacketHandlerM
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerMigratedPathCall) Do(f func(time.Time, protocol.ByteCount)) *MockSentPacketHandlerMigratedPathCall {
+func (c *MockSentPacketHandlerMigratedPathCall) Do(f func(monotime.Time, protocol.ByteCount)) *MockSentPacketHandlerMigratedPathCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerMigratedPathCall) DoAndReturn(f func(time.Time, protocol.ByteCount)) *MockSentPacketHandlerMigratedPathCall {
+func (c *MockSentPacketHandlerMigratedPathCall) DoAndReturn(f func(monotime.Time, protocol.ByteCount)) *MockSentPacketHandlerMigratedPathCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // OnLossDetectionTimeout mocks base method.
-func (m *MockSentPacketHandler) OnLossDetectionTimeout(now time.Time) error {
+func (m *MockSentPacketHandler) OnLossDetectionTimeout(now monotime.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OnLossDetectionTimeout", now)
 	ret0, _ := ret[0].(error)
@@ -218,13 +218,13 @@ func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) Return(arg0 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) Do(f func(time.Time) error) *MockSentPacketHandlerOnLossDetectionTimeoutCall {
+func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) Do(f func(monotime.Time) error) *MockSentPacketHandlerOnLossDetectionTimeoutCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) DoAndReturn(f func(time.Time) error) *MockSentPacketHandlerOnLossDetectionTimeoutCall {
+func (c *MockSentPacketHandlerOnLossDetectionTimeoutCall) DoAndReturn(f func(monotime.Time) error) *MockSentPacketHandlerOnLossDetectionTimeoutCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -345,7 +345,7 @@ func (c *MockSentPacketHandlerQueueProbePacketCall) DoAndReturn(f func(protocol.
 }
 
 // ReceivedAck mocks base method.
-func (m *MockSentPacketHandler) ReceivedAck(f *wire.AckFrame, encLevel protocol.EncryptionLevel, rcvTime time.Time) (bool, error) {
+func (m *MockSentPacketHandler) ReceivedAck(f *wire.AckFrame, encLevel protocol.EncryptionLevel, rcvTime monotime.Time) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReceivedAck", f, encLevel, rcvTime)
 	ret0, _ := ret[0].(bool)
@@ -372,19 +372,19 @@ func (c *MockSentPacketHandlerReceivedAckCall) Return(arg0 bool, arg1 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerReceivedAckCall) Do(f func(*wire.AckFrame, protocol.EncryptionLevel, time.Time) (bool, error)) *MockSentPacketHandlerReceivedAckCall {
+func (c *MockSentPacketHandlerReceivedAckCall) Do(f func(*wire.AckFrame, protocol.EncryptionLevel, monotime.Time) (bool, error)) *MockSentPacketHandlerReceivedAckCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerReceivedAckCall) DoAndReturn(f func(*wire.AckFrame, protocol.EncryptionLevel, time.Time) (bool, error)) *MockSentPacketHandlerReceivedAckCall {
+func (c *MockSentPacketHandlerReceivedAckCall) DoAndReturn(f func(*wire.AckFrame, protocol.EncryptionLevel, monotime.Time) (bool, error)) *MockSentPacketHandlerReceivedAckCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ReceivedBytes mocks base method.
-func (m *MockSentPacketHandler) ReceivedBytes(arg0 protocol.ByteCount, rcvTime time.Time) {
+func (m *MockSentPacketHandler) ReceivedBytes(arg0 protocol.ByteCount, rcvTime monotime.Time) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReceivedBytes", arg0, rcvTime)
 }
@@ -408,19 +408,19 @@ func (c *MockSentPacketHandlerReceivedBytesCall) Return() *MockSentPacketHandler
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerReceivedBytesCall) Do(f func(protocol.ByteCount, time.Time)) *MockSentPacketHandlerReceivedBytesCall {
+func (c *MockSentPacketHandlerReceivedBytesCall) Do(f func(protocol.ByteCount, monotime.Time)) *MockSentPacketHandlerReceivedBytesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerReceivedBytesCall) DoAndReturn(f func(protocol.ByteCount, time.Time)) *MockSentPacketHandlerReceivedBytesCall {
+func (c *MockSentPacketHandlerReceivedBytesCall) DoAndReturn(f func(protocol.ByteCount, monotime.Time)) *MockSentPacketHandlerReceivedBytesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ResetForRetry mocks base method.
-func (m *MockSentPacketHandler) ResetForRetry(rcvTime time.Time) {
+func (m *MockSentPacketHandler) ResetForRetry(rcvTime monotime.Time) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ResetForRetry", rcvTime)
 }
@@ -444,19 +444,19 @@ func (c *MockSentPacketHandlerResetForRetryCall) Return() *MockSentPacketHandler
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerResetForRetryCall) Do(f func(time.Time)) *MockSentPacketHandlerResetForRetryCall {
+func (c *MockSentPacketHandlerResetForRetryCall) Do(f func(monotime.Time)) *MockSentPacketHandlerResetForRetryCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerResetForRetryCall) DoAndReturn(f func(time.Time)) *MockSentPacketHandlerResetForRetryCall {
+func (c *MockSentPacketHandlerResetForRetryCall) DoAndReturn(f func(monotime.Time)) *MockSentPacketHandlerResetForRetryCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SendMode mocks base method.
-func (m *MockSentPacketHandler) SendMode(now time.Time) ackhandler.SendMode {
+func (m *MockSentPacketHandler) SendMode(now monotime.Time) ackhandler.SendMode {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendMode", now)
 	ret0, _ := ret[0].(ackhandler.SendMode)
@@ -482,19 +482,19 @@ func (c *MockSentPacketHandlerSendModeCall) Return(arg0 ackhandler.SendMode) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerSendModeCall) Do(f func(time.Time) ackhandler.SendMode) *MockSentPacketHandlerSendModeCall {
+func (c *MockSentPacketHandlerSendModeCall) Do(f func(monotime.Time) ackhandler.SendMode) *MockSentPacketHandlerSendModeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerSendModeCall) DoAndReturn(f func(time.Time) ackhandler.SendMode) *MockSentPacketHandlerSendModeCall {
+func (c *MockSentPacketHandlerSendModeCall) DoAndReturn(f func(monotime.Time) ackhandler.SendMode) *MockSentPacketHandlerSendModeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SentPacket mocks base method.
-func (m *MockSentPacketHandler) SentPacket(t time.Time, pn, largestAcked protocol.PacketNumber, streamFrames []ackhandler.StreamFrame, frames []ackhandler.Frame, encLevel protocol.EncryptionLevel, ecn protocol.ECN, size protocol.ByteCount, isPathMTUProbePacket, isPathProbePacket bool) {
+func (m *MockSentPacketHandler) SentPacket(t monotime.Time, pn, largestAcked protocol.PacketNumber, streamFrames []ackhandler.StreamFrame, frames []ackhandler.Frame, encLevel protocol.EncryptionLevel, ecn protocol.ECN, size protocol.ByteCount, isPathMTUProbePacket, isPathProbePacket bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SentPacket", t, pn, largestAcked, streamFrames, frames, encLevel, ecn, size, isPathMTUProbePacket, isPathProbePacket)
 }
@@ -518,13 +518,13 @@ func (c *MockSentPacketHandlerSentPacketCall) Return() *MockSentPacketHandlerSen
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerSentPacketCall) Do(f func(time.Time, protocol.PacketNumber, protocol.PacketNumber, []ackhandler.StreamFrame, []ackhandler.Frame, protocol.EncryptionLevel, protocol.ECN, protocol.ByteCount, bool, bool)) *MockSentPacketHandlerSentPacketCall {
+func (c *MockSentPacketHandlerSentPacketCall) Do(f func(monotime.Time, protocol.PacketNumber, protocol.PacketNumber, []ackhandler.StreamFrame, []ackhandler.Frame, protocol.EncryptionLevel, protocol.ECN, protocol.ByteCount, bool, bool)) *MockSentPacketHandlerSentPacketCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerSentPacketCall) DoAndReturn(f func(time.Time, protocol.PacketNumber, protocol.PacketNumber, []ackhandler.StreamFrame, []ackhandler.Frame, protocol.EncryptionLevel, protocol.ECN, protocol.ByteCount, bool, bool)) *MockSentPacketHandlerSentPacketCall {
+func (c *MockSentPacketHandlerSentPacketCall) DoAndReturn(f func(monotime.Time, protocol.PacketNumber, protocol.PacketNumber, []ackhandler.StreamFrame, []ackhandler.Frame, protocol.EncryptionLevel, protocol.ECN, protocol.ByteCount, bool, bool)) *MockSentPacketHandlerSentPacketCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -566,10 +566,10 @@ func (c *MockSentPacketHandlerSetMaxDatagramSizeCall) DoAndReturn(f func(protoco
 }
 
 // TimeUntilSend mocks base method.
-func (m *MockSentPacketHandler) TimeUntilSend() time.Time {
+func (m *MockSentPacketHandler) TimeUntilSend() monotime.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TimeUntilSend")
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(monotime.Time)
 	return ret0
 }
 
@@ -586,19 +586,19 @@ type MockSentPacketHandlerTimeUntilSendCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockSentPacketHandlerTimeUntilSendCall) Return(arg0 time.Time) *MockSentPacketHandlerTimeUntilSendCall {
+func (c *MockSentPacketHandlerTimeUntilSendCall) Return(arg0 monotime.Time) *MockSentPacketHandlerTimeUntilSendCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSentPacketHandlerTimeUntilSendCall) Do(f func() time.Time) *MockSentPacketHandlerTimeUntilSendCall {
+func (c *MockSentPacketHandlerTimeUntilSendCall) Do(f func() monotime.Time) *MockSentPacketHandlerTimeUntilSendCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSentPacketHandlerTimeUntilSendCall) DoAndReturn(f func() time.Time) *MockSentPacketHandlerTimeUntilSendCall {
+func (c *MockSentPacketHandlerTimeUntilSendCall) DoAndReturn(f func() monotime.Time) *MockSentPacketHandlerTimeUntilSendCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/mocks/congestion.go
+++ b/internal/mocks/congestion.go
@@ -11,8 +11,8 @@ package mocks
 
 import (
 	reflect "reflect"
-	time "time"
 
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -118,7 +118,7 @@ func (c *MockSendAlgorithmWithDebugInfosGetCongestionWindowCall) DoAndReturn(f f
 }
 
 // HasPacingBudget mocks base method.
-func (m *MockSendAlgorithmWithDebugInfos) HasPacingBudget(now time.Time) bool {
+func (m *MockSendAlgorithmWithDebugInfos) HasPacingBudget(now monotime.Time) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasPacingBudget", now)
 	ret0, _ := ret[0].(bool)
@@ -144,13 +144,13 @@ func (c *MockSendAlgorithmWithDebugInfosHasPacingBudgetCall) Return(arg0 bool) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSendAlgorithmWithDebugInfosHasPacingBudgetCall) Do(f func(time.Time) bool) *MockSendAlgorithmWithDebugInfosHasPacingBudgetCall {
+func (c *MockSendAlgorithmWithDebugInfosHasPacingBudgetCall) Do(f func(monotime.Time) bool) *MockSendAlgorithmWithDebugInfosHasPacingBudgetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSendAlgorithmWithDebugInfosHasPacingBudgetCall) DoAndReturn(f func(time.Time) bool) *MockSendAlgorithmWithDebugInfosHasPacingBudgetCall {
+func (c *MockSendAlgorithmWithDebugInfosHasPacingBudgetCall) DoAndReturn(f func(monotime.Time) bool) *MockSendAlgorithmWithDebugInfosHasPacingBudgetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -304,7 +304,7 @@ func (c *MockSendAlgorithmWithDebugInfosOnCongestionEventCall) DoAndReturn(f fun
 }
 
 // OnPacketAcked mocks base method.
-func (m *MockSendAlgorithmWithDebugInfos) OnPacketAcked(number protocol.PacketNumber, ackedBytes, priorInFlight protocol.ByteCount, eventTime time.Time) {
+func (m *MockSendAlgorithmWithDebugInfos) OnPacketAcked(number protocol.PacketNumber, ackedBytes, priorInFlight protocol.ByteCount, eventTime monotime.Time) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnPacketAcked", number, ackedBytes, priorInFlight, eventTime)
 }
@@ -328,19 +328,19 @@ func (c *MockSendAlgorithmWithDebugInfosOnPacketAckedCall) Return() *MockSendAlg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSendAlgorithmWithDebugInfosOnPacketAckedCall) Do(f func(protocol.PacketNumber, protocol.ByteCount, protocol.ByteCount, time.Time)) *MockSendAlgorithmWithDebugInfosOnPacketAckedCall {
+func (c *MockSendAlgorithmWithDebugInfosOnPacketAckedCall) Do(f func(protocol.PacketNumber, protocol.ByteCount, protocol.ByteCount, monotime.Time)) *MockSendAlgorithmWithDebugInfosOnPacketAckedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSendAlgorithmWithDebugInfosOnPacketAckedCall) DoAndReturn(f func(protocol.PacketNumber, protocol.ByteCount, protocol.ByteCount, time.Time)) *MockSendAlgorithmWithDebugInfosOnPacketAckedCall {
+func (c *MockSendAlgorithmWithDebugInfosOnPacketAckedCall) DoAndReturn(f func(protocol.PacketNumber, protocol.ByteCount, protocol.ByteCount, monotime.Time)) *MockSendAlgorithmWithDebugInfosOnPacketAckedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // OnPacketSent mocks base method.
-func (m *MockSendAlgorithmWithDebugInfos) OnPacketSent(sentTime time.Time, bytesInFlight protocol.ByteCount, packetNumber protocol.PacketNumber, bytes protocol.ByteCount, isRetransmittable bool) {
+func (m *MockSendAlgorithmWithDebugInfos) OnPacketSent(sentTime monotime.Time, bytesInFlight protocol.ByteCount, packetNumber protocol.PacketNumber, bytes protocol.ByteCount, isRetransmittable bool) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnPacketSent", sentTime, bytesInFlight, packetNumber, bytes, isRetransmittable)
 }
@@ -364,13 +364,13 @@ func (c *MockSendAlgorithmWithDebugInfosOnPacketSentCall) Return() *MockSendAlgo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSendAlgorithmWithDebugInfosOnPacketSentCall) Do(f func(time.Time, protocol.ByteCount, protocol.PacketNumber, protocol.ByteCount, bool)) *MockSendAlgorithmWithDebugInfosOnPacketSentCall {
+func (c *MockSendAlgorithmWithDebugInfosOnPacketSentCall) Do(f func(monotime.Time, protocol.ByteCount, protocol.PacketNumber, protocol.ByteCount, bool)) *MockSendAlgorithmWithDebugInfosOnPacketSentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSendAlgorithmWithDebugInfosOnPacketSentCall) DoAndReturn(f func(time.Time, protocol.ByteCount, protocol.PacketNumber, protocol.ByteCount, bool)) *MockSendAlgorithmWithDebugInfosOnPacketSentCall {
+func (c *MockSendAlgorithmWithDebugInfosOnPacketSentCall) DoAndReturn(f func(monotime.Time, protocol.ByteCount, protocol.PacketNumber, protocol.ByteCount, bool)) *MockSendAlgorithmWithDebugInfosOnPacketSentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -448,10 +448,10 @@ func (c *MockSendAlgorithmWithDebugInfosSetMaxDatagramSizeCall) DoAndReturn(f fu
 }
 
 // TimeUntilSend mocks base method.
-func (m *MockSendAlgorithmWithDebugInfos) TimeUntilSend(bytesInFlight protocol.ByteCount) time.Time {
+func (m *MockSendAlgorithmWithDebugInfos) TimeUntilSend(bytesInFlight protocol.ByteCount) monotime.Time {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TimeUntilSend", bytesInFlight)
-	ret0, _ := ret[0].(time.Time)
+	ret0, _ := ret[0].(monotime.Time)
 	return ret0
 }
 
@@ -468,19 +468,19 @@ type MockSendAlgorithmWithDebugInfosTimeUntilSendCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockSendAlgorithmWithDebugInfosTimeUntilSendCall) Return(arg0 time.Time) *MockSendAlgorithmWithDebugInfosTimeUntilSendCall {
+func (c *MockSendAlgorithmWithDebugInfosTimeUntilSendCall) Return(arg0 monotime.Time) *MockSendAlgorithmWithDebugInfosTimeUntilSendCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSendAlgorithmWithDebugInfosTimeUntilSendCall) Do(f func(protocol.ByteCount) time.Time) *MockSendAlgorithmWithDebugInfosTimeUntilSendCall {
+func (c *MockSendAlgorithmWithDebugInfosTimeUntilSendCall) Do(f func(protocol.ByteCount) monotime.Time) *MockSendAlgorithmWithDebugInfosTimeUntilSendCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSendAlgorithmWithDebugInfosTimeUntilSendCall) DoAndReturn(f func(protocol.ByteCount) time.Time) *MockSendAlgorithmWithDebugInfosTimeUntilSendCall {
+func (c *MockSendAlgorithmWithDebugInfosTimeUntilSendCall) DoAndReturn(f func(protocol.ByteCount) monotime.Time) *MockSendAlgorithmWithDebugInfosTimeUntilSendCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/mocks/short_header_opener.go
+++ b/internal/mocks/short_header_opener.go
@@ -11,8 +11,8 @@ package mocks
 
 import (
 	reflect "reflect"
-	time "time"
 
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -116,7 +116,7 @@ func (c *MockShortHeaderOpenerDecryptHeaderCall) DoAndReturn(f func([]byte, *byt
 }
 
 // Open mocks base method.
-func (m *MockShortHeaderOpener) Open(dst, src []byte, rcvTime time.Time, pn protocol.PacketNumber, kp protocol.KeyPhaseBit, associatedData []byte) ([]byte, error) {
+func (m *MockShortHeaderOpener) Open(dst, src []byte, rcvTime monotime.Time, pn protocol.PacketNumber, kp protocol.KeyPhaseBit, associatedData []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open", dst, src, rcvTime, pn, kp, associatedData)
 	ret0, _ := ret[0].([]byte)
@@ -143,13 +143,13 @@ func (c *MockShortHeaderOpenerOpenCall) Return(arg0 []byte, arg1 error) *MockSho
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockShortHeaderOpenerOpenCall) Do(f func([]byte, []byte, time.Time, protocol.PacketNumber, protocol.KeyPhaseBit, []byte) ([]byte, error)) *MockShortHeaderOpenerOpenCall {
+func (c *MockShortHeaderOpenerOpenCall) Do(f func([]byte, []byte, monotime.Time, protocol.PacketNumber, protocol.KeyPhaseBit, []byte) ([]byte, error)) *MockShortHeaderOpenerOpenCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockShortHeaderOpenerOpenCall) DoAndReturn(f func([]byte, []byte, time.Time, protocol.PacketNumber, protocol.KeyPhaseBit, []byte) ([]byte, error)) *MockShortHeaderOpenerOpenCall {
+func (c *MockShortHeaderOpenerOpenCall) DoAndReturn(f func([]byte, []byte, monotime.Time, protocol.PacketNumber, protocol.KeyPhaseBit, []byte) ([]byte, error)) *MockShortHeaderOpenerOpenCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/mocks/stream_flow_controller.go
+++ b/internal/mocks/stream_flow_controller.go
@@ -11,8 +11,8 @@ package mocks
 
 import (
 	reflect "reflect"
-	time "time"
 
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -153,7 +153,7 @@ func (c *MockStreamFlowControllerAddBytesSentCall) DoAndReturn(f func(protocol.B
 }
 
 // GetWindowUpdate mocks base method.
-func (m *MockStreamFlowController) GetWindowUpdate(arg0 time.Time) protocol.ByteCount {
+func (m *MockStreamFlowController) GetWindowUpdate(arg0 monotime.Time) protocol.ByteCount {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWindowUpdate", arg0)
 	ret0, _ := ret[0].(protocol.ByteCount)
@@ -179,13 +179,13 @@ func (c *MockStreamFlowControllerGetWindowUpdateCall) Return(arg0 protocol.ByteC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStreamFlowControllerGetWindowUpdateCall) Do(f func(time.Time) protocol.ByteCount) *MockStreamFlowControllerGetWindowUpdateCall {
+func (c *MockStreamFlowControllerGetWindowUpdateCall) Do(f func(monotime.Time) protocol.ByteCount) *MockStreamFlowControllerGetWindowUpdateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStreamFlowControllerGetWindowUpdateCall) DoAndReturn(f func(time.Time) protocol.ByteCount) *MockStreamFlowControllerGetWindowUpdateCall {
+func (c *MockStreamFlowControllerGetWindowUpdateCall) DoAndReturn(f func(monotime.Time) protocol.ByteCount) *MockStreamFlowControllerGetWindowUpdateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -267,7 +267,7 @@ func (c *MockStreamFlowControllerSendWindowSizeCall) DoAndReturn(f func() protoc
 }
 
 // UpdateHighestReceived mocks base method.
-func (m *MockStreamFlowController) UpdateHighestReceived(offset protocol.ByteCount, final bool, now time.Time) error {
+func (m *MockStreamFlowController) UpdateHighestReceived(offset protocol.ByteCount, final bool, now monotime.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateHighestReceived", offset, final, now)
 	ret0, _ := ret[0].(error)
@@ -293,13 +293,13 @@ func (c *MockStreamFlowControllerUpdateHighestReceivedCall) Return(arg0 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStreamFlowControllerUpdateHighestReceivedCall) Do(f func(protocol.ByteCount, bool, time.Time) error) *MockStreamFlowControllerUpdateHighestReceivedCall {
+func (c *MockStreamFlowControllerUpdateHighestReceivedCall) Do(f func(protocol.ByteCount, bool, monotime.Time) error) *MockStreamFlowControllerUpdateHighestReceivedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStreamFlowControllerUpdateHighestReceivedCall) DoAndReturn(f func(protocol.ByteCount, bool, time.Time) error) *MockStreamFlowControllerUpdateHighestReceivedCall {
+func (c *MockStreamFlowControllerUpdateHighestReceivedCall) DoAndReturn(f func(protocol.ByteCount, bool, monotime.Time) error) *MockStreamFlowControllerUpdateHighestReceivedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/monotime/time.go
+++ b/internal/monotime/time.go
@@ -8,7 +8,10 @@ import (
 	"time"
 )
 
-var start = time.Now()
+// The absolute value doesn't matter, but it should be in the past,
+// so that every timestamp obtained with Now() is non-zero,
+// even on systems with low timer resolutions (e.g. Windows).
+var start = time.Now().Add(-time.Hour)
 
 // A Time represents an instant in monotonic time.
 // Times can be compared using the comparison operators, but the specific

--- a/internal/monotime/time.go
+++ b/internal/monotime/time.go
@@ -69,7 +69,7 @@ func (t Time) ToTime() time.Time {
 
 // Since returns the time elapsed since t. It is shorthand for Now().Sub(t).
 func Since(t Time) time.Duration {
-	return time.Since(start.Add(time.Duration(t)))
+	return Now().Sub(t)
 }
 
 // Until returns the duration until t.

--- a/internal/monotime/time.go
+++ b/internal/monotime/time.go
@@ -1,0 +1,87 @@
+// Package monotime provides a monotonic time representation that is useful for
+// measuring elapsed time.
+// It is designed as a memory optimized drop-in replacement for time.Time, with
+// a monotime.Time consuming just 8 bytes instead of 24 bytes.
+package monotime
+
+import (
+	"time"
+)
+
+var start = time.Now()
+
+// A Time represents an instant in monotonic time.
+// Times can be compared using the comparison operators, but the specific
+// value is implementation-dependent and should not be relied upon.
+// The zero value of Time doesn't have any specific meaning.
+type Time int64
+
+// Now returns the current monotonic time.
+func Now() Time {
+	return Time(time.Since(start).Nanoseconds())
+}
+
+// Sub returns the duration t-t2. If the result exceeds the maximum (or minimum)
+// value that can be stored in a Duration, the maximum (or minimum) duration
+// will be returned.
+// To compute t-d for a duration d, use t.Add(-d).
+func (t Time) Sub(t2 Time) time.Duration {
+	return time.Duration(t - t2)
+}
+
+// Add returns the time t+d.
+func (t Time) Add(d time.Duration) Time {
+	return Time(int64(t) + d.Nanoseconds())
+}
+
+// After reports whether the time instant t is after t2.
+func (t Time) After(t2 Time) bool {
+	return t > t2
+}
+
+// Before reports whether the time instant t is before t2.
+func (t Time) Before(t2 Time) bool {
+	return t < t2
+}
+
+// IsZero reports whether t represents the zero time instant.
+func (t Time) IsZero() bool {
+	return t == 0
+}
+
+// Equal reports whether t and t2 represent the same time instant.
+func (t Time) Equal(t2 Time) bool {
+	return t == t2
+}
+
+// ToTime converts the monotonic time to a time.Time value.
+// The returned time.Time will have the same instant as the monotonic time,
+// but may be subject to clock adjustments.
+func (t Time) ToTime() time.Time {
+	if t.IsZero() {
+		return time.Time{}
+	}
+	return start.Add(time.Duration(t))
+}
+
+// Since returns the time elapsed since t. It is shorthand for Now().Sub(t).
+func Since(t Time) time.Duration {
+	return time.Since(start.Add(time.Duration(t)))
+}
+
+// Until returns the duration until t.
+// It is shorthand for t.Sub(Now()).
+// If t is in the past, the returned duration will be negative.
+func Until(t Time) time.Duration {
+	return time.Duration(t - Now())
+}
+
+// FromTime converts a time.Time to a monotonic Time.
+// The conversion is relative to the package's start time and may lose
+// precision if the time.Time is far from the start time.
+func FromTime(t time.Time) Time {
+	if t.IsZero() {
+		return 0
+	}
+	return Time(t.Sub(start).Nanoseconds())
+}

--- a/internal/monotime/time_test.go
+++ b/internal/monotime/time_test.go
@@ -10,25 +10,21 @@ import (
 )
 
 func TestTimeRelations(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		time.Sleep(time.Hour)
+	t1 := Now()
+	require.Equal(t, t1, t1)
+	require.False(t, t1.IsZero())
 
-		t1 := Now()
-		require.Equal(t, t1, t1)
-		require.False(t, t1.IsZero())
+	t2 := t1.Add(time.Second)
 
-		t2 := t1.Add(time.Second)
+	require.False(t, t1.Equal(t2))
+	require.False(t, t2.Equal(t1))
 
-		require.False(t, t1.Equal(t2))
-		require.False(t, t2.Equal(t1))
+	require.True(t, t2.After(t1))
+	require.False(t, t1.After(t2))
+	require.False(t, t2.Before(t1))
 
-		require.True(t, t2.After(t1))
-		require.False(t, t1.After(t2))
-		require.False(t, t2.Before(t1))
-
-		require.Equal(t, t2.Sub(t1), time.Second)
-		require.Equal(t, t1.Sub(t2), -time.Second)
-	})
+	require.Equal(t, t2.Sub(t1), time.Second)
+	require.Equal(t, t1.Sub(t2), -time.Second)
 }
 
 func TestSince(t *testing.T) {

--- a/internal/monotime/time_test.go
+++ b/internal/monotime/time_test.go
@@ -1,0 +1,83 @@
+package monotime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/synctest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeRelations(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		time.Sleep(time.Hour)
+
+		t1 := Now()
+		require.Equal(t, t1, t1)
+		require.False(t, t1.IsZero())
+
+		t2 := t1.Add(time.Second)
+
+		require.False(t, t1.Equal(t2))
+		require.False(t, t2.Equal(t1))
+
+		require.True(t, t2.After(t1))
+		require.False(t, t1.After(t2))
+		require.False(t, t2.Before(t1))
+
+		require.Equal(t, t2.Sub(t1), time.Second)
+		require.Equal(t, t1.Sub(t2), -time.Second)
+	})
+}
+
+func TestSince(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		t1 := Now()
+		time.Sleep(time.Second)
+		require.Equal(t, Since(t1), time.Second)
+		require.Equal(t, Now().Sub(t1), time.Second)
+		time.Sleep(time.Minute)
+		require.Equal(t, Since(t1), time.Minute+time.Second)
+		require.Equal(t, Now().Sub(t1), time.Minute+time.Second)
+	})
+}
+
+func TestUntil(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		t1 := Now().Add(time.Minute)
+		require.Equal(t, Until(t1), time.Minute)
+		require.Equal(t, t1.Sub(Now()), time.Minute)
+		time.Sleep(15 * time.Second)
+		require.Equal(t, Until(t1), 45*time.Second)
+		require.Equal(t, t1.Sub(Now()), 45*time.Second)
+	})
+}
+
+func TestConversions(t *testing.T) {
+	t1 := Now()
+	t1Time := t1.ToTime()
+	require.Equal(t, FromTime(t1Time), t1)
+	require.Zero(t, t1Time.Sub(t1.ToTime()))
+
+	var zeroTime time.Time
+	require.Zero(t, FromTime(zeroTime))
+	require.Zero(t, FromTime(zeroTime))
+
+	var zero Time
+	require.True(t, zero.ToTime().IsZero())
+}
+
+func BenchmarkNow(b *testing.B) {
+	b.Run("Now", func(b *testing.B) {
+		for b.Loop() {
+			_ = Now()
+		}
+	})
+
+	b.Run("time.Now", func(b *testing.B) {
+		for b.Loop() {
+			_ = time.Now()
+		}
+	})
+}

--- a/internal/utils/timer.go
+++ b/internal/utils/timer.go
@@ -3,13 +3,15 @@ package utils
 import (
 	"math"
 	"time"
+
+	"github.com/quic-go/quic-go/internal/monotime"
 )
 
 // A Timer wrapper that behaves correctly when resetting
 type Timer struct {
 	t        *time.Timer
 	read     bool
-	deadline time.Time
+	deadline monotime.Time
 }
 
 // NewTimer creates a new timer that is not set
@@ -23,7 +25,7 @@ func (t *Timer) Chan() <-chan time.Time {
 }
 
 // Reset the timer, no matter whether the value was read or not
-func (t *Timer) Reset(deadline time.Time) {
+func (t *Timer) Reset(deadline monotime.Time) {
 	if deadline.Equal(t.deadline) && !t.read {
 		// No need to reset the timer
 		return
@@ -35,7 +37,7 @@ func (t *Timer) Reset(deadline time.Time) {
 		<-t.t.C
 	}
 	if !deadline.IsZero() {
-		t.t.Reset(time.Until(deadline))
+		t.t.Reset(monotime.Until(deadline))
 	}
 
 	t.read = false
@@ -47,7 +49,7 @@ func (t *Timer) SetRead() {
 	t.read = true
 }
 
-func (t *Timer) Deadline() time.Time {
+func (t *Timer) Deadline() monotime.Time {
 	return t.deadline
 }
 

--- a/mock_ack_frame_source_test.go
+++ b/mock_ack_frame_source_test.go
@@ -11,8 +11,8 @@ package quic
 
 import (
 	reflect "reflect"
-	time "time"
 
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	wire "github.com/quic-go/quic-go/internal/wire"
 	gomock "go.uber.org/mock/gomock"
@@ -43,7 +43,7 @@ func (m *MockAckFrameSource) EXPECT() *MockAckFrameSourceMockRecorder {
 }
 
 // GetAckFrame mocks base method.
-func (m *MockAckFrameSource) GetAckFrame(arg0 protocol.EncryptionLevel, now time.Time, onlyIfQueued bool) *wire.AckFrame {
+func (m *MockAckFrameSource) GetAckFrame(arg0 protocol.EncryptionLevel, now monotime.Time, onlyIfQueued bool) *wire.AckFrame {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAckFrame", arg0, now, onlyIfQueued)
 	ret0, _ := ret[0].(*wire.AckFrame)
@@ -69,13 +69,13 @@ func (c *MockAckFrameSourceGetAckFrameCall) Return(arg0 *wire.AckFrame) *MockAck
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAckFrameSourceGetAckFrameCall) Do(f func(protocol.EncryptionLevel, time.Time, bool) *wire.AckFrame) *MockAckFrameSourceGetAckFrameCall {
+func (c *MockAckFrameSourceGetAckFrameCall) Do(f func(protocol.EncryptionLevel, monotime.Time, bool) *wire.AckFrame) *MockAckFrameSourceGetAckFrameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAckFrameSourceGetAckFrameCall) DoAndReturn(f func(protocol.EncryptionLevel, time.Time, bool) *wire.AckFrame) *MockAckFrameSourceGetAckFrameCall {
+func (c *MockAckFrameSourceGetAckFrameCall) DoAndReturn(f func(protocol.EncryptionLevel, monotime.Time, bool) *wire.AckFrame) *MockAckFrameSourceGetAckFrameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mock_frame_source_test.go
+++ b/mock_frame_source_test.go
@@ -11,9 +11,9 @@ package quic
 
 import (
 	reflect "reflect"
-	time "time"
 
 	ackhandler "github.com/quic-go/quic-go/internal/ackhandler"
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -43,7 +43,7 @@ func (m *MockFrameSource) EXPECT() *MockFrameSourceMockRecorder {
 }
 
 // Append mocks base method.
-func (m *MockFrameSource) Append(arg0 []ackhandler.Frame, arg1 []ackhandler.StreamFrame, arg2 protocol.ByteCount, arg3 time.Time, arg4 protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount) {
+func (m *MockFrameSource) Append(arg0 []ackhandler.Frame, arg1 []ackhandler.StreamFrame, arg2 protocol.ByteCount, arg3 monotime.Time, arg4 protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Append", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]ackhandler.Frame)
@@ -71,13 +71,13 @@ func (c *MockFrameSourceAppendCall) Return(arg0 []ackhandler.Frame, arg1 []ackha
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFrameSourceAppendCall) Do(f func([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount, time.Time, protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount)) *MockFrameSourceAppendCall {
+func (c *MockFrameSourceAppendCall) Do(f func([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount, monotime.Time, protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount)) *MockFrameSourceAppendCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFrameSourceAppendCall) DoAndReturn(f func([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount, time.Time, protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount)) *MockFrameSourceAppendCall {
+func (c *MockFrameSourceAppendCall) DoAndReturn(f func([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount, monotime.Time, protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount)) *MockFrameSourceAppendCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mock_mtu_discoverer_test.go
+++ b/mock_mtu_discoverer_test.go
@@ -11,9 +11,9 @@ package quic
 
 import (
 	reflect "reflect"
-	time "time"
 
 	ackhandler "github.com/quic-go/quic-go/internal/ackhandler"
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -81,7 +81,7 @@ func (c *MockMTUDiscovererCurrentSizeCall) DoAndReturn(f func() protocol.ByteCou
 }
 
 // GetPing mocks base method.
-func (m *MockMTUDiscoverer) GetPing(now time.Time) (ackhandler.Frame, protocol.ByteCount) {
+func (m *MockMTUDiscoverer) GetPing(now monotime.Time) (ackhandler.Frame, protocol.ByteCount) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPing", now)
 	ret0, _ := ret[0].(ackhandler.Frame)
@@ -108,19 +108,19 @@ func (c *MockMTUDiscovererGetPingCall) Return(ping ackhandler.Frame, datagramSiz
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMTUDiscovererGetPingCall) Do(f func(time.Time) (ackhandler.Frame, protocol.ByteCount)) *MockMTUDiscovererGetPingCall {
+func (c *MockMTUDiscovererGetPingCall) Do(f func(monotime.Time) (ackhandler.Frame, protocol.ByteCount)) *MockMTUDiscovererGetPingCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMTUDiscovererGetPingCall) DoAndReturn(f func(time.Time) (ackhandler.Frame, protocol.ByteCount)) *MockMTUDiscovererGetPingCall {
+func (c *MockMTUDiscovererGetPingCall) DoAndReturn(f func(monotime.Time) (ackhandler.Frame, protocol.ByteCount)) *MockMTUDiscovererGetPingCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Reset mocks base method.
-func (m *MockMTUDiscoverer) Reset(now time.Time, start, max protocol.ByteCount) {
+func (m *MockMTUDiscoverer) Reset(now monotime.Time, start, max protocol.ByteCount) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Reset", now, start, max)
 }
@@ -144,19 +144,19 @@ func (c *MockMTUDiscovererResetCall) Return() *MockMTUDiscovererResetCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMTUDiscovererResetCall) Do(f func(time.Time, protocol.ByteCount, protocol.ByteCount)) *MockMTUDiscovererResetCall {
+func (c *MockMTUDiscovererResetCall) Do(f func(monotime.Time, protocol.ByteCount, protocol.ByteCount)) *MockMTUDiscovererResetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMTUDiscovererResetCall) DoAndReturn(f func(time.Time, protocol.ByteCount, protocol.ByteCount)) *MockMTUDiscovererResetCall {
+func (c *MockMTUDiscovererResetCall) DoAndReturn(f func(monotime.Time, protocol.ByteCount, protocol.ByteCount)) *MockMTUDiscovererResetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ShouldSendProbe mocks base method.
-func (m *MockMTUDiscoverer) ShouldSendProbe(now time.Time) bool {
+func (m *MockMTUDiscoverer) ShouldSendProbe(now monotime.Time) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ShouldSendProbe", now)
 	ret0, _ := ret[0].(bool)
@@ -182,19 +182,19 @@ func (c *MockMTUDiscovererShouldSendProbeCall) Return(arg0 bool) *MockMTUDiscove
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMTUDiscovererShouldSendProbeCall) Do(f func(time.Time) bool) *MockMTUDiscovererShouldSendProbeCall {
+func (c *MockMTUDiscovererShouldSendProbeCall) Do(f func(monotime.Time) bool) *MockMTUDiscovererShouldSendProbeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMTUDiscovererShouldSendProbeCall) DoAndReturn(f func(time.Time) bool) *MockMTUDiscovererShouldSendProbeCall {
+func (c *MockMTUDiscovererShouldSendProbeCall) DoAndReturn(f func(monotime.Time) bool) *MockMTUDiscovererShouldSendProbeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Start mocks base method.
-func (m *MockMTUDiscoverer) Start(now time.Time) {
+func (m *MockMTUDiscoverer) Start(now monotime.Time) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Start", now)
 }
@@ -218,13 +218,13 @@ func (c *MockMTUDiscovererStartCall) Return() *MockMTUDiscovererStartCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMTUDiscovererStartCall) Do(f func(time.Time)) *MockMTUDiscovererStartCall {
+func (c *MockMTUDiscovererStartCall) Do(f func(monotime.Time)) *MockMTUDiscovererStartCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMTUDiscovererStartCall) DoAndReturn(f func(time.Time)) *MockMTUDiscovererStartCall {
+func (c *MockMTUDiscovererStartCall) DoAndReturn(f func(monotime.Time)) *MockMTUDiscovererStartCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mock_packer_test.go
+++ b/mock_packer_test.go
@@ -11,9 +11,9 @@ package quic
 
 import (
 	reflect "reflect"
-	time "time"
 
 	ackhandler "github.com/quic-go/quic-go/internal/ackhandler"
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	qerr "github.com/quic-go/quic-go/internal/qerr"
 	gomock "go.uber.org/mock/gomock"
@@ -44,7 +44,7 @@ func (m *MockPacker) EXPECT() *MockPackerMockRecorder {
 }
 
 // AppendPacket mocks base method.
-func (m *MockPacker) AppendPacket(arg0 *packetBuffer, maxPacketSize protocol.ByteCount, now time.Time, v protocol.Version) (shortHeaderPacket, error) {
+func (m *MockPacker) AppendPacket(arg0 *packetBuffer, maxPacketSize protocol.ByteCount, now monotime.Time, v protocol.Version) (shortHeaderPacket, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppendPacket", arg0, maxPacketSize, now, v)
 	ret0, _ := ret[0].(shortHeaderPacket)
@@ -71,19 +71,19 @@ func (c *MockPackerAppendPacketCall) Return(arg0 shortHeaderPacket, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPackerAppendPacketCall) Do(f func(*packetBuffer, protocol.ByteCount, time.Time, protocol.Version) (shortHeaderPacket, error)) *MockPackerAppendPacketCall {
+func (c *MockPackerAppendPacketCall) Do(f func(*packetBuffer, protocol.ByteCount, monotime.Time, protocol.Version) (shortHeaderPacket, error)) *MockPackerAppendPacketCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPackerAppendPacketCall) DoAndReturn(f func(*packetBuffer, protocol.ByteCount, time.Time, protocol.Version) (shortHeaderPacket, error)) *MockPackerAppendPacketCall {
+func (c *MockPackerAppendPacketCall) DoAndReturn(f func(*packetBuffer, protocol.ByteCount, monotime.Time, protocol.Version) (shortHeaderPacket, error)) *MockPackerAppendPacketCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // PackAckOnlyPacket mocks base method.
-func (m *MockPacker) PackAckOnlyPacket(maxPacketSize protocol.ByteCount, now time.Time, v protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
+func (m *MockPacker) PackAckOnlyPacket(maxPacketSize protocol.ByteCount, now monotime.Time, v protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PackAckOnlyPacket", maxPacketSize, now, v)
 	ret0, _ := ret[0].(shortHeaderPacket)
@@ -111,13 +111,13 @@ func (c *MockPackerPackAckOnlyPacketCall) Return(arg0 shortHeaderPacket, arg1 *p
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPackerPackAckOnlyPacketCall) Do(f func(protocol.ByteCount, time.Time, protocol.Version) (shortHeaderPacket, *packetBuffer, error)) *MockPackerPackAckOnlyPacketCall {
+func (c *MockPackerPackAckOnlyPacketCall) Do(f func(protocol.ByteCount, monotime.Time, protocol.Version) (shortHeaderPacket, *packetBuffer, error)) *MockPackerPackAckOnlyPacketCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPackerPackAckOnlyPacketCall) DoAndReturn(f func(protocol.ByteCount, time.Time, protocol.Version) (shortHeaderPacket, *packetBuffer, error)) *MockPackerPackAckOnlyPacketCall {
+func (c *MockPackerPackAckOnlyPacketCall) DoAndReturn(f func(protocol.ByteCount, monotime.Time, protocol.Version) (shortHeaderPacket, *packetBuffer, error)) *MockPackerPackAckOnlyPacketCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -162,7 +162,7 @@ func (c *MockPackerPackApplicationCloseCall) DoAndReturn(f func(*qerr.Applicatio
 }
 
 // PackCoalescedPacket mocks base method.
-func (m *MockPacker) PackCoalescedPacket(onlyAck bool, maxPacketSize protocol.ByteCount, now time.Time, v protocol.Version) (*coalescedPacket, error) {
+func (m *MockPacker) PackCoalescedPacket(onlyAck bool, maxPacketSize protocol.ByteCount, now monotime.Time, v protocol.Version) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PackCoalescedPacket", onlyAck, maxPacketSize, now, v)
 	ret0, _ := ret[0].(*coalescedPacket)
@@ -189,13 +189,13 @@ func (c *MockPackerPackCoalescedPacketCall) Return(arg0 *coalescedPacket, arg1 e
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPackerPackCoalescedPacketCall) Do(f func(bool, protocol.ByteCount, time.Time, protocol.Version) (*coalescedPacket, error)) *MockPackerPackCoalescedPacketCall {
+func (c *MockPackerPackCoalescedPacketCall) Do(f func(bool, protocol.ByteCount, monotime.Time, protocol.Version) (*coalescedPacket, error)) *MockPackerPackCoalescedPacketCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPackerPackCoalescedPacketCall) DoAndReturn(f func(bool, protocol.ByteCount, time.Time, protocol.Version) (*coalescedPacket, error)) *MockPackerPackCoalescedPacketCall {
+func (c *MockPackerPackCoalescedPacketCall) DoAndReturn(f func(bool, protocol.ByteCount, monotime.Time, protocol.Version) (*coalescedPacket, error)) *MockPackerPackCoalescedPacketCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -280,7 +280,7 @@ func (c *MockPackerPackMTUProbePacketCall) DoAndReturn(f func(ackhandler.Frame, 
 }
 
 // PackPTOProbePacket mocks base method.
-func (m *MockPacker) PackPTOProbePacket(arg0 protocol.EncryptionLevel, arg1 protocol.ByteCount, addPingIfEmpty bool, now time.Time, v protocol.Version) (*coalescedPacket, error) {
+func (m *MockPacker) PackPTOProbePacket(arg0 protocol.EncryptionLevel, arg1 protocol.ByteCount, addPingIfEmpty bool, now monotime.Time, v protocol.Version) (*coalescedPacket, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PackPTOProbePacket", arg0, arg1, addPingIfEmpty, now, v)
 	ret0, _ := ret[0].(*coalescedPacket)
@@ -307,13 +307,13 @@ func (c *MockPackerPackPTOProbePacketCall) Return(arg0 *coalescedPacket, arg1 er
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPackerPackPTOProbePacketCall) Do(f func(protocol.EncryptionLevel, protocol.ByteCount, bool, time.Time, protocol.Version) (*coalescedPacket, error)) *MockPackerPackPTOProbePacketCall {
+func (c *MockPackerPackPTOProbePacketCall) Do(f func(protocol.EncryptionLevel, protocol.ByteCount, bool, monotime.Time, protocol.Version) (*coalescedPacket, error)) *MockPackerPackPTOProbePacketCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPackerPackPTOProbePacketCall) DoAndReturn(f func(protocol.EncryptionLevel, protocol.ByteCount, bool, time.Time, protocol.Version) (*coalescedPacket, error)) *MockPackerPackPTOProbePacketCall {
+func (c *MockPackerPackPTOProbePacketCall) DoAndReturn(f func(protocol.EncryptionLevel, protocol.ByteCount, bool, monotime.Time, protocol.Version) (*coalescedPacket, error)) *MockPackerPackPTOProbePacketCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mock_stream_control_frame_getter_test.go
+++ b/mock_stream_control_frame_getter_test.go
@@ -11,9 +11,9 @@ package quic
 
 import (
 	reflect "reflect"
-	time "time"
 
 	ackhandler "github.com/quic-go/quic-go/internal/ackhandler"
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -42,7 +42,7 @@ func (m *MockStreamControlFrameGetter) EXPECT() *MockStreamControlFrameGetterMoc
 }
 
 // getControlFrame mocks base method.
-func (m *MockStreamControlFrameGetter) getControlFrame(arg0 time.Time) (ackhandler.Frame, bool, bool) {
+func (m *MockStreamControlFrameGetter) getControlFrame(arg0 monotime.Time) (ackhandler.Frame, bool, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "getControlFrame", arg0)
 	ret0, _ := ret[0].(ackhandler.Frame)
@@ -70,13 +70,13 @@ func (c *MockStreamControlFrameGettergetControlFrameCall) Return(arg0 ackhandler
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStreamControlFrameGettergetControlFrameCall) Do(f func(time.Time) (ackhandler.Frame, bool, bool)) *MockStreamControlFrameGettergetControlFrameCall {
+func (c *MockStreamControlFrameGettergetControlFrameCall) Do(f func(monotime.Time) (ackhandler.Frame, bool, bool)) *MockStreamControlFrameGettergetControlFrameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStreamControlFrameGettergetControlFrameCall) DoAndReturn(f func(time.Time) (ackhandler.Frame, bool, bool)) *MockStreamControlFrameGettergetControlFrameCall {
+func (c *MockStreamControlFrameGettergetControlFrameCall) DoAndReturn(f func(monotime.Time) (ackhandler.Frame, bool, bool)) *MockStreamControlFrameGettergetControlFrameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mock_unpacker_test.go
+++ b/mock_unpacker_test.go
@@ -11,8 +11,8 @@ package quic
 
 import (
 	reflect "reflect"
-	time "time"
 
+	monotime "github.com/quic-go/quic-go/internal/monotime"
 	protocol "github.com/quic-go/quic-go/internal/protocol"
 	wire "github.com/quic-go/quic-go/internal/wire"
 	gomock "go.uber.org/mock/gomock"
@@ -82,7 +82,7 @@ func (c *MockUnpackerUnpackLongHeaderCall) DoAndReturn(f func(*wire.Header, []by
 }
 
 // UnpackShortHeader mocks base method.
-func (m *MockUnpacker) UnpackShortHeader(rcvTime time.Time, data []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error) {
+func (m *MockUnpacker) UnpackShortHeader(rcvTime monotime.Time, data []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnpackShortHeader", rcvTime, data)
 	ret0, _ := ret[0].(protocol.PacketNumber)
@@ -112,13 +112,13 @@ func (c *MockUnpackerUnpackShortHeaderCall) Return(arg0 protocol.PacketNumber, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnpackerUnpackShortHeaderCall) Do(f func(time.Time, []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error)) *MockUnpackerUnpackShortHeaderCall {
+func (c *MockUnpackerUnpackShortHeaderCall) Do(f func(monotime.Time, []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error)) *MockUnpackerUnpackShortHeaderCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnpackerUnpackShortHeaderCall) DoAndReturn(f func(time.Time, []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error)) *MockUnpackerUnpackShortHeaderCall {
+func (c *MockUnpackerUnpackShortHeaderCall) DoAndReturn(f func(monotime.Time, []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error)) *MockUnpackerUnpackShortHeaderCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mtu_discoverer.go
+++ b/mtu_discoverer.go
@@ -1,9 +1,8 @@
 package quic
 
 import (
-	"time"
-
 	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -13,11 +12,11 @@ import (
 type mtuDiscoverer interface {
 	// Start starts the MTU discovery process.
 	// It's unnecessary to call ShouldSendProbe before that.
-	Start(now time.Time)
-	ShouldSendProbe(now time.Time) bool
+	Start(now monotime.Time)
+	ShouldSendProbe(now monotime.Time) bool
 	CurrentSize() protocol.ByteCount
-	GetPing(now time.Time) (ping ackhandler.Frame, datagramSize protocol.ByteCount)
-	Reset(now time.Time, start, max protocol.ByteCount)
+	GetPing(now monotime.Time) (ping ackhandler.Frame, datagramSize protocol.ByteCount)
+	Reset(now monotime.Time, start, max protocol.ByteCount)
 }
 
 const (
@@ -88,7 +87,7 @@ const (
 // MTU discovery concludes once the interval min and max has been narrowed down to maxMTUDiff.
 
 type mtuFinder struct {
-	lastProbeTime time.Time
+	lastProbeTime monotime.Time
 
 	rttStats *utils.RTTStats
 
@@ -147,11 +146,11 @@ func (f *mtuFinder) max() protocol.ByteCount {
 	return f.lost[len(f.lost)-1]
 }
 
-func (f *mtuFinder) Start(now time.Time) {
+func (f *mtuFinder) Start(now monotime.Time) {
 	f.lastProbeTime = now // makes sure the first probe packet is not sent immediately
 }
 
-func (f *mtuFinder) ShouldSendProbe(now time.Time) bool {
+func (f *mtuFinder) ShouldSendProbe(now monotime.Time) bool {
 	if f.lastProbeTime.IsZero() {
 		return false
 	}
@@ -161,7 +160,7 @@ func (f *mtuFinder) ShouldSendProbe(now time.Time) bool {
 	return !now.Before(f.lastProbeTime.Add(mtuProbeDelay * f.rttStats.SmoothedRTT()))
 }
 
-func (f *mtuFinder) GetPing(now time.Time) (ackhandler.Frame, protocol.ByteCount) {
+func (f *mtuFinder) GetPing(now monotime.Time) (ackhandler.Frame, protocol.ByteCount) {
 	var size protocol.ByteCount
 	if f.lastProbeWasLost {
 		size = (f.min + f.lost[0]) / 2
@@ -180,7 +179,7 @@ func (f *mtuFinder) CurrentSize() protocol.ByteCount {
 	return f.min
 }
 
-func (f *mtuFinder) Reset(now time.Time, start, max protocol.ByteCount) {
+func (f *mtuFinder) Reset(now monotime.Time, start, max protocol.ByteCount) {
 	f.generation++
 	f.lastProbeTime = now
 	f.lastProbeWasLost = false

--- a/mtu_discoverer_test.go
+++ b/mtu_discoverer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/logging"
@@ -19,7 +20,7 @@ func TestMTUDiscovererTiming(t *testing.T) {
 	rttStats.UpdateRTT(rtt, 0)
 	d := newMTUDiscoverer(&rttStats, 1000, 2000, nil)
 
-	now := time.Now()
+	now := monotime.Now()
 	require.False(t, d.ShouldSendProbe(now))
 	d.Start(now)
 	require.False(t, d.ShouldSendProbe(now))
@@ -39,7 +40,7 @@ func TestMTUDiscovererTiming(t *testing.T) {
 func TestMTUDiscovererAckAndLoss(t *testing.T) {
 	d := newMTUDiscoverer(&utils.RTTStats{}, 1000, 2000, nil)
 	// we use an RTT of 0 here, so we don't have to advance the timer on every step
-	now := time.Now()
+	now := monotime.Now()
 	ping, size := d.GetPing(now)
 	require.Equal(t, protocol.ByteCount(1500), size)
 	// the MTU is reduced if the frame is lost
@@ -100,7 +101,7 @@ func testMTUDiscovererMTUDiscovery(t *testing.T) {
 			},
 		},
 	)
-	now := time.Now()
+	now := monotime.Now()
 	d.Start(now)
 	realMTU := protocol.ByteCount(rand.IntN(int(maxMTU-startMTU))) + startMTU
 	t.Logf("MTU: %d, max: %d", realMTU, maxMTU)
@@ -158,8 +159,8 @@ func testMTUDiscovererWithRandomLoss(t *testing.T) {
 			},
 		},
 	)
-	d.Start(time.Now())
-	now := time.Now()
+	d.Start(monotime.Now())
+	now := monotime.Now()
 	realMTU := protocol.ByteCount(rand.IntN(int(maxMTU-startMTU))) + startMTU
 	t.Logf("MTU: %d, max: %d", realMTU, maxMTU)
 	now = now.Add(mtuProbeDelay * rtt)
@@ -215,7 +216,7 @@ func testMTUDiscovererReset(t *testing.T, ackLastProbe bool) {
 	rttStats := &utils.RTTStats{}
 	rttStats.SetInitialRTT(rtt)
 
-	now := time.Now()
+	now := monotime.Now()
 	d := newMTUDiscoverer(rttStats, startMTU, maxMTU, nil)
 	d.Start(now)
 

--- a/packet_packer.go
+++ b/packet_packer.go
@@ -6,10 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
-	"time"
 
 	"github.com/quic-go/quic-go/internal/ackhandler"
 	"github.com/quic-go/quic-go/internal/handshake"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -18,10 +18,10 @@ import (
 var errNothingToPack = errors.New("nothing to pack")
 
 type packer interface {
-	PackCoalescedPacket(onlyAck bool, maxPacketSize protocol.ByteCount, now time.Time, v protocol.Version) (*coalescedPacket, error)
-	PackAckOnlyPacket(maxPacketSize protocol.ByteCount, now time.Time, v protocol.Version) (shortHeaderPacket, *packetBuffer, error)
-	AppendPacket(_ *packetBuffer, maxPacketSize protocol.ByteCount, now time.Time, v protocol.Version) (shortHeaderPacket, error)
-	PackPTOProbePacket(_ protocol.EncryptionLevel, _ protocol.ByteCount, addPingIfEmpty bool, now time.Time, v protocol.Version) (*coalescedPacket, error)
+	PackCoalescedPacket(onlyAck bool, maxPacketSize protocol.ByteCount, now monotime.Time, v protocol.Version) (*coalescedPacket, error)
+	PackAckOnlyPacket(maxPacketSize protocol.ByteCount, now monotime.Time, v protocol.Version) (shortHeaderPacket, *packetBuffer, error)
+	AppendPacket(_ *packetBuffer, maxPacketSize protocol.ByteCount, now monotime.Time, v protocol.Version) (shortHeaderPacket, error)
+	PackPTOProbePacket(_ protocol.EncryptionLevel, _ protocol.ByteCount, addPingIfEmpty bool, now monotime.Time, v protocol.Version) (*coalescedPacket, error)
 	PackConnectionClose(*qerr.TransportError, protocol.ByteCount, protocol.Version) (*coalescedPacket, error)
 	PackApplicationClose(*qerr.ApplicationError, protocol.ByteCount, protocol.Version) (*coalescedPacket, error)
 	PackPathProbePacket(protocol.ConnectionID, []ackhandler.Frame, protocol.Version) (shortHeaderPacket, *packetBuffer, error)
@@ -108,11 +108,11 @@ type sealingManager interface {
 
 type frameSource interface {
 	HasData() bool
-	Append([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount, time.Time, protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount)
+	Append([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount, monotime.Time, protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount)
 }
 
 type ackFrameSource interface {
-	GetAckFrame(_ protocol.EncryptionLevel, now time.Time, onlyIfQueued bool) *wire.AckFrame
+	GetAckFrame(_ protocol.EncryptionLevel, now monotime.Time, onlyIfQueued bool) *wire.AckFrame
 }
 
 type packetPacker struct {
@@ -330,7 +330,7 @@ func (p *packetPacker) initialPaddingLen(frames []ackhandler.Frame, currentSize,
 // PackCoalescedPacket packs a new packet.
 // It packs an Initial / Handshake if there is data to send in these packet number spaces.
 // It should only be called before the handshake is confirmed.
-func (p *packetPacker) PackCoalescedPacket(onlyAck bool, maxSize protocol.ByteCount, now time.Time, v protocol.Version) (*coalescedPacket, error) {
+func (p *packetPacker) PackCoalescedPacket(onlyAck bool, maxSize protocol.ByteCount, now monotime.Time, v protocol.Version) (*coalescedPacket, error) {
 	var (
 		initialHdr, handshakeHdr, zeroRTTHdr                            *wire.ExtendedHeader
 		initialPayload, handshakePayload, zeroRTTPayload, oneRTTPayload payload
@@ -460,7 +460,7 @@ func (p *packetPacker) PackCoalescedPacket(onlyAck bool, maxSize protocol.ByteCo
 
 // PackAckOnlyPacket packs a packet containing only an ACK in the application data packet number space.
 // It should be called after the handshake is confirmed.
-func (p *packetPacker) PackAckOnlyPacket(maxSize protocol.ByteCount, now time.Time, v protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
+func (p *packetPacker) PackAckOnlyPacket(maxSize protocol.ByteCount, now monotime.Time, v protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
 	buf := getPacketBuffer()
 	packet, err := p.appendPacket(buf, true, maxSize, now, v)
 	return packet, buf, err
@@ -468,7 +468,7 @@ func (p *packetPacker) PackAckOnlyPacket(maxSize protocol.ByteCount, now time.Ti
 
 // AppendPacket packs a packet in the application data packet number space.
 // It should be called after the handshake is confirmed.
-func (p *packetPacker) AppendPacket(buf *packetBuffer, maxSize protocol.ByteCount, now time.Time, v protocol.Version) (shortHeaderPacket, error) {
+func (p *packetPacker) AppendPacket(buf *packetBuffer, maxSize protocol.ByteCount, now monotime.Time, v protocol.Version) (shortHeaderPacket, error) {
 	return p.appendPacket(buf, false, maxSize, now, v)
 }
 
@@ -476,7 +476,7 @@ func (p *packetPacker) appendPacket(
 	buf *packetBuffer,
 	onlyAck bool,
 	maxPacketSize protocol.ByteCount,
-	now time.Time,
+	now monotime.Time,
 	v protocol.Version,
 ) (shortHeaderPacket, error) {
 	sealer, err := p.cryptoSetup.Get1RTTSealer()
@@ -498,7 +498,7 @@ func (p *packetPacker) appendPacket(
 func (p *packetPacker) maybeGetCryptoPacket(
 	maxPacketSize protocol.ByteCount,
 	encLevel protocol.EncryptionLevel,
-	now time.Time,
+	now monotime.Time,
 	addPingIfEmpty bool,
 	onlyAck, ackAllowed bool,
 	v protocol.Version,
@@ -578,7 +578,7 @@ func (p *packetPacker) maybeGetCryptoPacket(
 	return hdr, pl
 }
 
-func (p *packetPacker) maybeGetAppDataPacketFor0RTT(sealer sealer, maxSize protocol.ByteCount, now time.Time, v protocol.Version) (*wire.ExtendedHeader, payload) {
+func (p *packetPacker) maybeGetAppDataPacketFor0RTT(sealer sealer, maxSize protocol.ByteCount, now monotime.Time, v protocol.Version) (*wire.ExtendedHeader, payload) {
 	if p.perspective != protocol.PerspectiveClient {
 		return nil, payload{}
 	}
@@ -592,7 +592,7 @@ func (p *packetPacker) maybeGetShortHeaderPacket(
 	sealer handshake.ShortHeaderSealer,
 	hdrLen, maxPacketSize protocol.ByteCount,
 	onlyAck, ackAllowed bool,
-	now time.Time,
+	now monotime.Time,
 	v protocol.Version,
 ) payload {
 	maxPayloadSize := maxPacketSize - hdrLen - protocol.ByteCount(sealer.Overhead())
@@ -602,7 +602,7 @@ func (p *packetPacker) maybeGetShortHeaderPacket(
 func (p *packetPacker) maybeGetAppDataPacket(
 	maxPayloadSize protocol.ByteCount,
 	onlyAck, ackAllowed bool,
-	now time.Time,
+	now monotime.Time,
 	v protocol.Version,
 ) payload {
 	pl := p.composeNextPacket(maxPayloadSize, onlyAck, ackAllowed, now, v)
@@ -630,7 +630,7 @@ func (p *packetPacker) maybeGetAppDataPacket(
 func (p *packetPacker) composeNextPacket(
 	maxPayloadSize protocol.ByteCount,
 	onlyAck, ackAllowed bool,
-	now time.Time,
+	now monotime.Time,
 	v protocol.Version,
 ) payload {
 	if onlyAck {
@@ -716,7 +716,7 @@ func (p *packetPacker) PackPTOProbePacket(
 	encLevel protocol.EncryptionLevel,
 	maxPacketSize protocol.ByteCount,
 	addPingIfEmpty bool,
-	now time.Time,
+	now monotime.Time,
 	v protocol.Version,
 ) (*coalescedPacket, error) {
 	if encLevel == protocol.Encryption1RTT {
@@ -769,7 +769,7 @@ func (p *packetPacker) PackPTOProbePacket(
 	return packet, nil
 }
 
-func (p *packetPacker) packPTOProbePacket1RTT(maxPacketSize protocol.ByteCount, addPingIfEmpty bool, now time.Time, v protocol.Version) (*coalescedPacket, error) {
+func (p *packetPacker) packPTOProbePacket1RTT(maxPacketSize protocol.ByteCount, addPingIfEmpty bool, now monotime.Time, v protocol.Version) (*coalescedPacket, error) {
 	s, err := p.cryptoSetup.Get1RTTSealer()
 	if err != nil {
 		return nil, err

--- a/packet_unpacker.go
+++ b/packet_unpacker.go
@@ -2,9 +2,9 @@ package quic
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/quic-go/quic-go/internal/handshake"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -106,7 +106,7 @@ func (u *packetUnpacker) UnpackLongHeader(hdr *wire.Header, data []byte) (*unpac
 	}, nil
 }
 
-func (u *packetUnpacker) UnpackShortHeader(rcvTime time.Time, data []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error) {
+func (u *packetUnpacker) UnpackShortHeader(rcvTime monotime.Time, data []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error) {
 	opener, err := u.cs.Get1RTTOpener()
 	if err != nil {
 		return 0, 0, 0, nil, err
@@ -144,7 +144,7 @@ func (u *packetUnpacker) unpackLongHeaderPacket(opener handshake.LongHeaderOpene
 	return extHdr, decrypted, nil
 }
 
-func (u *packetUnpacker) unpackShortHeaderPacket(opener handshake.ShortHeaderOpener, rcvTime time.Time, data []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error) {
+func (u *packetUnpacker) unpackShortHeaderPacket(opener handshake.ShortHeaderOpener, rcvTime monotime.Time, data []byte) (protocol.PacketNumber, protocol.PacketNumberLen, protocol.KeyPhaseBit, []byte, error) {
 	l, pn, pnLen, kp, parseErr := u.unpackShortHeader(opener, data)
 	// If the reserved bits are set incorrectly, we still need to continue unpacking.
 	// This avoids a timing side-channel, which otherwise might allow an attacker

--- a/packet_unpacker_test.go
+++ b/packet_unpacker_test.go
@@ -3,10 +3,10 @@ package quic
 import (
 	"crypto/rand"
 	"testing"
-	"time"
 
 	"github.com/quic-go/quic-go/internal/handshake"
 	"github.com/quic-go/quic-go/internal/mocks"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -211,7 +211,7 @@ func testUnpackShortHeaderPacket(t *testing.T, incorrectReservedBits bool, decry
 	opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		decryptResult.decrypted, decryptResult.err,
 	)
-	pn, pnLen, kp, data, err := unpacker.UnpackShortHeader(time.Now(), append(hdrRaw, payload...))
+	pn, pnLen, kp, data, err := unpacker.UnpackShortHeader(monotime.Now(), append(hdrRaw, payload...))
 	if expectedErr != nil {
 		require.ErrorIs(t, err, expectedErr)
 		return
@@ -282,7 +282,7 @@ func TestUnpackHeaderSampleShortHeader(t *testing.T) {
 
 	t.Run("too short", func(t *testing.T) {
 		cs.EXPECT().Get1RTTOpener().Return(mocks.NewMockShortHeaderOpener(mockCtrl), nil)
-		_, _, _, _, err = unpacker.UnpackShortHeader(time.Now(), data[:len(data)-1])
+		_, _, _, _, err = unpacker.UnpackShortHeader(monotime.Now(), data[:len(data)-1])
 		require.IsType(t, &headerParseError{}, err)
 		require.ErrorContains(t, err, "packet too small, expected at least 20 bytes after the header, got 19")
 	})
@@ -293,7 +293,7 @@ func TestUnpackHeaderSampleShortHeader(t *testing.T) {
 		opener.EXPECT().DecryptHeader(data[len(data)-16:], gomock.Any(), gomock.Any())
 		opener.EXPECT().DecodePacketNumber(gomock.Any(), gomock.Any()).Return(protocol.PacketNumber(1337))
 		opener.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte("decrypted"), nil)
-		_, _, _, _, err = unpacker.UnpackShortHeader(time.Now(), data)
+		_, _, _, _, err = unpacker.UnpackShortHeader(monotime.Now(), data)
 		require.NoError(t, err)
 	})
 }

--- a/path_manager.go
+++ b/path_manager.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -30,7 +31,7 @@ const pathTimeout = 5 * time.Second
 type path struct {
 	id             pathID
 	addr           net.Addr
-	lastPacketTime time.Time
+	lastPacketTime monotime.Time
 	pathChallenge  [8]byte
 	validated      bool
 	rcvdNonProbing bool
@@ -64,7 +65,7 @@ func newPathManager(
 // May return nil.
 func (pm *pathManager) HandlePacket(
 	remoteAddr net.Addr,
-	t time.Time,
+	t monotime.Time,
 	pathChallenge *wire.PathChallengeFrame, // may be nil if the packet didn't contain a PATH_CHALLENGE
 	isNonProbing bool,
 ) (_ protocol.ConnectionID, _ []ackhandler.Frame, shouldSwitch bool) {

--- a/path_manager_test.go
+++ b/path_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -29,7 +30,7 @@ func TestPathManagerIntentionalMigration(t *testing.T) {
 		func(id pathID) { retiredConnIDs = append(retiredConnIDs, connIDs[id]) },
 		utils.DefaultLogger,
 	)
-	now := time.Now()
+	now := monotime.Now()
 	connID, frames, shouldSwitch := pm.HandlePacket(
 		&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1000},
 		now,
@@ -132,7 +133,7 @@ func TestPathManagerMultipleProbes(t *testing.T) {
 		func(id pathID) {},
 		utils.DefaultLogger,
 	)
-	now := time.Now()
+	now := monotime.Now()
 	// first receive a packet without a PATH_CHALLENGE
 	connID, frames, shouldSwitch := pm.HandlePacket(
 		&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1000},
@@ -187,7 +188,7 @@ func TestPathManagerNATRebinding(t *testing.T) {
 		utils.DefaultLogger,
 	)
 
-	now := time.Now()
+	now := monotime.Now()
 	connID, frames, shouldSwitch := pm.HandlePacket(&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1000}, now, nil, true)
 	require.Equal(t, connIDs[0], connID)
 	require.Len(t, frames, 1)
@@ -219,7 +220,7 @@ func TestPathManagerLimits(t *testing.T) {
 		utils.DefaultLogger,
 	)
 
-	now := time.Now()
+	now := monotime.Now()
 	firstPathTime := now
 	var firstPathConnID protocol.ConnectionID
 	require.Greater(t, pathTimeout, maxPaths*time.Second)

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/quic-go/quic-go/internal/ackhandler"
 	"github.com/quic-go/quic-go/internal/flowcontrol"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/utils"
@@ -47,7 +48,7 @@ type ReceiveStream struct {
 
 	readChan chan struct{}
 	readOnce chan struct{} // cap: 1, to protect against concurrent use of Read
-	deadline time.Time
+	deadline monotime.Time
 
 	flowController flowcontrol.StreamFlowController
 }
@@ -161,7 +162,7 @@ func (s *ReceiveStream) readImpl(p []byte) (hasStreamWindowUpdate bool, hasConnW
 
 			deadline := s.deadline
 			if !deadline.IsZero() {
-				if !time.Now().Before(deadline) {
+				if !monotime.Now().Before(deadline) {
 					return hasStreamWindowUpdate, hasConnWindowUpdate, bytesRead, errDeadline
 				}
 				if deadlineTimer == nil {
@@ -283,7 +284,7 @@ func (s *ReceiveStream) cancelReadImpl(errorCode qerr.StreamErrorCode) (queuedNe
 	return true
 }
 
-func (s *ReceiveStream) handleStreamFrame(frame *wire.StreamFrame, now time.Time) error {
+func (s *ReceiveStream) handleStreamFrame(frame *wire.StreamFrame, now monotime.Time) error {
 	s.mutex.Lock()
 	err := s.handleStreamFrameImpl(frame, now)
 	completed := s.isNewlyCompleted()
@@ -296,7 +297,7 @@ func (s *ReceiveStream) handleStreamFrame(frame *wire.StreamFrame, now time.Time
 	return err
 }
 
-func (s *ReceiveStream) handleStreamFrameImpl(frame *wire.StreamFrame, now time.Time) error {
+func (s *ReceiveStream) handleStreamFrameImpl(frame *wire.StreamFrame, now monotime.Time) error {
 	maxOffset := frame.Offset + frame.DataLen()
 	if err := s.flowController.UpdateHighestReceived(maxOffset, frame.Fin, now); err != nil {
 		return err
@@ -314,7 +315,7 @@ func (s *ReceiveStream) handleStreamFrameImpl(frame *wire.StreamFrame, now time.
 	return nil
 }
 
-func (s *ReceiveStream) handleResetStreamFrame(frame *wire.ResetStreamFrame, now time.Time) error {
+func (s *ReceiveStream) handleResetStreamFrame(frame *wire.ResetStreamFrame, now monotime.Time) error {
 	s.mutex.Lock()
 	err := s.handleResetStreamFrameImpl(frame, now)
 	completed := s.isNewlyCompleted()
@@ -326,7 +327,7 @@ func (s *ReceiveStream) handleResetStreamFrame(frame *wire.ResetStreamFrame, now
 	return err
 }
 
-func (s *ReceiveStream) handleResetStreamFrameImpl(frame *wire.ResetStreamFrame, now time.Time) error {
+func (s *ReceiveStream) handleResetStreamFrameImpl(frame *wire.ResetStreamFrame, now monotime.Time) error {
 	if s.closeForShutdownErr != nil {
 		return nil
 	}
@@ -358,7 +359,7 @@ func (s *ReceiveStream) handleResetStreamFrameImpl(frame *wire.ResetStreamFrame,
 	return nil
 }
 
-func (s *ReceiveStream) getControlFrame(now time.Time) (_ ackhandler.Frame, ok, hasMore bool) {
+func (s *ReceiveStream) getControlFrame(now monotime.Time) (_ ackhandler.Frame, ok, hasMore bool) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -386,7 +387,7 @@ func (s *ReceiveStream) getControlFrame(now time.Time) (_ ackhandler.Frame, ok, 
 // A zero value for t means Read will not time out.
 func (s *ReceiveStream) SetReadDeadline(t time.Time) error {
 	s.mutex.Lock()
-	s.deadline = t
+	s.deadline = monotime.FromTime(t)
 	s.mutex.Unlock()
 	s.signalRead()
 	return nil

--- a/server_test.go
+++ b/server_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/quic-go/quic-go/internal/handshake"
 	mocklogging "github.com/quic-go/quic-go/internal/mocks/logging"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/utils"
@@ -1170,7 +1171,7 @@ func TestServer0RTTQueueing(t *testing.T) {
 		tracer:      tracer,
 	})
 
-	firstRcvTime := time.Now()
+	firstRcvTime := monotime.Now()
 	otherRcvTime := firstRcvTime.Add(protocol.Max0RTTQueueingDuration / 2)
 	var sizes []protocol.ByteCount
 	for i := range protocol.Max0RTTQueues {

--- a/stream.go
+++ b/stream.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/quic-go/quic-go/internal/ackhandler"
 	"github.com/quic-go/quic-go/internal/flowcontrol"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/wire"
 )
@@ -147,11 +148,11 @@ func (s *Stream) Close() error {
 	return s.sendStr.Close()
 }
 
-func (s *Stream) handleResetStreamFrame(frame *wire.ResetStreamFrame, rcvTime time.Time) error {
+func (s *Stream) handleResetStreamFrame(frame *wire.ResetStreamFrame, rcvTime monotime.Time) error {
 	return s.receiveStr.handleResetStreamFrame(frame, rcvTime)
 }
 
-func (s *Stream) handleStreamFrame(frame *wire.StreamFrame, rcvTime time.Time) error {
+func (s *Stream) handleStreamFrame(frame *wire.StreamFrame, rcvTime monotime.Time) error {
 	return s.receiveStr.handleStreamFrame(frame, rcvTime)
 }
 
@@ -171,7 +172,7 @@ func (s *Stream) popStreamFrame(maxBytes protocol.ByteCount, v protocol.Version)
 	return s.sendStr.popStreamFrame(maxBytes, v)
 }
 
-func (s *Stream) getControlFrame(now time.Time) (_ ackhandler.Frame, ok, hasMore bool) {
+func (s *Stream) getControlFrame(now monotime.Time) (_ ackhandler.Frame, ok, hasMore bool) {
 	f, ok, _ := s.sendStr.getControlFrame(now)
 	if ok {
 		return f, true, true

--- a/stream_test.go
+++ b/stream_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/quic-go/quic-go/internal/mocks"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/wire"
 
@@ -29,7 +30,7 @@ func TestStreamDeadlines(t *testing.T) {
 	require.Zero(t, n)
 
 	mockFC.EXPECT().UpdateHighestReceived(protocol.ByteCount(6), false, gomock.Any()).AnyTimes()
-	require.NoError(t, str.handleStreamFrame(&wire.StreamFrame{Data: []byte("foobar")}, time.Now()))
+	require.NoError(t, str.handleStreamFrame(&wire.StreamFrame{Data: []byte("foobar")}, monotime.Now()))
 	n, err = (&readerWithTimeout{Reader: str, Timeout: time.Second}).Read(make([]byte, 6))
 	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
 	require.Zero(t, n)
@@ -49,7 +50,7 @@ func TestStreamCompletion(t *testing.T) {
 			StreamID: str.StreamID(),
 			Data:     []byte("foobar"),
 			Fin:      true,
-		}, time.Now()))
+		}, monotime.Now()))
 		_, err := (&readerWithTimeout{Reader: str, Timeout: time.Second}).Read(make([]byte, 6))
 		require.ErrorIs(t, err, io.EOF)
 		require.True(t, mockCtrl.Satisfied())

--- a/streams_map.go
+++ b/streams_map.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/quic-go/quic-go/internal/flowcontrol"
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
 	"github.com/quic-go/quic-go/internal/wire"
@@ -251,8 +251,8 @@ func (m *streamsMap) HandleStopSendingFrame(f *wire.StopSendingFrame) error {
 }
 
 type receiveStreamFrameHandler interface {
-	handleResetStreamFrame(*wire.ResetStreamFrame, time.Time) error
-	handleStreamFrame(*wire.StreamFrame, time.Time) error
+	handleResetStreamFrame(*wire.ResetStreamFrame, monotime.Time) error
+	handleStreamFrame(*wire.StreamFrame, monotime.Time) error
 }
 
 func (m *streamsMap) getReceiveStream(id protocol.StreamID) (receiveStreamFrameHandler, error) {
@@ -295,7 +295,7 @@ func (m *streamsMap) HandleStreamDataBlockedFrame(f *wire.StreamDataBlockedFrame
 	return nil // we don't need to do anything in response to a STREAM_DATA_BLOCKED frame
 }
 
-func (m *streamsMap) HandleResetStreamFrame(f *wire.ResetStreamFrame, rcvTime time.Time) error {
+func (m *streamsMap) HandleResetStreamFrame(f *wire.ResetStreamFrame, rcvTime monotime.Time) error {
 	str, err := m.getReceiveStream(f.StreamID)
 	if err != nil {
 		return err
@@ -306,7 +306,7 @@ func (m *streamsMap) HandleResetStreamFrame(f *wire.ResetStreamFrame, rcvTime ti
 	return str.handleResetStreamFrame(f, rcvTime)
 }
 
-func (m *streamsMap) HandleStreamFrame(f *wire.StreamFrame, rcvTime time.Time) error {
+func (m *streamsMap) HandleStreamFrame(f *wire.StreamFrame, rcvTime monotime.Time) error {
 	str, err := m.getReceiveStream(f.StreamID)
 	if err != nil {
 		return err

--- a/sys_conn.go
+++ b/sys_conn.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 )
@@ -123,7 +124,7 @@ func (c *basicConn) ReadPacket() (receivedPacket, error) {
 	}
 	return receivedPacket{
 		remoteAddr: addr,
-		rcvTime:    time.Now(),
+		rcvTime:    monotime.Now(),
 		data:       buffer.Data[:n],
 		buffer:     buffer,
 	}, nil

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -12,13 +12,13 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
-	"time"
 	"unsafe"
 
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 	"golang.org/x/sys/unix"
 
+	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
 )
@@ -185,7 +185,7 @@ func (c *oobConn) ReadPacket() (receivedPacket, error) {
 	data := msg.OOB[:msg.NN]
 	p := receivedPacket{
 		remoteAddr: msg.Addr,
-		rcvTime:    time.Now(),
+		rcvTime:    monotime.Now(),
 		data:       msg.Buffers[0][:msg.N],
 		buffer:     buffer,
 	}

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -69,7 +69,7 @@ func TestReadECNFlagsIPv4(t *testing.T) {
 
 	select {
 	case p := <-packetChan:
-		require.WithinDuration(t, time.Now(), p.rcvTime, scaleDuration(20*time.Millisecond))
+		require.WithinDuration(t, time.Now(), p.rcvTime.ToTime(), scaleDuration(20*time.Millisecond))
 		require.Equal(t, []byte("foobar"), p.data)
 		require.Equal(t, sentFrom, p.remoteAddr)
 		require.Equal(t, protocol.ECT0, p.ecn)
@@ -91,7 +91,7 @@ func TestReadECNFlagsIPv6(t *testing.T) {
 
 	select {
 	case p := <-packetChan:
-		require.WithinDuration(t, time.Now(), p.rcvTime, scaleDuration(20*time.Millisecond))
+		require.WithinDuration(t, time.Now(), p.rcvTime.ToTime(), scaleDuration(20*time.Millisecond))
 		require.Equal(t, []byte("foobar"), p.data)
 		require.Equal(t, sentFrom, p.remoteAddr)
 		require.Equal(t, protocol.ECNCE, p.ecn)
@@ -192,7 +192,7 @@ func TestSysConnPacketInfoIPv4(t *testing.T) {
 
 	select {
 	case p := <-packetChan:
-		require.WithinDuration(t, time.Now(), p.rcvTime, scaleDuration(50*time.Millisecond))
+		require.WithinDuration(t, time.Now(), p.rcvTime.ToTime(), scaleDuration(50*time.Millisecond))
 		require.Equal(t, []byte("foobar"), p.data)
 		require.Equal(t, conn.LocalAddr(), p.remoteAddr)
 		require.True(t, p.info.addr.IsValid())
@@ -215,7 +215,7 @@ func TestSysConnPacketInfoIPv6(t *testing.T) {
 
 	select {
 	case p := <-packetChan:
-		require.WithinDuration(t, time.Now(), p.rcvTime, scaleDuration(20*time.Millisecond))
+		require.WithinDuration(t, time.Now(), p.rcvTime.ToTime(), scaleDuration(20*time.Millisecond))
 		require.Equal(t, []byte("foobar"), p.data)
 		require.Equal(t, conn.LocalAddr(), p.remoteAddr)
 		require.NotNil(t, p.info)

--- a/sys_conn_test.go
+++ b/sys_conn_test.go
@@ -27,6 +27,6 @@ func TestBasicConn(t *testing.T) {
 	p, err := conn.ReadPacket()
 	require.NoError(t, err)
 	require.Equal(t, []byte("foobar"), p.data)
-	require.WithinDuration(t, time.Now(), p.rcvTime, scaleDuration(100*time.Millisecond))
+	require.WithinDuration(t, time.Now(), p.rcvTime.ToTime(), scaleDuration(100*time.Millisecond))
 	require.Equal(t, addr, p.remoteAddr)
 }


### PR DESCRIPTION
We need to do a lot of timer computations when running a QUIC connection. In general, for every packet sent, we need to (re)set the loss detection timer, and similarly, for (almost) every packet received, we need to set a timer to send and acknowledgment for that packet.

This PR implements a monotonic drop-in replacement for `time.Time` that uses a single `int64`. For the purposes of internals of a QUIC connections, we don't care about the wall clock time, all we're interested are accurate time differences, i.e. monotonic clock readings.

In addition to the timer calculations described above, we store the time a packet was sent in the packet history. This is needed so we can run loss detection. Storing a `time.Time` costs 24 bytes, whereas an `int64` just consumes 8 bytes. This might not seem like a lot, but when storing (say) 10000 packets that are in flight, it adds up.

I was surprised by the speedup achieved by this change:
```
name                                                   old time/op    new time/op    delta
SendAndAcknowledge/ack_every:_2,_in_flight:_0-16          112ns ± 7%      84ns ± 3%  -24.78%  (p=0.008 n=5+5)
SendAndAcknowledge/ack_every:_10,_in_flight:_100-16      86.7ns ± 2%    62.7ns ± 2%  -27.60%  (p=0.008 n=5+5)
SendAndAcknowledge/ack_every:_100,_in_flight:_1000-16    79.9ns ± 3%    58.3ns ± 3%  -27.08%  (p=0.008 n=5+5)

name                                                   old alloc/op   new alloc/op   delta
SendAndAcknowledge/ack_every:_2,_in_flight:_0-16          8.00B ± 0%     8.00B ± 0%     ~     (all equal)
SendAndAcknowledge/ack_every:_10,_in_flight:_100-16       14.0B ± 0%     14.0B ± 0%     ~     (all equal)
SendAndAcknowledge/ack_every:_100,_in_flight:_1000-16     24.0B ± 0%     24.0B ± 0%     ~     (all equal)

name                                                   old allocs/op  new allocs/op  delta
SendAndAcknowledge/ack_every:_2,_in_flight:_0-16           0.00           0.00          ~     (all equal)
SendAndAcknowledge/ack_every:_10,_in_flight:_100-16        0.00           0.00          ~     (all equal)
SendAndAcknowledge/ack_every:_100,_in_flight:_1000-16      0.00           0.00          ~     (all equal)
```