### PR TITLE
http3: implement handling of RFC 9218 priority headers

### DIFF
--- a/http3/mock_datagram_stream_test.go
+++ b/http3/mock_datagram_stream_test.go
@@ -382,6 +382,42 @@ func (c *MockDatagramStreamSetDeadlineCall) DoAndReturn(f func(time.Time) error)
 	return c
 }
 
+// SetPriority mocks base method.
+func (m *MockDatagramStream) SetPriority(urgency int8, incremental bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPriority", urgency, incremental)
+}
+
+// SetPriority indicates an expected call of SetPriority.
+func (mr *MockDatagramStreamMockRecorder) SetPriority(urgency, incremental any) *MockDatagramStreamSetPriorityCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPriority", reflect.TypeOf((*MockDatagramStream)(nil).SetPriority), urgency, incremental)
+	return &MockDatagramStreamSetPriorityCall{Call: call}
+}
+
+// MockDatagramStreamSetPriorityCall wrap *gomock.Call
+type MockDatagramStreamSetPriorityCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockDatagramStreamSetPriorityCall) Return() *MockDatagramStreamSetPriorityCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockDatagramStreamSetPriorityCall) Do(f func(int8, bool)) *MockDatagramStreamSetPriorityCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockDatagramStreamSetPriorityCall) DoAndReturn(f func(int8, bool)) *MockDatagramStreamSetPriorityCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetReadDeadline mocks base method.
 func (m *MockDatagramStream) SetReadDeadline(arg0 time.Time) error {
 	m.ctrl.T.Helper()

--- a/http3/priority.go
+++ b/http3/priority.go
@@ -1,0 +1,44 @@
+package http3
+
+import "strings"
+
+const defaultPriorityUrgency int8 = 3
+
+// parsePriority parses the RFC 9218 Priority header field value. It only
+// recognizes the u and i parameters; malformed members return both defaults.
+func parsePriority(value string, defaultUrgency int8, defaultIncremental bool) (urgency int8, incremental bool) {
+	urgency, incremental = defaultUrgency, defaultIncremental
+	var inString, escapes bool
+	for i, start := 0, 0; i <= len(value); i++ {
+		switch {
+		case i == len(value) || !inString && value[i] == ',':
+			member, _, _ := strings.Cut(strings.TrimSpace(value[start:i]), ";")
+			start = i + 1
+			key, item, hasValue := strings.Cut(member, "=")
+			if key == "" || hasValue && item == "" {
+				return defaultUrgency, defaultIncremental
+			}
+			switch key {
+			case "u":
+				if hasValue && len(item) == 1 && item[0] >= '0' && item[0] <= '7' {
+					urgency = int8(item[0] - '0')
+				}
+			case "i":
+				if !hasValue || item == "?1" {
+					incremental = true
+				} else if item == "?0" {
+					incremental = false
+				}
+			}
+		case escapes && value[i] == '\\':
+			i++
+		case value[i] == '"':
+			inString = !inString
+			escapes = inString && (i == 0 || value[i-1] != '%')
+		}
+	}
+	if inString {
+		return defaultUrgency, defaultIncremental
+	}
+	return urgency, incremental
+}

--- a/http3/priority_test.go
+++ b/http3/priority_test.go
@@ -1,0 +1,86 @@
+package http3
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePriority(t *testing.T) {
+	// 6 is not a value that any of the test cases sets, so it's easy to spot an unmodified default
+	const defaultUrgency int8 = 6
+
+	tests := []struct {
+		name            string
+		value           string
+		wantUrgency     int8
+		wantIncremental bool
+	}{
+		{name: "empty", wantUrgency: defaultUrgency},
+		{name: "urgency", value: "u=0", wantUrgency: 0},
+		{name: "implicit incremental", value: "i", wantUrgency: defaultUrgency, wantIncremental: true},
+		{name: "explicit incremental", value: "i=?1", wantUrgency: defaultUrgency, wantIncremental: true},
+		{name: "urgency and non-incremental", value: "i=?0, u=4", wantUrgency: 4},
+		{name: "unknown fields", value: "some=data;someparam;u=fake, u=1;foo, i;bar", wantUrgency: 1, wantIncremental: true},
+		{name: "repeated fields", value: "u=1,i,u=5,i=?0", wantUrgency: 5},
+		{name: "wrong types", value: `u="ignored", i=1`, wantUrgency: defaultUrgency},
+		{name: "out of range urgency", value: "u=8", wantUrgency: defaultUrgency},
+		{name: "valid unknown SFV types", value: `a=(1 "two" ?1);x, b=:YWJj:, c=%"hello%20world", u=2`, wantUrgency: 2},
+		{name: "semicolon inside an extension value", value: `a="x;y";q=1, u=2`, wantUrgency: 2},
+		{name: "known fields inside extension values", value: `future="x\",u=0,i", u=5`, wantUrgency: 5},
+		{name: "backslash inside a display string", value: `future=%"x\", u=5`, wantUrgency: 5},
+		{name: "invalid member", value: "u=0, bad=", wantUrgency: defaultUrgency},
+		{name: "unterminated string", value: `u=1,i, invalid="`, wantUrgency: defaultUrgency},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			urgency, incremental := parsePriority(test.value, defaultUrgency, false)
+			require.Equal(t, test.wantUrgency, urgency)
+			require.Equal(t, test.wantIncremental, incremental)
+		})
+	}
+}
+
+func FuzzParsePriority(f *testing.F) {
+	for _, value := range []string{"", "u=0", "i=?0, u=7", `future="x,u=0", u=5`, `u=1, invalid="`} {
+		f.Add(value)
+	}
+	f.Fuzz(func(t *testing.T, value string) {
+		urgency, _ := parsePriority(value, defaultPriorityUrgency, false)
+		if urgency < 0 || urgency > 7 {
+			t.Fatalf("invalid urgency: %d", urgency)
+		}
+	})
+}
+
+func TestServerRequestPriority(t *testing.T) {
+	conn := &RawServerConn{}
+
+	urgency, incremental := conn.requestPriority(http.Header{})
+	require.Equal(t, defaultPriorityUrgency, urgency)
+	require.True(t, incremental)
+
+	header := http.Header{}
+	header.Set("Priority", "u=0")
+	urgency, incremental = conn.requestPriority(header)
+	require.Equal(t, int8(0), urgency)
+	require.False(t, incremental)
+	require.True(t, conn.priorityAware.Load())
+
+	urgency, incremental = conn.requestPriority(http.Header{})
+	require.Equal(t, defaultPriorityUrgency, urgency)
+	require.False(t, incremental)
+
+	header.Set("Priority", "i")
+	urgency, incremental = conn.requestPriority(header)
+	require.Equal(t, defaultPriorityUrgency, urgency)
+	require.True(t, incremental)
+
+	conn = &RawServerConn{}
+	header.Set("Priority", `u=0, invalid="`)
+	urgency, incremental = conn.requestPriority(header)
+	require.Equal(t, defaultPriorityUrgency, urgency)
+	require.False(t, incremental)
+	require.True(t, conn.priorityAware.Load())
+}

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -104,6 +104,7 @@ func TestResponseWriterInvalidStatus(t *testing.T) {
 func TestResponseWriterHeader(t *testing.T) {
 	rw := newTestResponseWriter(t)
 	rw.Header().Add("Content-Length", "42")
+	rw.Header().Set("Priority", "u=0")
 	rw.WriteHeader(http.StatusTeapot) // 418
 	// repeated WriteHeader calls are ignored
 	rw.WriteHeader(http.StatusInternalServerError)
@@ -117,6 +118,7 @@ func TestResponseWriterHeader(t *testing.T) {
 	fields := rw.DecodeHeaders(t, 0)
 	require.Equal(t, []string{"418"}, fields[":status"])
 	require.Equal(t, []string{"42"}, fields["content-length"])
+	require.Equal(t, []string{"u=0"}, fields["priority"])
 	require.Equal(t,
 		[]string{"foo=bar", `baz="lorem ipsum"`},
 		fields["set-cookie"],

--- a/http3/server_conn.go
+++ b/http3/server_conn.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/quic-go/qpack"
@@ -27,7 +29,8 @@ type RawServerConn struct {
 	requestHandler http.Handler
 	maxHeaderBytes int
 
-	decoder *qpack.Decoder
+	decoder       *qpack.Decoder
+	priorityAware atomic.Bool // whether the client sent an RFC 9218 priority signal
 
 	qlogger qlogwriter.Recorder
 	logger  *slog.Logger
@@ -180,6 +183,14 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 		req.Trailer = trailers
 		return nil
 	}, qlogger)
+
+	// We only use the client's priority for local scheduling.
+	// A Priority response header is only transmitted so that potential intermediaries can use it,
+	// it doesn't affect local scheduling.
+	// This mirrors the behavior of HTTP/2, see https://github.com/golang/go/issues/75500.
+	urgency, incremental := c.requestPriority(req.Header)
+	hstr.SetPriority(urgency, incremental)
+
 	body := newRequestBody(hstr, contentLength, connCtx, conn.ReceivedSettings(), conn.Settings)
 	req.Body = body
 
@@ -243,6 +254,15 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 	// If the EOF was read by the handler, CancelRead() is a no-op.
 	str.CancelRead(quic.StreamErrorCode(ErrCodeNoError))
 	str.Close()
+}
+
+func (c *RawServerConn) requestPriority(header http.Header) (int8, bool) {
+	values, ok := header["Priority"]
+	if !ok {
+		return defaultPriorityUrgency, !c.priorityAware.Load()
+	}
+	c.priorityAware.Store(true)
+	return parsePriority(strings.Join(values, ","), defaultPriorityUrgency, false)
 }
 
 func (c *RawServerConn) rejectWithHeaderFieldsTooLarge(str *stateTrackingStream) {

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -25,6 +25,7 @@ type datagramStream interface {
 	SetDeadline(time.Time) error
 	SetReadDeadline(time.Time) error
 	SetWriteDeadline(time.Time) error
+	SetPriority(urgency int8, incremental bool)
 	TryWriteAll([]byte) error
 	SendDatagram(b []byte) error
 	ReceiveDatagram(ctx context.Context) ([]byte, error)


### PR DESCRIPTION
This only looks at the clients and the server's `Priority` header. It does not yet parse the PRIORITY_UPDATE frame. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP/3 request priority support through the RFC 9218 `Priority` header.
  * Requests can specify urgency and incremental delivery preferences.
  * Requests without priority information use sensible defaults until priority signaling is detected.

* **Bug Fixes**
  * Improved handling of malformed, repeated, quoted, and escaped priority values.

* **Tests**
  * Added coverage for priority parsing, request handling, response headers, and scheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Implement RFC 9218 Priority header handling in the HTTP/3 server
> - Parses the `Priority` header (fields `u` for urgency 0–7 and `i` for incremental) per RFC 9218 in [http3/priority.go](https://github.com/quic-go/quic-go/pull/5783/files#diff-82e143ff4833958bbe26161c53b6fb1025db74193ef8fb295e5773298b253c86), with a default urgency of 3.
> - `RawServerConn.handleRequestStream` now calls `requestPriority` to derive per-request urgency and incremental values and applies them via `hstr.SetPriority`.
> - Before any `Priority` header is seen, incremental defaults to `true`; once a client sends a `Priority` header the connection is marked priority-aware and incremental defaults to `false` for subsequent requests without a header.
> - Extends the `datagramStream` interface with `SetPriority(urgency int8, incremental bool)` and adds corresponding mock support.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5507385.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->