### PR TITLE
protocol: optimize ConnectionID.String

### DIFF
--- a/internal/protocol/connection_id.go
+++ b/internal/protocol/connection_id.go
@@ -2,8 +2,8 @@ package protocol
 
 import (
 	"crypto/rand"
+	"encoding/hex"
 	"errors"
-	"fmt"
 	"io"
 )
 
@@ -26,7 +26,7 @@ func (c ArbitraryLenConnectionID) String() string {
 	if c.Len() == 0 {
 		return "(empty)"
 	}
-	return fmt.Sprintf("%x", c.Bytes())
+	return hex.EncodeToString(c.Bytes())
 }
 
 const maxConnectionIDLen = 20
@@ -100,7 +100,7 @@ func (c ConnectionID) String() string {
 	if c.Len() == 0 {
 		return "(empty)"
 	}
-	return fmt.Sprintf("%x", c.Bytes())
+	return hex.EncodeToString(c.Bytes())
 }
 
 type DefaultConnectionIDGenerator struct {

--- a/internal/protocol/connection_id_test.go
+++ b/internal/protocol/connection_id_test.go
@@ -68,6 +68,15 @@ func TestConnectionIDZeroValue(t *testing.T) {
 	require.Equal(t, "(empty)", (ConnectionID{}).String())
 }
 
+// The string representation of a connection ID is used in qlog, so it should be fast.
+func BenchmarkConnectionIDStringer(b *testing.B) {
+	c := ParseConnectionID([]byte{0xde, 0xad, 0xbe, 0xef, 0x42})
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = c.String()
+	}
+}
+
 func TestArbitraryLenConnectionID(t *testing.T) {
 	b := make([]byte, 42)
 	rand.Read(b)


### PR DESCRIPTION
This function is used by qlog, so it should be fast.

```
name                     old time/op    new time/op    delta
ConnectionIDStringer-16    65.2ns ± 4%    15.6ns ± 3%  -76.08%  (p=0.000 n=9+9)

name                     old alloc/op   new alloc/op   delta
ConnectionIDStringer-16     64.0B ± 0%     16.0B ± 0%  -75.00%  (p=0.000 n=10+10)

name                     old allocs/op  new allocs/op  delta
ConnectionIDStringer-16      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
```