### PR TITLE
feat: expose maximum datagram payload size

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -3039,19 +3039,37 @@ func (c *Conn) SendDatagram(p []byte) error {
 		return errors.New("datagram support disabled")
 	}
 
-	f := &wire.DatagramFrame{DataLenPresent: true}
-	// The payload size estimate is conservative.
-	// Under many circumstances we could send a few more bytes.
-	maxDataLen := min(
-		f.MaxDataLen(c.peerParams.MaxDatagramFrameSize, c.version),
-		protocol.ByteCount(c.maxPayloadSizeEstimate.Load()),
-	)
+	maxDataLen := c.maxDatagramPayloadSize()
 	if protocol.ByteCount(len(p)) > maxDataLen {
 		return &DatagramTooLargeError{MaxDatagramPayloadSize: int64(maxDataLen)}
 	}
+
+	f := &wire.DatagramFrame{DataLenPresent: true}
 	f.Data = make([]byte, len(p))
 	copy(f.Data, p)
 	return c.datagramQueue.Add(f)
+}
+
+// MaxDatagramPayloadSize returns the maximum payload size for a QUIC datagram
+// that can be sent at the current time.
+//
+// The value is conservative. Under many circumstances, a datagram with a
+// slightly larger payload might still fit into a packet. The value can change
+// as the path MTU changes.
+// It returns 0 if datagram support is not enabled by both endpoints.
+func (c *Conn) MaxDatagramPayloadSize() int64 {
+	if !c.supportsDatagrams() {
+		return 0
+	}
+	return int64(c.maxDatagramPayloadSize())
+}
+
+func (c *Conn) maxDatagramPayloadSize() protocol.ByteCount {
+	f := &wire.DatagramFrame{DataLenPresent: true}
+	return min(
+		f.MaxDataLen(c.peerParams.MaxDatagramFrameSize, c.version),
+		protocol.ByteCount(c.maxPayloadSizeEstimate.Load()),
+	)
 }
 
 // ReceiveDatagram gets a message received in a QUIC datagram, as specified in RFC 9221.

--- a/connection.go
+++ b/connection.go
@@ -1302,6 +1302,11 @@ func (c *Conn) handleShortHeaderPacket(
 		protocol.ByteCount(c.config.InitialPacketSize),
 		maxPacketSize,
 	)
+	// The new path might not support the old path's MTU. Since maxPayloadSizeEstimate
+	// only ever grows as MTU discovery confirms larger sizes work, it must be reset here
+	// too, or a datagram sized for the old path could be accepted and then fail to send
+	// on the new, smaller-MTU path.
+	c.maxPayloadSizeEstimate.Store(uint32(estimateMaxPayloadSize(protocol.ByteCount(c.config.InitialPacketSize))))
 	c.conn.ChangeRemoteAddr(p.remoteAddr, p.info)
 	return true, nil
 }
