### PR TITLE
avoid locking stream mutex when reading priorities in the framer

### DIFF
--- a/framer.go
+++ b/framer.go
@@ -32,12 +32,15 @@ type streamControlFrameGetter interface {
 	getControlFrame(monotime.Time) (_ ackhandler.Frame, ok, hasMore bool)
 }
 
-// streamQueueEntry identifies a queued generation of a stream.
+// streamQueueEntry captures the stream's generation when it is queued.
+// A mismatch with the current generation identifies an entry left behind by a priority change.
 type streamQueueEntry struct {
 	id         protocol.StreamID
 	generation uint32
 }
 
+// queuedStream tracks the latest generation added to a scheduling queue,
+// preventing duplicate and out-of-order notifications from queueing it again.
 type queuedStream struct {
 	streamFrameGetter
 	generation uint32
@@ -385,7 +388,7 @@ func (f *framer) getNextIncrementalStreamFrame(
 	}
 	entry := queue.PopFront()
 	str, ok := f.activeStreams[entry.id]
-	if !ok || str.generation != entry.generation {
+	if !ok {
 		return ackhandler.StreamFrame{}, nil
 	}
 	_, _, generation := str.priority()
@@ -412,13 +415,12 @@ func (f *framer) getNextNonIncrementalStreamFrame(
 	}
 	id, queuedGeneration := queue.Peek()
 	str, ok := f.activeStreams[id]
-	if !ok || str.generation != queuedGeneration {
+	if !ok {
 		queue.Pop()
 		return ackhandler.StreamFrame{}, nil
 	}
-
-	_, _, currentGeneration := str.priority()
-	if currentGeneration != queuedGeneration {
+	_, _, generation := str.priority()
+	if generation != queuedGeneration {
 		queue.Pop()
 		return ackhandler.StreamFrame{}, nil
 	}

--- a/framer_test.go
+++ b/framer_test.go
@@ -483,7 +483,7 @@ func TestFramerSchedulesReprioritizedStream(t *testing.T) {
 	updatedStr := NewMockStreamFrameGetter(gomock.NewController(t))
 	gomock.InOrder(
 		updatedStr.EXPECT().priority().Return(0, true, 0).Times(2),
-		updatedStr.EXPECT().priority().Return(2, false, 1).Times(2),
+		updatedStr.EXPECT().priority().Return(2, false, 1).Times(3),
 	)
 	remaining := 2
 	updatedStr.EXPECT().popStreamFrame(gomock.Any(), protocol.Version1).DoAndReturn(

--- a/send_stream.go
+++ b/send_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/quic-go/quic-go/internal/ackhandler"
@@ -13,6 +14,18 @@ import (
 )
 
 const defaultUrgency = 3
+
+func encodeStreamPriority(urgency int8, incremental bool, generation uint32) uint64 {
+	priorityValue := uint64(uint8(urgency)) | uint64(generation)<<32
+	if incremental {
+		priorityValue |= 1 << 8
+	}
+	return priorityValue
+}
+
+func decodeStreamPriority(priorityValue uint64) (urgency int8, incremental bool, generation uint32) {
+	return int8(priorityValue), uint8(priorityValue>>8) != 0, uint32(priorityValue >> 32)
+}
 
 // A SendStream is a unidirectional Send Stream.
 type SendStream struct {
@@ -59,10 +72,7 @@ type SendStream struct {
 	cancellationFlagged bool
 	completed           bool // set when this stream has been reported to the streamSender as completed
 
-	// priority
-	urgency            int8
-	incremental        bool
-	priorityGeneration uint32
+	priorityValue atomic.Uint64
 
 	writeChan chan struct{}
 	writeOnce chan struct{}
@@ -91,9 +101,8 @@ func newSendStream(
 		writeChan:             make(chan struct{}, 1),
 		writeOnce:             make(chan struct{}, 1), // cap: 1, to protect against concurrent use of Write
 		supportsResetStreamAt: supportsResetStreamAt,
-		urgency:               defaultUrgency,
-		incremental:           true,
 	}
+	s.priorityValue.Store(encodeStreamPriority(defaultUrgency, true, 0))
 	s.ctx, s.ctxCancel = context.WithCancelCause(ctx)
 	return s
 }
@@ -792,20 +801,18 @@ func (s *SendStream) reliableOffset() protocol.ByteCount {
 //
 // [RFC 9218]: https://www.rfc-editor.org/rfc/rfc9218.html
 func (s *SendStream) SetPriority(urgency int8, incremental bool) {
-	var changed bool
-	s.mutex.Lock()
 	urgency = max(0, min(urgency, 7)) // urgency must be between 0 and 7
-	if s.urgency != urgency || s.incremental != incremental {
-		s.urgency = urgency
-		s.incremental = incremental
-		s.priorityGeneration++
-		changed = true
+	// This use of the mutex only serializes concurrent SetPriority calls.
+	// priorityValue itself is atomic and doesn't need the mutex.
+	s.mutex.Lock()
+	oldUrgency, oldIncremental, generation := decodeStreamPriority(s.priorityValue.Load())
+	if oldUrgency == urgency && oldIncremental == incremental {
+		s.mutex.Unlock()
+		return
 	}
+	s.priorityValue.Store(encodeStreamPriority(urgency, incremental, generation+1))
 	s.mutex.Unlock()
-
-	if changed {
-		s.sender.updateStreamPriority(s.streamID)
-	}
+	s.sender.updateStreamPriority(s.streamID)
 }
 
 // The Context is canceled as soon as the write-side of the stream is closed.
@@ -853,10 +860,7 @@ func (s *SendStream) signalWrite() {
 }
 
 func (s *SendStream) priority() (urgency int8, incremental bool, generation uint32) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	return s.urgency, s.incremental, s.priorityGeneration
+	return decodeStreamPriority(s.priorityValue.Load())
 }
 
 type sendStreamAckHandler SendStream

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -65,17 +65,23 @@ func TestSendStreamPriorityGeneration(t *testing.T) {
 	str := newSendStream(context.Background(), streamID, mockSender, newTestStreamFlowControllerWithSendWindow(streamID, protocol.MaxByteCount), false)
 
 	str.SetPriority(defaultUrgency, true)
-	_, _, generation := str.priority()
+	urgency, incremental, generation := str.priority()
+	require.Equal(t, int8(defaultUrgency), urgency)
+	require.True(t, incremental)
 	require.Zero(t, generation)
 
 	mockSender.EXPECT().updateStreamPriority(streamID).Times(2)
 	str.SetPriority(2, false)
 	str.SetPriority(2, false)
-	_, _, generation = str.priority()
+	urgency, incremental, generation = str.priority()
+	require.Equal(t, int8(2), urgency)
+	require.False(t, incremental)
 	require.Equal(t, uint32(1), generation)
 
 	str.SetPriority(1, false)
-	_, _, generation = str.priority()
+	urgency, incremental, generation = str.priority()
+	require.Equal(t, int8(1), urgency)
+	require.False(t, incremental)
 	require.Equal(t, uint32(2), generation)
 }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Avoid locking stream mutex when reading priorities in the framer
- Consolidates `urgency`, `incremental`, and `priorityGeneration` fields in `SendStream` into a single `atomic.Uint64` via `encodeStreamPriority`/`decodeStreamPriority` helpers in [send_stream.go](https://github.com/quic-go/quic-go/pull/5781/files#diff-0683df4767cffeaa4b1127b3e6027900d06dac7973a80454782e810871af742e), making priority reads lock-free.
- Updates `SetPriority` to only notify the sender when priority actually changes, and to increment generation only on a real change.
- Updates `getNextIncrementalStreamFrame` and `getNextNonIncrementalStreamFrame` in [framer.go](https://github.com/quic-go/quic-go/pull/5781/files#diff-a97a2544cb1bf86661368aeb59921e0629ab259d2728c61715e856a7ab5c1f6f) to validate staleness via `str.priority()` (the atomic read) instead of a separately-stored `str.generation` field, removing the need to hold the stream mutex during scheduling.
- Behavioral Change: the framer now calls `str.priority()` one additional time per scheduling cycle for reprioritized streams, as reflected in updated test expectations in [framer_test.go](https://github.com/quic-go/quic-go/pull/5781/files#diff-44d4e5f3567272c5d38adad20085dc713b183d678b6d1832bd455ea97bf88d25).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27deca2.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stream priority changes to prevent stale queued entries from being processed.
  * Ensured priority updates are applied consistently during stream scheduling.
  * Reduced unnecessary sender notifications when priority values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->