### PR TITLE
ci: update Go 1.27rc1 to Go 1.27rc2

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.25.x", "1.26.x", "1.27.0-rc.1" ]
+        go: [ "1.25.x", "1.26.x", "1.27.0-rc.2" ]
     runs-on: ${{ fromJSON(vars['CROSS_COMPILE_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}
     name: "Cross Compilation (Go ${{matrix.go}})"
     timeout-minutes: 30

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu" ]
-        go: [ "1.25.x", "1.26.x", "1.27.0-rc.1" ]
+        go: [ "1.25.x", "1.26.x", "1.27.0-rc.2" ]
         race: [ false ]
         include:
           - os: "ubuntu"

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu", "windows", "macos" ]
-        go: [ "1.25.x", "1.26.x", "1.27.0-rc.1" ]
+        go: [ "1.25.x", "1.26.x", "1.27.0-rc.2" ]
     runs-on: ${{ fromJSON(vars[format('UNIT_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
     name: Unit tests (${{ matrix.os}}, Go ${{ matrix.go }})
     timeout-minutes: 30


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated build, integration, and unit test checks to run with Go 1.27.0-rc.2.
  * Continued coverage across supported operating systems and cross-compilation targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update Go version from 1.27rc1 to 1.27rc2 in CI workflows
> Updates the Go version matrix entry from `1.27.0-rc.1` to `1.27.0-rc.2` in the cross-compile, integration, and unit test workflows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b12a98f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->