### PR TITLE
offer both draft-09 and draft-07 of Reliable Stream Resets

### DIFF
--- a/internal/wire/transport_parameters.go
+++ b/internal/wire/transport_parameters.go
@@ -458,6 +458,8 @@ func (p *TransportParameters) Marshal(pers protocol.Perspective) []byte {
 	if p.EnableResetStreamAt {
 		b = quicvarint.Append(b, uint64(resetStreamAtParameterID))
 		b = quicvarint.Append(b, 0)
+		b = quicvarint.Append(b, uint64(legacyResetStreamAtParameterID))
+		b = quicvarint.Append(b, 0)
 	}
 	if p.MinAckDelay != nil {
 		b = p.marshalVarintParam(b, minAckDelayParameterID, uint64(*p.MinAckDelay/time.Microsecond))


### PR DESCRIPTION
originally introduced with #5158 then later changed with #5724

the problem is that Safari breaks with resetStreamAtParameterID (draft-9) only.
adding legacyResetStreamAtParameterID (draft-6/7) back fixes Safari again.

basically, #5724 caused a regression on Safari when used with webtransport-go

as far as I can tell, there's no harm in marshalling and sending both parameters

---

I also wanted to note that unmarshalling flow already exists and works properly for both draft-9 and draft-6/7:
```go
// transport_parameters.go:212
case resetStreamAtParameterID, legacyResetStreamAtParameterID:
	if paramLen != 0 {
		return fmt.Errorf("wrong length for reset_stream_at: %d (expected empty)", paramLen)
	}
	p.EnableResetStreamAt = true
```