### PR TITLE
implement RFC 9218-style stream priorities for Stream and SendStream

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -3023,6 +3023,11 @@ func (c *Conn) onStreamCompleted(id protocol.StreamID) {
 	c.framer.RemoveActiveStream(id)
 }
 
+func (c *Conn) updateStreamPriority(id protocol.StreamID) {
+	c.framer.UpdateStreamPriority(id)
+	c.scheduleSending()
+}
+
 // SendDatagram sends a message using a QUIC datagram, as specified in RFC 9221,
 // if the peer enabled datagram support.
 // There is no delivery guarantee for DATAGRAM frames, they are not retransmitted if lost.

--- a/framer.go
+++ b/framer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/quic-go/quic-go/internal/ackhandler"
 	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils/minheap"
 	"github.com/quic-go/quic-go/internal/utils/ringbuffer"
 	"github.com/quic-go/quic-go/internal/wire"
 	"github.com/quic-go/quic-go/quicvarint"
@@ -22,7 +23,8 @@ const (
 const maxStreamControlFrameSize = 25
 
 type streamFrameGetter interface {
-	popStreamFrame(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool)
+	priority() (urgency int8, incremental bool, generation uint32)
+	popStreamFrame(protocol.ByteCount, protocol.Version) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasMoreData bool)
 	popRetransmissionFrame(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, bool)
 }
 
@@ -30,19 +32,42 @@ type streamControlFrameGetter interface {
 	getControlFrame(monotime.Time) (_ ackhandler.Frame, ok, hasMore bool)
 }
 
