### PR TITLE
packet_packer: remove stale size TODO

### DIFF
--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -306,12 +306,7 @@ func TestPack0RTTPacket(t *testing.T) {
 	tp.pnManager.EXPECT().PopPacketNumber(protocol.Encryption0RTT).Return(protocol.PacketNumber(0x42))
 	cf := ackhandler.Frame{Frame: &wire.MaxDataFrame{MaximumData: 0x1337}}
 	tp.framer.EXPECT().HasData().Return(true)
-	// TODO: check sizes
-	tp.framer.EXPECT().Append(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(fs []ackhandler.Frame, sf []ackhandler.StreamFrame, _ protocol.ByteCount, _ monotime.Time, _ protocol.Version) ([]ackhandler.Frame, []ackhandler.StreamFrame, protocol.ByteCount) {
-			return append(fs, cf), sf, cf.Frame.Length(protocol.Version1)
-		},
-	)
+	expectAppendFrames(tp.framer, []ackhandler.Frame{cf}, nil)
 	p, err := tp.packer.PackCoalescedPacket(false, protocol.MaxByteCount, monotime.Now(), protocol.Version1)
 	require.NoError(t, err)
 	require.NotNil(t, p)


### PR DESCRIPTION
  ## Summary

  Remove a stale size-check TODO from `TestPack0RTTPacket` and simplify the `framer.Append` mock.

  ## Background

  The TODO was originally placed between calls to `AppendControlFrames` and `AppendStreamFrames`. 
At that time, the packet packer was responsible for subtracting the size of the appended control frames before passing the remaining size to `AppendStreamFrames`.

  These methods were combined into `framer.Append` in #4801. The size accounting between control and stream frames is now an internal responsibility of the framer, so it no longer needs to be checked by the packet packer test.

  The custom mock can also be replaced with the existing `expectAppendFrames` helper, which produces the same result for this test while respecting the size limit passed to `framer.Append`.

  ## Changes

  - Remove the stale size-check TODO.
  - Replace the custom `framer.Append` mock with `expectAppendFrames`.

  Tested with:

  `go test . -run '^TestPack0RTTPacket$' -count=1`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale size TODO comment from `TestPack0RTTPacket` in packet packer tests
> Replaces an inline `gomock` `DoAndReturn` expectation in [packet_packer_test.go](https://github.com/quic-go/quic-go/pull/5777/files#diff-c38c7d6bd26d8bbb870e91c4f810876df3195073e00d5ec9b687e6b211933768) with a call to the shared `expectAppendFrames` helper, and removes the adjacent TODO about checking sizes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b405cfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->