@@ -3056,7 +3061,7 @@ func (c *Conn) SendDatagram(p []byte) error {
 // The value is conservative. Under many circumstances, a datagram with a
 // slightly larger payload might still fit into a packet. The value can change
 // as the path MTU changes.
-// It returns 0 if datagram support is not enabled by both endpoints.
+// It returns 0 if the peer has not enabled datagram support.
 func (c *Conn) MaxDatagramPayloadSize() int64 {
 	if !c.supportsDatagrams() {
 		return 0

--- a/connection_test.go
+++ b/connection_test.go
@@ -3363,6 +3363,122 @@ func testConnectionPathValidation(t *testing.T, isNATRebinding bool) {
 	})
 }
 
+func TestConnectionMigrationResetsMaxPayloadSizeEstimate(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		unpacker := NewMockUnpacker(mockCtrl)
+		tc := newServerTestConnection(
+			t,
+			mockCtrl,
+			nil,
+			false,
+			connectionOptUnpacker(unpacker),
+			connectionOptHandshakeConfirmed(),
+			connectionOptRTT(time.Second),
+		)
+		require.NoError(t, tc.conn.handleTransportParameters(&wire.TransportParameters{MaxUDPPayloadSize: 1456}))
+
+		// Simulate MTU discovery having grown the estimate on the original path.
+		const inflatedEstimate = 1400
+		tc.conn.maxPayloadSizeEstimate.Store(inflatedEstimate)
+		initialEstimate := uint32(estimateMaxPayloadSize(protocol.ByteCount(tc.conn.config.InitialPacketSize)))
+		require.Less(t, initialEstimate, uint32(inflatedEstimate))
+
+		newRemoteAddr := &net.UDPAddr{IP: net.IPv4(192, 168, 1, 1), Port: 1234}
+		require.NotEqual(t, tc.remoteAddr, newRemoteAddr)
+
+		errChan := make(chan error, 1)
+		go func() { errChan <- tc.conn.run() }()
+
+		probeSent := make(chan struct{})
+		var pathChallenge *wire.PathChallengeFrame
+		// A non-probing (PING) frame arriving on a new address, as happens on NAT rebinding.
+		payload := []byte{1}
+		gomock.InOrder(
+			unpacker.EXPECT().UnpackShortHeader(gomock.Any(), gomock.Any()).Return(
+				protocol.PacketNumber(10), protocol.PacketNumberLen2, protocol.KeyPhaseZero, payload, nil,
+			),
+			tc.packer.EXPECT().PackPathProbePacket(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ protocol.ConnectionID, frames []ackhandler.Frame, _ protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
+					pathChallenge = frames[0].Frame.(*wire.PathChallengeFrame)
+					return shortHeaderPacket{IsPathProbePacket: true}, getPacketBuffer(), nil
+				},
+			),
+			tc.sendConn.EXPECT().WriteTo(gomock.Any(), newRemoteAddr, packetInfo{}).DoAndReturn(
+				func([]byte, net.Addr, packetInfo) error { close(probeSent); return nil },
+			),
+			tc.packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				shortHeaderPacket{}, errNothingToPack,
+			),
+		)
+		tc.conn.handlePacket(receivedPacket{
+			data:       make([]byte, 10),
+			buffer:     getPacketBuffer(),
+			remoteAddr: newRemoteAddr,
+			rcvTime:    monotime.Now(),
+		})
+
+		synctest.Wait()
+
+		select {
+		case <-probeSent:
+		case <-time.After(time.Second):
+			t.Fatal("timeout")
+		}
+
+		// The estimate must not drop until the path is actually validated and switched to.
+		require.Equal(t, uint32(inflatedEstimate), tc.conn.maxPayloadSizeEstimate.Load())
+
+		// Receive the matching PATH_RESPONSE on the new address: since the first packet on
+		// this address was already non-probing, this alone completes the migration.
+		migrated := make(chan struct{})
+		data, err := (&wire.PathResponseFrame{Data: pathChallenge.Data}).Append(nil, protocol.Version1)
+		require.NoError(t, err)
+		gomock.InOrder(
+			unpacker.EXPECT().UnpackShortHeader(gomock.Any(), gomock.Any()).Return(
+				protocol.PacketNumber(11), protocol.PacketNumberLen2, protocol.KeyPhaseZero, data, nil,
+			),
+			tc.sendConn.EXPECT().ChangeRemoteAddr(newRemoteAddr, gomock.Any()).Do(
+				func(net.Addr, packetInfo) { close(migrated) },
+			),
+			tc.packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				shortHeaderPacket{}, errNothingToPack,
+			).MaxTimes(1),
+		)
+		tc.conn.handlePacket(receivedPacket{
+			data:       make([]byte, 100),
+			buffer:     getPacketBuffer(),
+			remoteAddr: newRemoteAddr,
+			rcvTime:    monotime.Now(),
+		})
+
+		synctest.Wait()
+
+		select {
+		case <-migrated:
+		default:
+			t.Fatal("should have migrated")
+		}
+
+		// The new path might not support the old path's MTU: the estimate must have been
+		// reset, not carried over from the path we just migrated away from.
+		require.Equal(t, initialEstimate, tc.conn.maxPayloadSizeEstimate.Load())
+
+		// test teardown
+		tc.connRunner.EXPECT().Remove(gomock.Any()).AnyTimes()
+		tc.conn.destroy(nil)
+
+		synctest.Wait()
+
+		select {
+		case err := <-errChan:
+			require.NoError(t, err)
+		default:
+			t.Fatal("should have shut down")
+		}
+	})
+}
+
 func TestConnectionMigrationServer(t *testing.T) {
 	tc := newServerTestConnection(t, nil, nil, false)
 	_, err := tc.conn.AddPath(&Transport{})

--- a/integrationtests/self/datagram_test.go
+++ b/integrationtests/self/datagram_test.go
@@ -119,6 +119,7 @@ func TestDatagramSizeLimit(t *testing.T) {
 	var sizeErr *quic.DatagramTooLargeError
 	require.ErrorAs(t, err, &sizeErr)
 	require.InDelta(t, sizeErr.MaxDatagramPayloadSize, maxDatagramSize, 10)
+	require.Equal(t, sizeErr.MaxDatagramPayloadSize, clientConn.MaxDatagramPayloadSize())
 
 	require.NoError(t, clientConn.SendDatagram(bytes.Repeat([]byte("b"), int(sizeErr.MaxDatagramPayloadSize))))
 	require.Error(t, clientConn.SendDatagram(bytes.Repeat([]byte("c"), int(sizeErr.MaxDatagramPayloadSize+1))))


### PR DESCRIPTION
Closes #4259.

Adds `Conn.MaxDatagramPayloadSize()` so applications can discover the current conservative QUIC DATAGRAM payload limit. The method shares the calculation used by `SendDatagram`, and the integration test verifies that the reported limit is accepted while one byte more is rejected.

Tests:
- `go test ./...`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `MaxDatagramPayloadSize` API and reset estimate on path migration
> - Adds an exported `MaxDatagramPayloadSize` method to query the current datagram payload limit, returning zero when datagrams are unavailable
> - Centralizes the conservative size limit calculation in a new internal `maxDatagramPayloadSize` helper used by `SendDatagram`
> - Resets the payload size estimate to the initial packet-size estimate during both client and server path migrations in [connection.go](https://github.com/quic-go/quic-go/pull/5784/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7)
> - Adds tests in [connection_test.go](https://github.com/quic-go/quic-go/pull/5784/files#diff-b490092874a7d23daa711d51e772d0e7196b4337067351af81b448c6901ce377) and [integrationtests/self/datagram_test.go](https://github.com/quic-go/quic-go/pull/5784/files#diff-dcd6bfe78bf00f3b683ab9cd006bed2a3cea29b31efbacf249706a138c802bfb) to verify the new API and migration resets
> - Behavioral Change: Path migration now resets the datagram payload size estimate instead of carrying over the previous path's grown estimate
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3ca78a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API to retrieve the current maximum supported datagram payload size.
  * The API reports no available size when datagram support is not enabled.

* **Bug Fixes**
  * Corrected datagram size estimation after connection path migration, preventing payloads sized for the previous path from being accepted when the new path supports a smaller size.
  * Improved consistency between reported datagram limits and datagram-too-large errors.
  * Ensured datagram size limits update correctly after both client- and server-side path changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->