+// streamQueueEntry identifies a queued generation of a stream.
+type streamQueueEntry struct {
+	id         protocol.StreamID
+	generation uint32
+}
+
+// streamPriorityBucket contains streams with the same urgency
+type streamPriorityBucket struct {
+	Incremental    ringbuffer.RingBuffer[streamQueueEntry]
+	NonIncremental minheap.Heap[protocol.StreamID, uint32 /* generation */]
+	// If a bucket contains both incremental and non-incremental streams,
+	// we round-robin between incremental and non-incremental streams.
+	LastSendWasIncremental bool
+}
+
+func (b *streamPriorityBucket) Len() int {
+	return b.Incremental.Len() + b.NonIncremental.Len()
+}
+
+type queuedStream struct {
+	streamFrameGetter
+	generation uint32
+}
+
 type framer struct {
 	mutex sync.Mutex
 
-	activeStreams map[protocol.StreamID]streamFrameGetter
-	// New stream data is sent incrementally. The ring buffer provides
-	// round-robin scheduling between active streams.
-	streamQueue           ringbuffer.RingBuffer[protocol.StreamID]
+	activeStreams         map[protocol.StreamID]queuedStream
 	retransmissionStreams map[protocol.StreamID]streamFrameGetter
+
+	streamQueue              [8]streamPriorityBucket
+	streamsWithControlFrames map[protocol.StreamID]streamControlFrameGetter
 	// Retransmissions are not incremental: repair all lost data for the first queued stream.
 	// New losses extend its batch, so A, B, A is repaired as A, A, B, delaying B.
 	// The ring buffer provides FIFO scheduling while reusing its storage.
-	retransmissionQueue      ringbuffer.RingBuffer[protocol.StreamID]
-	streamsWithControlFrames map[protocol.StreamID]streamControlFrameGetter
+	retransmissionQueue [8]ringbuffer.RingBuffer[protocol.StreamID]
 
 	controlFrameMutex          sync.Mutex
 	controlFrames              []wire.Frame
@@ -53,7 +78,7 @@ type framer struct {
 
 func newFramer(connFlowController *connectionFlowController) *framer {
 	return &framer{
-		activeStreams:            make(map[protocol.StreamID]streamFrameGetter),
+		activeStreams:            make(map[protocol.StreamID]queuedStream),
 		retransmissionStreams:    make(map[protocol.StreamID]streamFrameGetter),
 		streamsWithControlFrames: make(map[protocol.StreamID]streamControlFrameGetter),
 		connFlowController:       connFlowController,
@@ -61,15 +86,24 @@ func newFramer(connFlowController *connectionFlowController) *framer {
 }
 
 func (f *framer) HasData() bool {
-	f.mutex.Lock()
-	hasData := !f.retransmissionQueue.Empty() || !f.streamQueue.Empty()
-	f.mutex.Unlock()
-	if hasData {
+	f.controlFrameMutex.Lock()
+	hasControlFrames := len(f.streamsWithControlFrames) > 0 || len(f.controlFrames) > 0 || len(f.pathResponses) > 0
+	f.controlFrameMutex.Unlock()
+
+	if hasControlFrames {
 		return true
 	}
-	f.controlFrameMutex.Lock()
-	defer f.controlFrameMutex.Unlock()
-	return len(f.streamsWithControlFrames) > 0 || len(f.controlFrames) > 0 || len(f.pathResponses) > 0
+
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	for urgency := range f.streamQueue {
+		bucket := &f.streamQueue[urgency]
+		if !bucket.Incremental.Empty() || !bucket.NonIncremental.Empty() || !f.retransmissionQueue[urgency].Empty() {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *framer) QueueControlFrame(frame wire.Frame) {
@@ -109,57 +143,71 @@ func (f *framer) Append(
 	var streamFrameLen protocol.ByteCount
 	f.mutex.Lock()
 	// retransmit all lost STREAM data before sending new STREAM data
-	for !f.retransmissionQueue.Empty() && protocol.MinStreamFrameSize <= maxLen {
-		id := f.retransmissionQueue.PeekFront()
-		str, ok := f.retransmissionStreams[id]
-		if !ok { // the stream was removed after being enqueued
-			f.retransmissionQueue.PopFront()
-			continue
-		}
-		// For the last STREAM frame, we'll remove the DataLen field later.
-		frameMaxLen := maxLen + protocol.ByteCount(quicvarint.Len(uint64(maxLen)))
-		sf, hasMoreRetransmissions := str.popRetransmissionFrame(frameMaxLen, v)
-		if !hasMoreRetransmissions {
-			f.retransmissionQueue.PopFront()
-			delete(f.retransmissionStreams, id)
-		}
-		if sf.Frame == nil {
-			// If the retransmission didn't fit, retry it in the next packet.
-			if hasMoreRetransmissions {
-				break
+retransmissions:
+	for urgency := range f.retransmissionQueue {
+		bucket := &f.retransmissionQueue[urgency]
+		for !bucket.Empty() && protocol.MinStreamFrameSize <= maxLen {
+			id := bucket.PeekFront()
+			str, ok := f.retransmissionStreams[id]
+			if !ok {
+				bucket.PopFront()
+				continue
 			}
-			continue
-		}
-		streamFrames = append(streamFrames, sf)
-		maxLen -= sf.Frame.Length(v)
-		lastFrame = sf
-		streamFrameLen += sf.Frame.Length(v)
-	}
-	// pop STREAM frames, until less than 128 bytes are left in the packet
-	numActiveStreams := f.streamQueue.Len()
-	for range numActiveStreams {
-		if protocol.MinStreamFrameSize > maxLen {
-			break
-		}
-		sf, blocked := f.getNextStreamFrame(maxLen, v)
-		if sf.Frame != nil {
+			currentUrgency, _, _ := str.priority()
+			if currentUrgency != int8(urgency) {
+				bucket.PopFront()
+				f.retransmissionQueue[currentUrgency].PushBack(id)
+				continue
+			}
+			// For the last STREAM frame, we'll remove the DataLen field later.
+			frameMaxLen := maxLen + protocol.ByteCount(quicvarint.Len(uint64(maxLen)))
+			sf, hasMoreRetransmissions := str.popRetransmissionFrame(frameMaxLen, v)
+			if !hasMoreRetransmissions {
+				bucket.PopFront()
+				delete(f.retransmissionStreams, id)
+			}
+			if sf.Frame == nil {
+				// If the retransmission didn't fit, retry it in the next packet.
+				if hasMoreRetransmissions {
+					break retransmissions
+				}
+				continue
+			}
 			streamFrames = append(streamFrames, sf)
 			maxLen -= sf.Frame.Length(v)
 			lastFrame = sf
 			streamFrameLen += sf.Frame.Length(v)
 		}
-		// If the stream just became blocked on stream flow control, attempt to pack the
-		// STREAM_DATA_BLOCKED into the same packet.
-		if blocked != nil {
-			l := blocked.Length(v)
-			// In case it doesn't fit, queue it for the next packet.
-			if maxLen < l {
-				f.controlFrames = append(f.controlFrames, blocked)
+	}
+	// pop STREAM frames, until less than 128 bytes are left in the packet
+	for urgency := range f.streamQueue {
+		bucket := &f.streamQueue[urgency]
+		numActiveStreams := bucket.Len()
+
+		for range numActiveStreams {
+			if protocol.MinStreamFrameSize > maxLen {
 				break
 			}
-			frames = append(frames, ackhandler.Frame{Frame: blocked})
-			maxLen -= l
-			controlFrameLen += l
+			sf, blocked := f.getNextStreamFrame(maxLen, int8(urgency), v)
+			if sf.Frame != nil {
+				streamFrames = append(streamFrames, sf)
+				maxLen -= sf.Frame.Length(v)
+				lastFrame = sf
+				streamFrameLen += sf.Frame.Length(v)
+			}
+			// If the stream just became blocked on stream flow control, attempt to pack the
+			// STREAM_DATA_BLOCKED into the same packet.
+			if blocked != nil {
+				l := blocked.Length(v)
+				// In case it doesn't fit, queue it for the next packet.
+				if maxLen < l {
+					f.controlFrames = append(f.controlFrames, blocked)
+					break
+				}
+				frames = append(frames, ackhandler.Frame{Frame: blocked})
+				maxLen -= l
+				controlFrameLen += l
+			}
 		}
 	}
 
@@ -255,63 +303,163 @@ func (f *framer) QueuedTooManyControlFrames() bool {
 
 func (f *framer) AddActiveStream(id protocol.StreamID, str streamFrameGetter) {
 	f.mutex.Lock()
-	if _, ok := f.activeStreams[id]; !ok {
-		f.streamQueue.PushBack(id)
-		f.activeStreams[id] = str
+	defer f.mutex.Unlock()
+
+	urgency, incremental, generation := str.priority()
+	if activeStr, ok := f.activeStreams[id]; ok && activeStr.generation == generation {
+		return
 	}
-	f.mutex.Unlock()
+	bucket := &f.streamQueue[urgency]
+	if incremental {
+		bucket.Incremental.PushBack(streamQueueEntry{id: id, generation: generation})
+	} else {
+		bucket.NonIncremental.Push(id, generation)
+	}
+	f.activeStreams[id] = queuedStream{streamFrameGetter: str, generation: generation}
 }
 
 func (f *framer) AddStreamWithRetransmission(id protocol.StreamID, str streamFrameGetter) {
 	f.mutex.Lock()
-	if _, ok := f.retransmissionStreams[id]; !ok {
-		f.retransmissionQueue.PushBack(id)
-		f.retransmissionStreams[id] = str
+	defer f.mutex.Unlock()
+
+	urgency, _, _ := str.priority()
+	if _, ok := f.retransmissionStreams[id]; ok {
+		return
 	}
-	f.mutex.Unlock()
+	f.retransmissionQueue[urgency].PushBack(id)
+	f.retransmissionStreams[id] = str
 }
 
 func (f *framer) AddStreamWithControlFrames(id protocol.StreamID, str streamControlFrameGetter) {
 	f.controlFrameMutex.Lock()
+	defer f.controlFrameMutex.Unlock()
+
 	if _, ok := f.streamsWithControlFrames[id]; !ok {
 		f.streamsWithControlFrames[id] = str
 	}
-	f.controlFrameMutex.Unlock()
 }
 
 // RemoveActiveStream is called when a stream completes.
 func (f *framer) RemoveActiveStream(id protocol.StreamID) {
 	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	// We don't delete the stream from the ring buffers and heaps,
+	// since we'd have to find it there first.
+	// Instead, we check if the stream is still in active when appending STREAM frames.
 	delete(f.activeStreams, id)
 	delete(f.retransmissionStreams, id)
-	// We don't delete the stream from the queues, since we'd have to search them.
-	// Instead, we check if the stream is still in the corresponding map when appending STREAM frames.
-	f.mutex.Unlock()
 }
 
-func (f *framer) getNextStreamFrame(maxLen protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
-	id := f.streamQueue.PopFront()
-	// This should never return an error. Better check it anyway.
-	// The stream will only be in the streamQueue, if it enqueued itself there.
+func (f *framer) UpdateStreamPriority(id protocol.StreamID) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
 	str, ok := f.activeStreams[id]
-	// The stream might have been removed after being enqueued.
 	if !ok {
+		return
+	}
+	urgency, incremental, generation := str.priority()
+	if str.generation != generation {
+		// Leave the old queue entry in place. It will be discarded when it reaches
+		// the front of that queue and no longer matches the stream's generation.
+		bucket := &f.streamQueue[urgency]
+		if incremental {
+			bucket.Incremental.PushBack(streamQueueEntry{id: id, generation: generation})
+		} else {
+			bucket.NonIncremental.Push(id, generation)
+		}
+		str.generation = generation
+		f.activeStreams[id] = str
+	}
+}
+
+func (f *framer) getNextStreamFrame(
+	maxLen protocol.ByteCount,
+	urgency int8,
+	v protocol.Version,
+) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
+	bucket := &f.streamQueue[urgency]
+	if bucket.NonIncremental.Empty() || (!bucket.LastSendWasIncremental && !bucket.Incremental.Empty()) {
+		return f.getNextIncrementalStreamFrame(maxLen, urgency, v)
+	}
+	return f.getNextNonIncrementalStreamFrame(maxLen, urgency, v)
+}
+
+func (f *framer) getNextIncrementalStreamFrame(
+	maxLen protocol.ByteCount,
+	urgency int8,
+	v protocol.Version,
+) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
+	bucket := &f.streamQueue[urgency]
+	if bucket.Incremental.Empty() {
 		return ackhandler.StreamFrame{}, nil
 	}
+	entry := bucket.Incremental.PopFront()
+	str, ok := f.activeStreams[entry.id]
+	if !ok || str.generation != entry.generation {
+		return ackhandler.StreamFrame{}, nil
+	}
+	_, _, generation := str.priority()
+	if generation != entry.generation {
+		return ackhandler.StreamFrame{}, nil
+	}
+
+	frame, blocked, hasMoreData := f.popStreamFrame(entry.id, str, maxLen, v)
+	if hasMoreData {
+		bucket.Incremental.PushBack(entry)
+	}
+	bucket.LastSendWasIncremental = true
+	return frame, blocked
+}
+
+func (f *framer) getNextNonIncrementalStreamFrame(
+	maxLen protocol.ByteCount,
+	urgency int8,
+	v protocol.Version,
+) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
+	bucket := &f.streamQueue[urgency]
+	if bucket.NonIncremental.Empty() {
+		return ackhandler.StreamFrame{}, nil
+	}
+	id, queuedGeneration := bucket.NonIncremental.Peek()
+	str, ok := f.activeStreams[id]
+	if !ok || str.generation != queuedGeneration {
+		bucket.NonIncremental.Pop()
+		return ackhandler.StreamFrame{}, nil
+	}
+	_, _, currentGeneration := str.priority()
+	if currentGeneration != queuedGeneration {
+		bucket.NonIncremental.Pop()
+		return ackhandler.StreamFrame{}, nil
+	}
+
+	frame, blocked, hasMoreData := f.popStreamFrame(id, str, maxLen, v)
+	if !hasMoreData {
+		bucket.NonIncremental.Pop()
+	}
+	bucket.LastSendWasIncremental = false
+	return frame, blocked
+}
+
+func (f *framer) popStreamFrame(
+	id protocol.StreamID,
+	str queuedStream,
+	maxLen protocol.ByteCount,
+	v protocol.Version,
+) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
 	// For the last STREAM frame, we'll remove the DataLen field later.
 	// Therefore, we can pretend to have more bytes available when popping
 	// the STREAM frame (which will always have the DataLen set).
 	maxLen += protocol.ByteCount(quicvarint.Len(uint64(maxLen)))
 	frame, blocked, hasMoreData := str.popStreamFrame(maxLen, v)
-	if hasMoreData { // put the stream back in the queue (at the end)
-		f.streamQueue.PushBack(id)
-	} else { // no more data to send. Stream is not active
+	if !hasMoreData {
 		delete(f.activeStreams, id)
 	}
 	// Note that the frame.Frame can be nil:
 	// * if the stream was canceled after it said it had data
 	// * the remaining size doesn't allow us to add another STREAM frame
-	return frame, blocked
+	return frame, blocked, hasMoreData
 }
 
 func (f *framer) Handle0RTTRejection() {
@@ -320,11 +468,17 @@ func (f *framer) Handle0RTTRejection() {
 	f.controlFrameMutex.Lock()
 	defer f.controlFrameMutex.Unlock()
 
-	f.streamQueue.Clear()
+	for urgency := range f.streamQueue {
+		bucket := &f.streamQueue[urgency]
+		bucket.Incremental.Clear()
+		bucket.NonIncremental.Clear()
+		bucket.LastSendWasIncremental = false
+		f.retransmissionQueue[urgency].Clear()
+	}
 	clear(f.activeStreams)
-	f.retransmissionQueue.Clear()
 	clear(f.retransmissionStreams)
 	clear(f.streamsWithControlFrames)
+
 	var j int
 	for i, frame := range f.controlFrames {
 		switch frame.(type) {

--- a/framer.go
+++ b/framer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/quic-go/quic-go/internal/ackhandler"
 	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/utils/minheap"
 	"github.com/quic-go/quic-go/internal/utils/ringbuffer"
 	"github.com/quic-go/quic-go/internal/wire"
 	"github.com/quic-go/quic-go/quicvarint"
@@ -22,7 +23,8 @@ const (
 const maxStreamControlFrameSize = 25
 
 type streamFrameGetter interface {
-	popStreamFrame(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool)
+	priority() (urgency int8, incremental bool, generation uint32)
+	popStreamFrame(protocol.ByteCount, protocol.Version) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasMoreData bool)
 	popRetransmissionFrame(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, bool)
 }
 
@@ -30,19 +32,38 @@ type streamControlFrameGetter interface {
 	getControlFrame(monotime.Time) (_ ackhandler.Frame, ok, hasMore bool)
 }
 
+type streamQueueEntry struct {
+	id         protocol.StreamID
+	generation uint32
+}
+
+type streamPriorityBucket struct {
+	Incremental            ringbuffer.RingBuffer[streamQueueEntry]
+	NonIncremental         minheap.Heap[protocol.StreamID, uint32]
+	LastSendWasIncremental bool
+}
+
+func (b *streamPriorityBucket) Len() int {
+	return b.Incremental.Len() + b.NonIncremental.Len()
+}
+
+type queuedStream struct {
+	streamFrameGetter
+	generation uint32
+}
+
 type framer struct {
 	mutex sync.Mutex
 
-	activeStreams map[protocol.StreamID]streamFrameGetter
-	// New stream data is sent incrementally. The ring buffer provides
-	// round-robin scheduling between active streams.
-	streamQueue           ringbuffer.RingBuffer[protocol.StreamID]
+	activeStreams         map[protocol.StreamID]queuedStream
 	retransmissionStreams map[protocol.StreamID]streamFrameGetter
+
+	streamQueue              [8]streamPriorityBucket
+	streamsWithControlFrames map[protocol.StreamID]streamControlFrameGetter
 	// Retransmissions are not incremental: repair all lost data for the first queued stream.
 	// New losses extend its batch, so A, B, A is repaired as A, A, B, delaying B.
 	// The ring buffer provides FIFO scheduling while reusing its storage.
-	retransmissionQueue      ringbuffer.RingBuffer[protocol.StreamID]
-	streamsWithControlFrames map[protocol.StreamID]streamControlFrameGetter
+	retransmissionQueue [8]ringbuffer.RingBuffer[protocol.StreamID]
 
 	controlFrameMutex          sync.Mutex
 	controlFrames              []wire.Frame
@@ -53,7 +74,7 @@ type framer struct {
 
 func newFramer(connFlowController *connectionFlowController) *framer {
 	return &framer{
-		activeStreams:            make(map[protocol.StreamID]streamFrameGetter),
+		activeStreams:            make(map[protocol.StreamID]queuedStream),
 		retransmissionStreams:    make(map[protocol.StreamID]streamFrameGetter),
 		streamsWithControlFrames: make(map[protocol.StreamID]streamControlFrameGetter),
 		connFlowController:       connFlowController,
@@ -61,15 +82,23 @@ func newFramer(connFlowController *connectionFlowController) *framer {
 }
 
 func (f *framer) HasData() bool {
-	f.mutex.Lock()
-	hasData := !f.retransmissionQueue.Empty() || !f.streamQueue.Empty()
-	f.mutex.Unlock()
-	if hasData {
+	f.controlFrameMutex.Lock()
+	hasControlFrames := len(f.streamsWithControlFrames) > 0 || len(f.controlFrames) > 0 || len(f.pathResponses) > 0
+	f.controlFrameMutex.Unlock()
+
+	if hasControlFrames {
 		return true
 	}
-	f.controlFrameMutex.Lock()
-	defer f.controlFrameMutex.Unlock()
-	return len(f.streamsWithControlFrames) > 0 || len(f.controlFrames) > 0 || len(f.pathResponses) > 0
+
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	for urgency, bucket := range f.streamQueue {
+		if !bucket.Incremental.Empty() || !bucket.NonIncremental.Empty() || !f.retransmissionQueue[urgency].Empty() {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *framer) QueueControlFrame(frame wire.Frame) {
@@ -109,57 +138,70 @@ func (f *framer) Append(
 	var streamFrameLen protocol.ByteCount
 	f.mutex.Lock()
 	// retransmit all lost STREAM data before sending new STREAM data
-	for !f.retransmissionQueue.Empty() && protocol.MinStreamFrameSize <= maxLen {
-		id := f.retransmissionQueue.PeekFront()
-		str, ok := f.retransmissionStreams[id]
-		if !ok { // the stream was removed after being enqueued
-			f.retransmissionQueue.PopFront()
-			continue
-		}
-		// For the last STREAM frame, we'll remove the DataLen field later.
-		frameMaxLen := maxLen + protocol.ByteCount(quicvarint.Len(uint64(maxLen)))
-		sf, hasMoreRetransmissions := str.popRetransmissionFrame(frameMaxLen, v)
-		if !hasMoreRetransmissions {
-			f.retransmissionQueue.PopFront()
-			delete(f.retransmissionStreams, id)
-		}
-		if sf.Frame == nil {
-			// If the retransmission didn't fit, retry it in the next packet.
-			if hasMoreRetransmissions {
-				break
+retransmissions:
+	for urgency := range f.retransmissionQueue {
+		bucket := &f.retransmissionQueue[urgency]
+		for !bucket.Empty() && protocol.MinStreamFrameSize <= maxLen {
+			id := bucket.PeekFront()
+			str, ok := f.retransmissionStreams[id]
+			if !ok {
+				bucket.PopFront()
+				continue
 			}
-			continue
-		}
-		streamFrames = append(streamFrames, sf)
-		maxLen -= sf.Frame.Length(v)
-		lastFrame = sf
-		streamFrameLen += sf.Frame.Length(v)
-	}
-	// pop STREAM frames, until less than 128 bytes are left in the packet
-	numActiveStreams := f.streamQueue.Len()
-	for range numActiveStreams {
-		if protocol.MinStreamFrameSize > maxLen {
-			break
-		}
-		sf, blocked := f.getNextStreamFrame(maxLen, v)
-		if sf.Frame != nil {
+			currentUrgency, _, _ := str.priority()
+			if currentUrgency != int8(urgency) {
+				bucket.PopFront()
+				f.retransmissionQueue[currentUrgency].PushBack(id)
+				continue
+			}
+			// For the last STREAM frame, we'll remove the DataLen field later.
+			frameMaxLen := maxLen + protocol.ByteCount(quicvarint.Len(uint64(maxLen)))
+			sf, hasMoreRetransmissions := str.popRetransmissionFrame(frameMaxLen, v)
+			if !hasMoreRetransmissions {
+				bucket.PopFront()
+				delete(f.retransmissionStreams, id)
+			}
+			if sf.Frame == nil {
+				// If the retransmission didn't fit, retry it in the next packet.
+				if hasMoreRetransmissions {
+					break retransmissions
+				}
+				continue
+			}
 			streamFrames = append(streamFrames, sf)
 			maxLen -= sf.Frame.Length(v)
 			lastFrame = sf
 			streamFrameLen += sf.Frame.Length(v)
 		}
-		// If the stream just became blocked on stream flow control, attempt to pack the
-		// STREAM_DATA_BLOCKED into the same packet.
-		if blocked != nil {
-			l := blocked.Length(v)
-			// In case it doesn't fit, queue it for the next packet.
-			if maxLen < l {
-				f.controlFrames = append(f.controlFrames, blocked)
+	}
+	// pop STREAM frames, until less than 128 bytes are left in the packet
+	for urgency, bucket := range f.streamQueue {
+		numActiveStreams := bucket.Len()
+
+		for range numActiveStreams {
+			if protocol.MinStreamFrameSize > maxLen {
 				break
 			}
-			frames = append(frames, ackhandler.Frame{Frame: blocked})
-			maxLen -= l
-			controlFrameLen += l
+			sf, blocked := f.getNextStreamFrame(maxLen, int8(urgency), v)
+			if sf.Frame != nil {
+				streamFrames = append(streamFrames, sf)
+				maxLen -= sf.Frame.Length(v)
+				lastFrame = sf
+				streamFrameLen += sf.Frame.Length(v)
+			}
+			// If the stream just became blocked on stream flow control, attempt to pack the
+			// STREAM_DATA_BLOCKED into the same packet.
+			if blocked != nil {
+				l := blocked.Length(v)
+				// In case it doesn't fit, queue it for the next packet.
+				if maxLen < l {
+					f.controlFrames = append(f.controlFrames, blocked)
+					break
+				}
+				frames = append(frames, ackhandler.Frame{Frame: blocked})
+				maxLen -= l
+				controlFrameLen += l
+			}
 		}
 	}
 
@@ -255,63 +297,158 @@ func (f *framer) QueuedTooManyControlFrames() bool {
 
 func (f *framer) AddActiveStream(id protocol.StreamID, str streamFrameGetter) {
 	f.mutex.Lock()
-	if _, ok := f.activeStreams[id]; !ok {
-		f.streamQueue.PushBack(id)
-		f.activeStreams[id] = str
+	defer f.mutex.Unlock()
+
+	urgency, incremental, generation := str.priority()
+	if activeStr, ok := f.activeStreams[id]; ok && activeStr.generation == generation {
+		return
 	}
-	f.mutex.Unlock()
+	bucket := &f.streamQueue[urgency]
+	if incremental {
+		bucket.Incremental.PushBack(streamQueueEntry{id: id, generation: generation})
+	} else {
+		bucket.NonIncremental.Push(id, generation)
+	}
+	f.activeStreams[id] = queuedStream{streamFrameGetter: str, generation: generation}
 }
 
 func (f *framer) AddStreamWithRetransmission(id protocol.StreamID, str streamFrameGetter) {
 	f.mutex.Lock()
-	if _, ok := f.retransmissionStreams[id]; !ok {
-		f.retransmissionQueue.PushBack(id)
-		f.retransmissionStreams[id] = str
+	defer f.mutex.Unlock()
+
+	urgency, _, _ := str.priority()
+	if _, ok := f.retransmissionStreams[id]; ok {
+		return
 	}
-	f.mutex.Unlock()
+	f.retransmissionQueue[urgency].PushBack(id)
+	f.retransmissionStreams[id] = str
 }
 
 func (f *framer) AddStreamWithControlFrames(id protocol.StreamID, str streamControlFrameGetter) {
 	f.controlFrameMutex.Lock()
+	defer f.controlFrameMutex.Unlock()
+
 	if _, ok := f.streamsWithControlFrames[id]; !ok {
 		f.streamsWithControlFrames[id] = str
 	}
-	f.controlFrameMutex.Unlock()
 }
 
 // RemoveActiveStream is called when a stream completes.
 func (f *framer) RemoveActiveStream(id protocol.StreamID) {
 	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	// We don't delete the stream from the ring buffers and heaps,
+	// since we'd have to find it there first.
+	// Instead, we check if the stream is still in active when appending STREAM frames.
 	delete(f.activeStreams, id)
 	delete(f.retransmissionStreams, id)
-	// We don't delete the stream from the queues, since we'd have to search them.
-	// Instead, we check if the stream is still in the corresponding map when appending STREAM frames.
-	f.mutex.Unlock()
 }
 
-func (f *framer) getNextStreamFrame(maxLen protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
-	id := f.streamQueue.PopFront()
-	// This should never return an error. Better check it anyway.
-	// The stream will only be in the streamQueue, if it enqueued itself there.
+func (f *framer) UpdateStreamPriority(id protocol.StreamID) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
 	str, ok := f.activeStreams[id]
-	// The stream might have been removed after being enqueued.
 	if !ok {
+		return
+	}
+	urgency, incremental, generation := str.priority()
+	if str.generation != generation {
+		// Leave the old queue entry in place. It will be discarded when it reaches
+		// the front of that queue and no longer matches the stream's generation.
+		bucket := &f.streamQueue[urgency]
+		if incremental {
+			bucket.Incremental.PushBack(streamQueueEntry{id: id, generation: generation})
+		} else {
+			bucket.NonIncremental.Push(id, generation)
+		}
+		str.generation = generation
+		f.activeStreams[id] = str
+	}
+}
+
+func (f *framer) getNextStreamFrame(
+	maxLen protocol.ByteCount,
+	urgency int8,
+	v protocol.Version,
+) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
+	bucket := &f.streamQueue[urgency]
+	if bucket.NonIncremental.Empty() || (!bucket.LastSendWasIncremental && !bucket.Incremental.Empty()) {
+		return f.getNextIncrementalStreamFrame(maxLen, urgency, v)
+	}
+	bucket.LastSendWasIncremental = false
+	return f.getNextNonIncrementalStreamFrame(maxLen, urgency, v)
+}
+
+func (f *framer) getNextIncrementalStreamFrame(
+	maxLen protocol.ByteCount,
+	urgency int8,
+	v protocol.Version,
+) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
+	bucket := &f.streamQueue[urgency]
+	entry := bucket.Incremental.PopFront()
+	str, ok := f.activeStreams[entry.id]
+	if !ok || str.generation != entry.generation {
 		return ackhandler.StreamFrame{}, nil
 	}
+	_, _, generation := str.priority()
+	if generation != entry.generation {
+		return ackhandler.StreamFrame{}, nil
+	}
+
+	frame, blocked, hasMoreData := f.popStreamFrame(entry.id, str, maxLen, v)
+	if hasMoreData {
+		bucket.Incremental.PushBack(entry)
+	}
+	bucket.LastSendWasIncremental = true
+	return frame, blocked
+}
+
+func (f *framer) getNextNonIncrementalStreamFrame(
+	maxLen protocol.ByteCount,
+	urgency int8,
+	v protocol.Version,
+) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
+	bucket := &f.streamQueue[urgency]
+	id, queuedGeneration := bucket.NonIncremental.Peek()
+	str, ok := f.activeStreams[id]
+	if !ok || str.generation != queuedGeneration {
+		bucket.NonIncremental.Pop()
+		return ackhandler.StreamFrame{}, nil
+	}
+	_, _, currentGeneration := str.priority()
+	if currentGeneration != queuedGeneration {
+		bucket.NonIncremental.Pop()
+		return ackhandler.StreamFrame{}, nil
+	}
+
+	frame, blocked, hasMoreData := f.popStreamFrame(id, str, maxLen, v)
+	if !hasMoreData {
+		bucket.NonIncremental.Pop()
+	}
+	bucket.LastSendWasIncremental = false
+	return frame, blocked
+}
+
+func (f *framer) popStreamFrame(
+	id protocol.StreamID,
+	str queuedStream,
+	maxLen protocol.ByteCount,
+	v protocol.Version,
+) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
 	// For the last STREAM frame, we'll remove the DataLen field later.
 	// Therefore, we can pretend to have more bytes available when popping
 	// the STREAM frame (which will always have the DataLen set).
 	maxLen += protocol.ByteCount(quicvarint.Len(uint64(maxLen)))
 	frame, blocked, hasMoreData := str.popStreamFrame(maxLen, v)
-	if hasMoreData { // put the stream back in the queue (at the end)
-		f.streamQueue.PushBack(id)
-	} else { // no more data to send. Stream is not active
+	if !hasMoreData {
 		delete(f.activeStreams, id)
 	}
 	// Note that the frame.Frame can be nil:
 	// * if the stream was canceled after it said it had data
 	// * the remaining size doesn't allow us to add another STREAM frame
-	return frame, blocked
+	return frame, blocked, hasMoreData
 }
 
 func (f *framer) Handle0RTTRejection() {
@@ -320,11 +457,17 @@ func (f *framer) Handle0RTTRejection() {
 	f.controlFrameMutex.Lock()
 	defer f.controlFrameMutex.Unlock()
 
-	f.streamQueue.Clear()
+	for urgency := range f.streamQueue {
+		bucket := &f.streamQueue[urgency]
+		bucket.Incremental.Clear()
+		bucket.NonIncremental.Clear()
+		bucket.LastSendWasIncremental = false
+		f.retransmissionQueue[urgency].Clear()
+	}
 	clear(f.activeStreams)
-	f.retransmissionQueue.Clear()
 	clear(f.retransmissionStreams)
 	clear(f.streamsWithControlFrames)
+
 	var j int
 	for i, frame := range f.controlFrames {
 		switch frame.(type) {

--- a/framer_test.go
+++ b/framer_test.go
@@ -114,6 +114,7 @@ func TestFramerStreamDataBlocked(t *testing.T) {
 func testFramerStreamDataBlocked(t *testing.T, fits bool) {
 	const streamID = 5
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 	framer.AddActiveStream(streamID, str)
 	str.EXPECT().popStreamFrame(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -175,6 +176,7 @@ func testFramerDataBlocked(t *testing.T, fits bool) {
 	require.True(t, fc.TryAddBytesSent(offset))
 
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer := newFramer(fc)
 	framer.AddActiveStream(streamID, str)
 
@@ -292,8 +294,10 @@ func TestFramerAppendStreamFrames(t *testing.T) {
 	// add two streams
 	mockCtrl := gomock.NewController(t)
 	str1 := NewMockStreamFrameGetter(mockCtrl)
+	str1.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	str1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: f1}, nil, true)
 	str2 := NewMockStreamFrameGetter(mockCtrl)
+	str2.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	str2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: f2}, nil, false)
 	framer.AddActiveStream(str1ID, str1)
 	framer.AddActiveStream(str1ID, str1) // duplicate calls are ok (they're no-ops)
@@ -334,8 +338,11 @@ func TestFramerPrioritizesStreamRetransmissions(t *testing.T) {
 		secondRetransStreamID = protocol.StreamID(8)
 	)
 	newDataStr := NewMockStreamFrameGetter(gomock.NewController(t))
+	newDataStr.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	str1 := NewMockStreamFrameGetter(gomock.NewController(t))
+	str1.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	str2 := NewMockStreamFrameGetter(gomock.NewController(t))
+	str2.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	firstRetransmission := &wire.StreamFrame{StreamID: firstRetransStreamID, Data: []byte("first"), DataLenPresent: true}
 	secondRetransmission := &wire.StreamFrame{StreamID: secondRetransStreamID, Data: []byte("second"), DataLenPresent: true}
 	thirdRetransmission := &wire.StreamFrame{StreamID: secondRetransStreamID, Offset: 6, Data: []byte("third"), DataLenPresent: true}
@@ -370,7 +377,9 @@ func TestFramerSplitsStreamRetransmissions(t *testing.T) {
 		maxLen         = protocol.ByteCount(1000)
 	)
 	str1 := NewMockStreamFrameGetter(gomock.NewController(t))
+	str1.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	str2 := NewMockStreamFrameGetter(gomock.NewController(t))
+	str2.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	data1 := bytes.Repeat([]byte{1}, 500)
 	data2 := bytes.Repeat([]byte{2}, 1000)
 	retransmit1 := &wire.StreamFrame{StreamID: firstStreamID, Data: data1, DataLenPresent: true}
@@ -407,11 +416,99 @@ func TestFramerSplitsStreamRetransmissions(t *testing.T) {
 	require.False(t, framer.HasData())
 }
 
+func TestFramerUpdatesStreamPriorityWithoutDuplicates(t *testing.T) {
+	const streamID = protocol.StreamID(4)
+	urgency := int8(3)
+	incremental := true
+	var generation uint32
+	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().DoAndReturn(func() (int8, bool, uint32) {
+		return urgency, incremental, generation
+	}).AnyTimes()
+	str.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(
+		ackhandler.StreamFrame{Frame: &wire.StreamFrame{StreamID: streamID}}, nil, false,
+	)
+
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddActiveStream(streamID, str)
+	framer.UpdateStreamPriority(streamID)
+
+	urgency = 2
+	incremental = false
+	generation++
+	framer.UpdateStreamPriority(streamID)
+
+	urgency = 3
+	incremental = true
+	generation++
+	framer.UpdateStreamPriority(streamID)
+	framer.UpdateStreamPriority(streamID)
+
+	_, frames, _ := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
+	require.Len(t, frames, 1)
+	require.Equal(t, streamID, frames[0].Frame.StreamID)
+	require.False(t, framer.HasData())
+}
+
+func TestFramerRequeuesRetransmissionAfterPriorityChange(t *testing.T) {
+	const streamID = protocol.StreamID(4)
+	urgency := int8(3)
+	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().DoAndReturn(func() (int8, bool, uint32) {
+		return urgency, true, 0
+	}).AnyTimes()
+	str.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(
+		ackhandler.StreamFrame{Frame: &wire.StreamFrame{StreamID: streamID}}, false,
+	)
+
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddStreamWithRetransmission(streamID, str)
+	urgency = 2
+	_, frames, _ := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
+	require.Empty(t, frames)
+	require.True(t, framer.HasData())
+
+	_, frames, _ = framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
+	require.Len(t, frames, 1)
+	require.Equal(t, streamID, frames[0].Frame.StreamID)
+	require.False(t, framer.HasData())
+}
+
+func TestFramerUpdatesStreamRetransmissionPriority(t *testing.T) {
+	const (
+		updatedStreamID = protocol.StreamID(4)
+		otherStreamID   = protocol.StreamID(8)
+	)
+	urgency := int8(0)
+	updatedStr := NewMockStreamFrameGetter(gomock.NewController(t))
+	updatedStr.EXPECT().priority().DoAndReturn(func() (int8, bool, uint32) {
+		return urgency, true, 0
+	}).AnyTimes()
+	otherStr := NewMockStreamFrameGetter(gomock.NewController(t))
+	otherStr.EXPECT().priority().Return(int8(1), true, uint32(0)).AnyTimes()
+	updatedStr.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(
+		ackhandler.StreamFrame{Frame: &wire.StreamFrame{StreamID: updatedStreamID}}, false,
+	)
+	otherStr.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(
+		ackhandler.StreamFrame{Frame: &wire.StreamFrame{StreamID: otherStreamID}}, false,
+	)
+
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddStreamWithRetransmission(updatedStreamID, updatedStr)
+	framer.AddStreamWithRetransmission(otherStreamID, otherStr)
+	urgency = 2
+	_, frames, _ := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
+	require.Len(t, frames, 2)
+	require.Equal(t, otherStreamID, frames[0].Frame.StreamID)
+	require.Equal(t, updatedStreamID, frames[1].Frame.StreamID)
+}
+
 func TestFramerRemoveActiveStream(t *testing.T) {
 	const id = protocol.StreamID(42)
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 	require.False(t, framer.HasData())
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer.AddActiveStream(id, str)
 	framer.AddStreamWithRetransmission(id, str)
 	require.True(t, framer.HasData())
@@ -426,6 +523,7 @@ func TestFramerMinStreamFrameSize(t *testing.T) {
 	const id = protocol.StreamID(42)
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer.AddActiveStream(id, str)
 
 	require.True(t, framer.HasData())
@@ -451,6 +549,7 @@ func TestFramerMinStreamFrameSizeMultipleStreamFrames(t *testing.T) {
 	const id = protocol.StreamID(42)
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer.AddActiveStream(id, str)
 
 	// pop a frame such that the remaining size is one byte less than the minimum STREAM frame size
@@ -470,6 +569,7 @@ func TestFramerMinStreamFrameSizeMultipleStreamFrames(t *testing.T) {
 func TestFramerFillPacketOneStream(t *testing.T) {
 	const id = protocol.StreamID(42)
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 
 	for i := protocol.MinStreamFrameSize; i < 2000; i++ {
@@ -499,19 +599,21 @@ func TestFramerFillPacketMultipleStreams(t *testing.T) {
 		id2 = protocol.StreamID(11)
 	)
 	mockCtrl := gomock.NewController(t)
-	stream1 := NewMockStreamFrameGetter(mockCtrl)
-	stream2 := NewMockStreamFrameGetter(mockCtrl)
+	str1 := NewMockStreamFrameGetter(mockCtrl)
+	str1.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
+	str2 := NewMockStreamFrameGetter(mockCtrl)
+	str2.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 
 	for i := 2 * protocol.MinStreamFrameSize; i < 2000; i++ {
-		stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(
+		str1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(
 			func(size protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
 				f := &wire.StreamFrame{StreamID: id1, DataLenPresent: true}
 				f.Data = make([]byte, f.MaxDataLen(protocol.MinStreamFrameSize, v))
 				return ackhandler.StreamFrame{Frame: f}, nil, false
 			},
 		)
-		stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(
+		str2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(
 			func(size protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
 				f := &wire.StreamFrame{StreamID: id2, DataLenPresent: true}
 				f.Data = make([]byte, f.MaxDataLen(size, v))
@@ -519,8 +621,8 @@ func TestFramerFillPacketMultipleStreams(t *testing.T) {
 				return ackhandler.StreamFrame{Frame: f}, nil, false
 			},
 		)
-		framer.AddActiveStream(id1, stream1)
-		framer.AddActiveStream(id2, stream2)
+		framer.AddActiveStream(id1, str1)
+		framer.AddActiveStream(id2, str2)
 		_, frames, _ := framer.Append(nil, nil, i, monotime.Now(), protocol.Version1)
 		require.Len(t, frames, 2)
 		require.True(t, frames[0].Frame.DataLenPresent)
@@ -546,6 +648,7 @@ func TestFramer0RTTRejection(t *testing.T) {
 	framer.QueueControlFrame(pc)
 
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer.AddActiveStream(10, str)
 	framer.AddStreamWithRetransmission(10, str)
 	framer.AddStreamWithControlFrames(10, NewMockStreamControlFrameGetter(gomock.NewController(t)))

--- a/framer_test.go
+++ b/framer_test.go
@@ -114,6 +114,7 @@ func TestFramerStreamDataBlocked(t *testing.T) {
 func testFramerStreamDataBlocked(t *testing.T, fits bool) {
 	const streamID = 5
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 	framer.AddActiveStream(streamID, str)
 	str.EXPECT().popStreamFrame(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -175,6 +176,7 @@ func testFramerDataBlocked(t *testing.T, fits bool) {
 	require.True(t, fc.TryAddBytesSent(offset))
 
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer := newFramer(fc)
 	framer.AddActiveStream(streamID, str)
 
@@ -292,8 +294,10 @@ func TestFramerAppendStreamFrames(t *testing.T) {
 	// add two streams
 	mockCtrl := gomock.NewController(t)
 	str1 := NewMockStreamFrameGetter(mockCtrl)
+	str1.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	str1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: f1}, nil, true)
 	str2 := NewMockStreamFrameGetter(mockCtrl)
+	str2.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	str2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).Return(ackhandler.StreamFrame{Frame: f2}, nil, false)
 	framer.AddActiveStream(str1ID, str1)
 	framer.AddActiveStream(str1ID, str1) // duplicate calls are ok (they're no-ops)
@@ -334,8 +338,11 @@ func TestFramerPrioritizesStreamRetransmissions(t *testing.T) {
 		secondRetransStreamID = protocol.StreamID(8)
 	)
 	newDataStr := NewMockStreamFrameGetter(gomock.NewController(t))
+	newDataStr.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	str1 := NewMockStreamFrameGetter(gomock.NewController(t))
+	str1.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	str2 := NewMockStreamFrameGetter(gomock.NewController(t))
+	str2.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	firstRetransmission := &wire.StreamFrame{StreamID: firstRetransStreamID, Data: []byte("first"), DataLenPresent: true}
 	secondRetransmission := &wire.StreamFrame{StreamID: secondRetransStreamID, Data: []byte("second"), DataLenPresent: true}
 	thirdRetransmission := &wire.StreamFrame{StreamID: secondRetransStreamID, Offset: 6, Data: []byte("third"), DataLenPresent: true}
@@ -370,7 +377,9 @@ func TestFramerSplitsStreamRetransmissions(t *testing.T) {
 		maxLen         = protocol.ByteCount(1000)
 	)
 	str1 := NewMockStreamFrameGetter(gomock.NewController(t))
+	str1.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	str2 := NewMockStreamFrameGetter(gomock.NewController(t))
+	str2.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	data1 := bytes.Repeat([]byte{1}, 500)
 	data2 := bytes.Repeat([]byte{2}, 1000)
 	retransmit1 := &wire.StreamFrame{StreamID: firstStreamID, Data: data1, DataLenPresent: true}
@@ -407,16 +416,186 @@ func TestFramerSplitsStreamRetransmissions(t *testing.T) {
 	require.False(t, framer.HasData())
 }
 
+// newMockPriorityStream creates a mock stream that produces packet-sized frames at the given priority
+func newMockPriorityStream(t *testing.T, id protocol.StreamID, urgency int8, incremental bool, numFrames int) *MockStreamFrameGetter {
+	t.Helper()
+
+	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(urgency, incremental, uint32(0)).AnyTimes()
+	remaining := numFrames
+	str.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(
+		func(_ protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
+			frame := &wire.StreamFrame{StreamID: id, DataLenPresent: true}
+			frame.Data = make([]byte, frame.MaxDataLen(protocol.MinStreamFrameSize, v))
+			remaining--
+			return ackhandler.StreamFrame{Frame: frame}, nil, remaining > 0
+		},
+	).Times(numFrames)
+	return str
+}
+
+// appendPriorityPackets appends one STREAM frame per packet and returns their stream IDs.
+func appendPriorityPackets(t *testing.T, framer *framer, numPackets int) []protocol.StreamID {
+	t.Helper()
+
+	ids := make([]protocol.StreamID, 0, numPackets)
+	for range numPackets {
+		_, frames, _ := framer.Append(nil, nil, protocol.MinStreamFrameSize, monotime.Now(), protocol.Version1)
+		require.Len(t, frames, 1)
+		ids = append(ids, frames[0].Frame.StreamID)
+	}
+	return ids
+}
+
+func TestFramerSchedulesIncrementalStreams(t *testing.T) {
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddActiveStream(8, newMockPriorityStream(t, 8, 0, true, 3))
+	framer.AddActiveStream(0, newMockPriorityStream(t, 0, 1, true, 1))
+	framer.AddActiveStream(4, newMockPriorityStream(t, 4, 0, true, 2))
+
+	require.Equal(t,
+		[]protocol.StreamID{8, 4, 8, 4, 8, 0},
+		appendPriorityPackets(t, framer, 6),
+	)
+	require.False(t, framer.HasData())
+}
+
+func TestFramerSchedulesNonIncrementalStreams(t *testing.T) {
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddActiveStream(8, newMockPriorityStream(t, 8, 0, false, 2))
+	framer.AddActiveStream(0, newMockPriorityStream(t, 0, 1, false, 1))
+	framer.AddActiveStream(4, newMockPriorityStream(t, 4, 0, false, 3))
+
+	require.Equal(t,
+		[]protocol.StreamID{4, 4, 4, 8, 8, 0},
+		appendPriorityPackets(t, framer, 6),
+	)
+	require.False(t, framer.HasData())
+}
+
+func TestFramerSchedulesReprioritizedStream(t *testing.T) {
+	const updatedStreamID = protocol.StreamID(8)
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddActiveStream(4, newMockPriorityStream(t, 4, 1, true, 1))
+	framer.AddActiveStream(12, newMockPriorityStream(t, 12, 2, true, 1))
+
+	// stream 8 starts at urgency 0 with enough data for two packets
+	updatedStr := NewMockStreamFrameGetter(gomock.NewController(t))
+	gomock.InOrder(
+		updatedStr.EXPECT().priority().Return(0, true, 0).Times(2),
+		updatedStr.EXPECT().priority().Return(2, false, 1).Times(2),
+	)
+	remaining := 2
+	updatedStr.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(
+		func(_ protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
+			frame := &wire.StreamFrame{StreamID: updatedStreamID, DataLenPresent: true}
+			frame.Data = make([]byte, frame.MaxDataLen(protocol.MinStreamFrameSize, v))
+			remaining--
+			return ackhandler.StreamFrame{Frame: frame}, nil, remaining > 0
+		},
+	).Times(2)
+	framer.AddActiveStream(updatedStreamID, updatedStr)
+
+	// the first packet contains stream 8 and leaves it queued at urgency 0
+	ids := appendPriorityPackets(t, framer, 1)
+	// lower stream 8 to urgency 2 and make it non-incremental, leaving its old queue entry stale
+	framer.UpdateStreamPriority(updatedStreamID)
+	ids = append(ids, appendPriorityPackets(t, framer, 3)...)
+
+	// the stale entry is skipped, so stream 4 runs next; without the update, stream 8 would run next
+	// at urgency 2, incremental stream 12 is scheduled before non-incremental stream 8
+	require.Equal(t, []protocol.StreamID{8, 4, 12, 8}, ids)
+	require.False(t, framer.HasData())
+}
+
+func TestFramerAlternatesIncrementalAndNonIncrementalStreams(t *testing.T) {
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddActiveStream(8, newMockPriorityStream(t, 8, 0, true, 2))
+	framer.AddActiveStream(4, newMockPriorityStream(t, 4, 0, false, 3))
+	framer.AddActiveStream(12, newMockPriorityStream(t, 12, 0, true, 1))
+
+	// incremental streams 8 and 12 round-robin while stream 4 gets every non-incremental turn
+	require.Equal(t,
+		[]protocol.StreamID{8, 4, 12, 4, 8, 4},
+		appendPriorityPackets(t, framer, 6),
+	)
+	require.False(t, framer.HasData())
+}
+
+func TestFramerRequeuesRetransmissionAfterPriorityChange(t *testing.T) {
+	const streamID = protocol.StreamID(4)
+	urgency := int8(3)
+	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().DoAndReturn(func() (int8, bool, uint32) {
+		return urgency, true, 0
+	}).AnyTimes()
+	str.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(
+		ackhandler.StreamFrame{Frame: &wire.StreamFrame{StreamID: streamID}}, false,
+	)
+
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddStreamWithRetransmission(streamID, str)
+	urgency = 2
+	_, frames, _ := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
+	require.Empty(t, frames)
+	require.True(t, framer.HasData())
+
+	_, frames, _ = framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
+	require.Len(t, frames, 1)
+	require.Equal(t, streamID, frames[0].Frame.StreamID)
+	require.False(t, framer.HasData())
+}
+
+func TestFramerUpdatesStreamRetransmissionPriority(t *testing.T) {
+	const (
+		updatedStreamID = protocol.StreamID(4)
+		otherStreamID   = protocol.StreamID(8)
+	)
+	urgency := int8(0)
+	updatedStr := NewMockStreamFrameGetter(gomock.NewController(t))
+	updatedStr.EXPECT().priority().DoAndReturn(func() (int8, bool, uint32) {
+		return urgency, true, 0
+	}).AnyTimes()
+	otherStr := NewMockStreamFrameGetter(gomock.NewController(t))
+	otherStr.EXPECT().priority().Return(int8(1), true, uint32(0)).AnyTimes()
+	updatedStr.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(
+		ackhandler.StreamFrame{Frame: &wire.StreamFrame{StreamID: updatedStreamID}}, false,
+	)
+	otherStr.EXPECT().popRetransmissionFrame(gomock.Any(), protocol.Version1).Return(
+		ackhandler.StreamFrame{Frame: &wire.StreamFrame{StreamID: otherStreamID}}, false,
+	)
+
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddStreamWithRetransmission(updatedStreamID, updatedStr)
+	framer.AddStreamWithRetransmission(otherStreamID, otherStr)
+	urgency = 2
+	_, frames, _ := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
+	require.Len(t, frames, 2)
+	require.Equal(t, otherStreamID, frames[0].Frame.StreamID)
+	require.Equal(t, updatedStreamID, frames[1].Frame.StreamID)
+}
+
 func TestFramerRemoveActiveStream(t *testing.T) {
+	t.Run("incremental", func(t *testing.T) {
+		testFramerRemoveActiveStream(t, true)
+	})
+	t.Run("non-incremental", func(t *testing.T) {
+		testFramerRemoveActiveStream(t, false)
+	})
+}
+
+// testFramerRemoveActiveStream verifies that queued data is discarded when a stream is removed.
+func testFramerRemoveActiveStream(t *testing.T, incremental bool) {
 	const id = protocol.StreamID(42)
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 	require.False(t, framer.HasData())
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, incremental, uint32(0)).AnyTimes()
 	framer.AddActiveStream(id, str)
 	framer.AddStreamWithRetransmission(id, str)
 	require.True(t, framer.HasData())
 	framer.RemoveActiveStream(id) // no calls will be issued to the mock stream
-	// we can't assert on framer.HasData here, since it's not removed from the ringbuffer
+	// we can't assert on framer.HasData here, since it's not removed from the scheduling queue
 	_, frames, _ := framer.Append(nil, nil, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
 	require.Empty(t, frames)
 	require.False(t, framer.HasData())
@@ -426,6 +605,7 @@ func TestFramerMinStreamFrameSize(t *testing.T) {
 	const id = protocol.StreamID(42)
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer.AddActiveStream(id, str)
 
 	require.True(t, framer.HasData())
@@ -451,6 +631,7 @@ func TestFramerMinStreamFrameSizeMultipleStreamFrames(t *testing.T) {
 	const id = protocol.StreamID(42)
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer.AddActiveStream(id, str)
 
 	// pop a frame such that the remaining size is one byte less than the minimum STREAM frame size
@@ -470,6 +651,7 @@ func TestFramerMinStreamFrameSizeMultipleStreamFrames(t *testing.T) {
 func TestFramerFillPacketOneStream(t *testing.T) {
 	const id = protocol.StreamID(42)
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 
 	for i := protocol.MinStreamFrameSize; i < 2000; i++ {
@@ -499,19 +681,21 @@ func TestFramerFillPacketMultipleStreams(t *testing.T) {
 		id2 = protocol.StreamID(11)
 	)
 	mockCtrl := gomock.NewController(t)
-	stream1 := NewMockStreamFrameGetter(mockCtrl)
-	stream2 := NewMockStreamFrameGetter(mockCtrl)
+	str1 := NewMockStreamFrameGetter(mockCtrl)
+	str1.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
+	str2 := NewMockStreamFrameGetter(mockCtrl)
+	str2.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
 
 	for i := 2 * protocol.MinStreamFrameSize; i < 2000; i++ {
-		stream1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(
+		str1.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(
 			func(size protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
 				f := &wire.StreamFrame{StreamID: id1, DataLenPresent: true}
 				f.Data = make([]byte, f.MaxDataLen(protocol.MinStreamFrameSize, v))
 				return ackhandler.StreamFrame{Frame: f}, nil, false
 			},
 		)
-		stream2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(
+		str2.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(
 			func(size protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool) {
 				f := &wire.StreamFrame{StreamID: id2, DataLenPresent: true}
 				f.Data = make([]byte, f.MaxDataLen(size, v))
@@ -519,8 +703,8 @@ func TestFramerFillPacketMultipleStreams(t *testing.T) {
 				return ackhandler.StreamFrame{Frame: f}, nil, false
 			},
 		)
-		framer.AddActiveStream(id1, stream1)
-		framer.AddActiveStream(id2, stream2)
+		framer.AddActiveStream(id1, str1)
+		framer.AddActiveStream(id2, str2)
 		_, frames, _ := framer.Append(nil, nil, i, monotime.Now(), protocol.Version1)
 		require.Len(t, frames, 2)
 		require.True(t, frames[0].Frame.DataLenPresent)
@@ -546,6 +730,7 @@ func TestFramer0RTTRejection(t *testing.T) {
 	framer.QueueControlFrame(pc)
 
 	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
 	framer.AddActiveStream(10, str)
 	framer.AddStreamWithRetransmission(10, str)
 	framer.AddStreamWithControlFrames(10, NewMockStreamControlFrameGetter(gomock.NewController(t)))

--- a/internal/utils/minheap/minheap.go
+++ b/internal/utils/minheap/minheap.go
@@ -1,0 +1,78 @@
+package minheap
+
+import "cmp"
+
+type entry[K, V any] struct {
+	key   K
+	value V
+}
+
+// A Heap is a minimum heap ordered by key.
+type Heap[K cmp.Ordered, V any] []entry[K, V]
+
+func (h Heap[K, V]) Len() int    { return len(h) }
+func (h Heap[K, V]) Empty() bool { return len(h) == 0 }
+
+// Peek returns the smallest element in the heap.
+// It must not be called when the heap is empty.
+func (h Heap[K, V]) Peek() (K, V) {
+	v := h[0]
+	return v.key, v.value
+}
+
+// Push adds an element to the heap.
+func (h *Heap[K, V]) Push(key K, value V) {
+	*h = append(*h, entry[K, V]{key: key, value: value})
+	(*h).up(len(*h) - 1)
+}
+
+// Pop removes and returns the smallest element in the heap.
+// It must not be called when the heap is empty.
+func (h *Heap[K, V]) Pop() (K, V) {
+	values := *h
+	last := len(values) - 1
+	v := values[0]
+	values[0] = values[last]
+	var zero entry[K, V]
+	values[last] = zero
+	values = values[:last]
+	if last > 0 {
+		values.down(0)
+	}
+	*h = values
+	return v.key, v.value
+}
+
+// Clear removes all elements from the heap.
+func (h *Heap[K, V]) Clear() {
+	clear(*h)
+	*h = (*h)[:0]
+}
+
+func (h Heap[K, V]) up(i int) {
+	for i > 0 {
+		parent := (i - 1) / 2
+		if h[parent].key <= h[i].key {
+			return
+		}
+		h[parent], h[i] = h[i], h[parent]
+		i = parent
+	}
+}
+
+func (h Heap[K, V]) down(i int) {
+	for {
+		child := 2*i + 1
+		if child >= len(h) {
+			break
+		}
+		if right := child + 1; right < len(h) && h[right].key < h[child].key {
+			child = right
+		}
+		if h[i].key <= h[child].key {
+			break
+		}
+		h[i], h[child] = h[child], h[i]
+		i = child
+	}
+}

--- a/internal/utils/minheap/minheap_test.go
+++ b/internal/utils/minheap/minheap_test.go
@@ -1,0 +1,37 @@
+package minheap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeap(t *testing.T) {
+	var h Heap[int, string]
+	require.True(t, h.Empty())
+	require.Panics(t, func() { h.Peek() })
+	require.Panics(t, func() { h.Pop() })
+
+	h.Push(4, "four")
+	h.Push(1, "one")
+	h.Push(3, "three")
+	h.Push(2, "two")
+	require.Equal(t, 4, h.Len())
+	key, value := h.Peek()
+	require.Equal(t, 1, key)
+	require.Equal(t, "one", value)
+	for _, expected := range []struct {
+		key   int
+		value string
+	}{{1, "one"}, {2, "two"}, {3, "three"}, {4, "four"}} {
+		key, value = h.Pop()
+		require.Equal(t, expected.key, key)
+		require.Equal(t, expected.value, value)
+	}
+	require.True(t, h.Empty())
+
+	h.Push(1, "one")
+	h.Push(2, "two")
+	h.Clear()
+	require.True(t, h.Empty())
+}

--- a/mock_stream_frame_getter_test.go
+++ b/mock_stream_frame_getter_test.go
@@ -104,8 +104,8 @@ type MockStreamFrameGetterpopStreamFrameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStreamFrameGetterpopStreamFrameCall) Return(arg0 ackhandler.StreamFrame, arg1 *wire.StreamDataBlockedFrame, arg2 bool) *MockStreamFrameGetterpopStreamFrameCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
+func (c *MockStreamFrameGetterpopStreamFrameCall) Return(arg0 ackhandler.StreamFrame, arg1 *wire.StreamDataBlockedFrame, hasMoreData bool) *MockStreamFrameGetterpopStreamFrameCall {
+	c.Call = c.Call.Return(arg0, arg1, hasMoreData)
 	return c
 }
 
@@ -117,6 +117,46 @@ func (c *MockStreamFrameGetterpopStreamFrameCall) Do(f func(protocol.ByteCount, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStreamFrameGetterpopStreamFrameCall) DoAndReturn(f func(protocol.ByteCount, protocol.Version) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame, bool)) *MockStreamFrameGetterpopStreamFrameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// priority mocks base method.
+func (m *MockStreamFrameGetter) priority() (int8, bool, uint32) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "priority")
+	ret0, _ := ret[0].(int8)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(uint32)
+	return ret0, ret1, ret2
+}
+
+// priority indicates an expected call of priority.
+func (mr *MockStreamFrameGetterMockRecorder) priority() *MockStreamFrameGetterpriorityCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "priority", reflect.TypeOf((*MockStreamFrameGetter)(nil).priority))
+	return &MockStreamFrameGetterpriorityCall{Call: call}
+}
+
+// MockStreamFrameGetterpriorityCall wrap *gomock.Call
+type MockStreamFrameGetterpriorityCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStreamFrameGetterpriorityCall) Return(urgency int8, incremental bool, generation uint32) *MockStreamFrameGetterpriorityCall {
+	c.Call = c.Call.Return(urgency, incremental, generation)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStreamFrameGetterpriorityCall) Do(f func() (int8, bool, uint32)) *MockStreamFrameGetterpriorityCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStreamFrameGetterpriorityCall) DoAndReturn(f func() (int8, bool, uint32)) *MockStreamFrameGetterpriorityCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mock_stream_sender_test.go
+++ b/mock_stream_sender_test.go
@@ -219,3 +219,39 @@ func (c *MockStreamSenderonStreamCompletedCall) DoAndReturn(f func(protocol.Stre
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// updateStreamPriority mocks base method.
+func (m *MockStreamSender) updateStreamPriority(arg0 protocol.StreamID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "updateStreamPriority", arg0)
+}
+
+// updateStreamPriority indicates an expected call of updateStreamPriority.
+func (mr *MockStreamSenderMockRecorder) updateStreamPriority(arg0 any) *MockStreamSenderupdateStreamPriorityCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateStreamPriority", reflect.TypeOf((*MockStreamSender)(nil).updateStreamPriority), arg0)
+	return &MockStreamSenderupdateStreamPriorityCall{Call: call}
+}
+
+// MockStreamSenderupdateStreamPriorityCall wrap *gomock.Call
+type MockStreamSenderupdateStreamPriorityCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStreamSenderupdateStreamPriorityCall) Return() *MockStreamSenderupdateStreamPriorityCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStreamSenderupdateStreamPriorityCall) Do(f func(protocol.StreamID)) *MockStreamSenderupdateStreamPriorityCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStreamSenderupdateStreamPriorityCall) DoAndReturn(f func(protocol.StreamID)) *MockStreamSenderupdateStreamPriorityCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/send_stream.go
+++ b/send_stream.go
@@ -12,6 +12,8 @@ import (
 	"github.com/quic-go/quic-go/internal/wire"
 )
 
+const defaultUrgency = 3
+
 // A SendStream is a unidirectional Send Stream.
 type SendStream struct {
 	mutex sync.Mutex
@@ -57,6 +59,11 @@ type SendStream struct {
 	cancellationFlagged bool
 	completed           bool // set when this stream has been reported to the streamSender as completed
 
+	// priority
+	urgency            int8
+	incremental        bool
+	priorityGeneration uint32
+
 	writeChan chan struct{}
 	writeOnce chan struct{}
 	deadline  monotime.Time
@@ -84,6 +91,8 @@ func newSendStream(
 		writeChan:             make(chan struct{}, 1),
 		writeOnce:             make(chan struct{}, 1), // cap: 1, to protect against concurrent use of Write
 		supportsResetStreamAt: supportsResetStreamAt,
+		urgency:               defaultUrgency,
+		incremental:           true,
 	}
 	s.ctx, s.ctxCancel = context.WithCancelCause(ctx)
 	return s
@@ -334,13 +343,18 @@ func (s *SendStream) canBufferStreamFrame() bool {
 
 // popStreamFrame returns the next STREAM frame that is supposed to be sent on this stream
 // maxBytes is the maximum length this frame (including frame header) will have.
-func (s *SendStream) popStreamFrame(maxBytes protocol.ByteCount, v protocol.Version) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasMore bool) {
+// hasMoreData says if more data can be sent after this call without first
+// receiving a MAX_STREAM_DATA frame.
+func (s *SendStream) popStreamFrame(maxBytes protocol.ByteCount, v protocol.Version) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasMoreData bool) {
 	s.mutex.Lock()
 	f, blocked, hasMoreData := s.popNewStreamFrameForPacket(maxBytes, v)
 	if f != nil {
 		s.numOutstandingFrames++
 	}
 	s.mutex.Unlock()
+	if blocked != nil {
+		hasMoreData = false
+	}
 
 	if f == nil {
 		return ackhandler.StreamFrame{}, blocked, hasMoreData
@@ -428,7 +442,9 @@ func (s *SendStream) popNewStreamFrameForPacket(maxBytes protocol.ByteCount, v p
 		hasMoreData = false
 	}
 	var blocked *wire.StreamDataBlockedFrame
-	if f.DataLen() > 0 {
+	// Flow control for a reserved frame was consumed when it was queued. Don't
+	// report the stream blocked while reserved bytes can still be sent.
+	if f.DataLen() > 0 && !s.nextFrameReserved {
 		if isBlocked, offset := s.flowController.isNewlyBlocked(); isBlocked {
 			blocked = &wire.StreamDataBlockedFrame{StreamID: s.streamID, MaximumStreamData: offset}
 		}
@@ -765,6 +781,33 @@ func (s *SendStream) reliableOffset() protocol.ByteCount {
 	return s.reliableSize
 }
 
+// SetPriority sets the scheduling priority for data sent on the stream.
+// It uses the urgency and incremental parameters defined by [RFC 9218].
+// Urgency is clipped to the range 0 through 7, with lower values taking priority.
+// Within an urgency level, incremental streams are scheduled round-robin,
+// while non-incremental streams are scheduled by stream ID.
+//
+// The default priority is urgency 3 with incremental set to true. RFC 9218
+// instead defaults incremental to false.
+//
+// [RFC 9218]: https://www.rfc-editor.org/rfc/rfc9218.html
+func (s *SendStream) SetPriority(urgency int8, incremental bool) {
+	var changed bool
+	s.mutex.Lock()
+	urgency = max(0, min(urgency, 7)) // urgency must be between 0 and 7
+	if s.urgency != urgency || s.incremental != incremental {
+		s.urgency = urgency
+		s.incremental = incremental
+		s.priorityGeneration++
+		changed = true
+	}
+	s.mutex.Unlock()
+
+	if changed {
+		s.sender.updateStreamPriority(s.streamID)
+	}
+}
+
 // The Context is canceled as soon as the write-side of the stream is closed.
 // This happens when Close() or CancelWrite() is called, or when the peer
 // cancels the read-side of their stream.
@@ -807,6 +850,13 @@ func (s *SendStream) signalWrite() {
 	case s.writeChan <- struct{}{}:
 	default:
 	}
+}
+
+func (s *SendStream) priority() (urgency int8, incremental bool, generation uint32) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.urgency, s.incremental, s.priorityGeneration
 }
 
 type sendStreamAckHandler SendStream

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -59,6 +59,26 @@ func TestSendStreamSetup(t *testing.T) {
 	require.Equal(t, protocol.StreamID(1337), str.StreamID())
 }
 
+func TestSendStreamPriorityGeneration(t *testing.T) {
+	const streamID = protocol.StreamID(42)
+	mockSender := NewMockStreamSender(gomock.NewController(t))
+	str := newSendStream(context.Background(), streamID, mockSender, newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount), false)
+
+	str.SetPriority(defaultUrgency, true)
+	_, _, generation := str.priority()
+	require.Zero(t, generation)
+
+	mockSender.EXPECT().updateStreamPriority(streamID).Times(2)
+	str.SetPriority(2, false)
+	str.SetPriority(2, false)
+	_, _, generation = str.priority()
+	require.Equal(t, uint32(1), generation)
+
+	str.SetPriority(1, false)
+	_, _, generation = str.priority()
+	require.Equal(t, uint32(2), generation)
+}
+
 func TestSendStreamWriteData(t *testing.T) {
 	const streamID protocol.StreamID = 42
 	mockCtrl := gomock.NewController(t)
@@ -187,7 +207,7 @@ func TestSendStreamWriteWithLimit(t *testing.T) {
 		synctest.Wait()
 
 		frame, _, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
-		require.True(t, hasMore)
+		require.False(t, hasMore)
 		require.Equal(t, data[25:50], frame.Frame.Data)
 		require.Equal(t, 2, calls)
 
@@ -791,18 +811,23 @@ func TestSendStreamFlowControlBlocked(t *testing.T) {
 	_, err := str.Write([]byte("foobar"))
 	require.NoError(t, err)
 
-	frame, blocked, hasMore := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
-	require.True(t, hasMore)
+	frame, blocked, hasMoreData := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	require.False(t, hasMoreData)
 	require.EqualExportedValues(t,
 		&wire.StreamFrame{StreamID: streamID, Data: []byte("foo"), DataLenPresent: true},
 		frame.Frame,
 	)
 	require.Equal(t, &wire.StreamDataBlockedFrame{StreamID: streamID, MaximumStreamData: 3}, blocked)
 
-	frame, blocked, hasMore = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
-	require.Nil(t, frame.Frame)
+	mockSender.EXPECT().onHasStreamData(streamID, str)
+	str.updateSendWindow(10)
+	frame, blocked, hasMoreData = str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	require.EqualExportedValues(t,
+		&wire.StreamFrame{StreamID: streamID, Offset: 3, Data: []byte("bar"), DataLenPresent: true},
+		frame.Frame,
+	)
 	require.Nil(t, blocked)
-	require.True(t, hasMore)
+	require.False(t, hasMoreData)
 
 	_, ok, hasMore := str.getControlFrame(monotime.Now())
 	require.False(t, ok)

--- a/stream.go
+++ b/stream.go
@@ -28,6 +28,7 @@ type streamSender interface {
 	onHasStreamData(protocol.StreamID, *SendStream)
 	onHasStreamRetransmission(protocol.StreamID, *SendStream)
 	onHasStreamControlFrame(protocol.StreamID, streamControlFrameGetter)
+	updateStreamPriority(protocol.StreamID)
 	// must be called without holding the mutex that is acquired by closeForShutdown
 	onStreamCompleted(protocol.StreamID)
 }
@@ -108,6 +109,12 @@ func newStream(
 func (s *Stream) StreamID() StreamID {
 	// the result is same for receiveStream and sendStream
 	return s.sendStr.StreamID()
+}
+
+// SetPriority sets the scheduling priority for data sent on the stream.
+// See [SendStream.SetPriority] for details.
+func (s *Stream) SetPriority(urgency int8, incremental bool) {
+	s.sendStr.SetPriority(urgency, incremental)
 }
 
 // Read reads data from the stream.
@@ -207,10 +214,6 @@ func (s *Stream) enableResetStreamAt() {
 
 func (s *Stream) popStreamFrame(maxBytes protocol.ByteCount, v protocol.Version) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasMore bool) {
 	return s.sendStr.popStreamFrame(maxBytes, v)
-}
-
-func (s *Stream) popRetransmissionFrame(maxBytes protocol.ByteCount, v protocol.Version) (ackhandler.StreamFrame, bool) {
-	return s.sendStr.popRetransmissionFrame(maxBytes, v)
 }
 
 func (s *Stream) getControlFrame(now monotime.Time) (_ ackhandler.Frame, ok, hasMore bool) {


### PR DESCRIPTION
Fixes #437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring stream urgency and incremental delivery preferences.
  - Improved transmission scheduling to prioritize streams according to their configured settings.
  - Stream priority changes now take effect during transmission, including for retransmitted data.

- **Bug Fixes**
  - Improved flow-control handling to avoid incorrectly reporting blocked or pending data.
  - Ensured buffered data is sent promptly when the send window becomes available.
  - Improved handling of final stream frames and priority updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement RFC 9218-style stream priorities for `Stream` and `SendStream`
> - Adds per-stream priority with `urgency` (0–7) and `incremental` (bool) fields to `SendStream`, defaulting to urgency 3 and incremental scheduling; exposes `SetPriority` on both `Stream` and `SendStream`.
> - Refactors [framer.go](https://github.com/quic-go/quic-go/pull/5774/files#diff-a97a2544cb1bf86661368aeb59921e0629ab259d2728c61715e856a7ab5c1f6f) to maintain 8 per-urgency scheduling buckets, each with a round-robin ringbuffer for incremental streams and a min-heap (by stream ID) for non-incremental streams.
> - Adds a generic min-heap in [internal/utils/minheap/minheap.go](https://github.com/quic-go/quic-go/pull/5774/files#diff-f90f568219ec63ba75fa4427da0b5c3466b9c1922eb9d0c03fb8c4880b303d99) used for non-incremental stream scheduling.
> - Retransmission queues are also split per urgency; if a stream's priority changes before a retransmission is dequeued, it is re-queued at the new urgency.
> - Stale queue entries from removed or reprioritized streams are discarded lazily at dequeue time rather than eagerly purged.
> - Behavioral Change: `SendStream.popStreamFrame` now returns `hasMoreData=false` when flow-control blocked, which prevents the framer from re-queuing the stream unnecessarily.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 718fc6c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->