### PR TITLE
probe for the largest supported receive and send buffer size

### DIFF
--- a/sys_conn_buffers.go
+++ b/sys_conn_buffers.go
@@ -54,6 +54,15 @@ func setReceiveBuffer(c net.PacketConn) error {
 			return fmt.Errorf("failed to determine receive buffer size: %w", err)
 		}
 	}
+	if err == nil && newSize < protocol.DesiredReceiveBufferSize {
+		// Some kernels (e.g. OpenBSD, Darwin) reject sizes exceeding their
+		// limit outright instead of clamping. Probe for the largest size the
+		// kernel accepts.
+		newSize = largestBufferSize(newSize, protocol.DesiredReceiveBufferSize,
+			conn.SetReadBuffer,
+			func() (int, error) { return inspectReadBuffer(syscallConn) },
+		)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to determine receive buffer size: %w", err)
 	}

--- a/sys_conn_buffers.go
+++ b/sys_conn_buffers.go
@@ -58,7 +58,7 @@ func setReceiveBuffer(c net.PacketConn) error {
 		// Some kernels (e.g. OpenBSD, Darwin) reject sizes exceeding their
 		// limit outright instead of clamping. Probe for the largest size the
 		// kernel accepts.
-		newSize = largestBufferSize(newSize, protocol.DesiredReceiveBufferSize,
+		newSize, err = largestBufferSize(newSize, protocol.DesiredReceiveBufferSize,
 			conn.SetReadBuffer,
 			func() (int, error) { return inspectReadBuffer(syscallConn) },
 		)

--- a/sys_conn_buffers_common.go
+++ b/sys_conn_buffers_common.go
@@ -8,9 +8,9 @@ package quic
 // its (much smaller) default size.
 // Success is verified by reading the size back, not by the error returned from
 // setting it: Linux, for example, silently clamps instead of failing.
-func largestBufferSize(current, desired int, set func(int) error, inspect func() (int, error)) int {
+func largestBufferSize(current, desired int, set func(int) error, inspect func() (int, error)) (int, error) {
 	if desired <= current {
-		return current
+		return current, nil
 	}
 	known := current // largest size read back after a successful set
 	// Invariant: lo took effect (or is the starting size), hi didn't.
@@ -20,7 +20,7 @@ func largestBufferSize(current, desired int, set func(int) error, inspect func()
 		_ = set(mid)
 		size, err := inspect()
 		if err != nil {
-			return known
+			return known, err
 		}
 		if size >= mid {
 			lo, known = mid, size
@@ -28,5 +28,5 @@ func largestBufferSize(current, desired int, set func(int) error, inspect func()
 			hi = mid
 		}
 	}
-	return known
+	return known, nil
 }

--- a/sys_conn_buffers_common.go
+++ b/sys_conn_buffers_common.go
@@ -1,0 +1,32 @@
+package quic
+
+// largestBufferSize finds the largest socket buffer size in (current, desired)
+// that the kernel accepts, and leaves the socket buffer set to it.
+// It is called after an attempt to set desired directly didn't take effect.
+// Some kernels (e.g. OpenBSD, Darwin) reject requests exceeding their limit
+// outright instead of clamping, so without probing the buffer would stay at
+// its (much smaller) default size.
+// Success is verified by reading the size back, not by the error returned from
+// setting it: Linux, for example, silently clamps instead of failing.
+func largestBufferSize(current, desired int, set func(int) error, inspect func() (int, error)) int {
+	if desired <= current {
+		return current
+	}
+	known := current // largest size read back after a successful set
+	// Invariant: lo took effect (or is the starting size), hi didn't.
+	lo, hi := current, desired
+	for hi-lo > 1 {
+		mid := lo + (hi-lo)/2
+		_ = set(mid)
+		size, err := inspect()
+		if err != nil {
+			return known
+		}
+		if size >= mid {
+			lo, known = mid, size
+		} else {
+			hi = mid
+		}
+	}
+	return known
+}

--- a/sys_conn_buffers_common_test.go
+++ b/sys_conn_buffers_common_test.go
@@ -42,7 +42,8 @@ func TestLargestBufferSizeFailAtomicKernel(t *testing.T) {
 	// OpenBSD 7.9: default 41600, SB_MAX caps buffers at exactly 2 MiB,
 	// larger requests fail with ENOBUFS. quic-go desires 7 MiB.
 	k := &failAtomicKernel{cap: 2 << 20, size: 41600}
-	got := largestBufferSize(41600, 7<<20, k.set, k.inspect)
+	got, err := largestBufferSize(41600, 7<<20, k.set, k.inspect)
+	require.NoError(t, err)
 	require.Equal(t, 2<<20, got)
 	require.Equal(t, 2<<20, k.size, "socket should be left at the discovered size")
 }
@@ -51,21 +52,27 @@ func TestLargestBufferSizeClampingKernel(t *testing.T) {
 	// Linux with a low rmem_max: sets succeed but silently clamp, so the
 	// search must rely on reading the value back, not on the set error.
 	k := &clampingKernel{cap: 416 << 10, size: 208 << 10}
-	got := largestBufferSize(208<<10, 7<<20, k.set, k.inspect)
+	got, err := largestBufferSize(208<<10, 7<<20, k.set, k.inspect)
+	require.NoError(t, err)
 	require.Equal(t, 416<<10, got)
 	require.Equal(t, 416<<10, k.size)
 }
 
 func TestLargestBufferSizeNothingToGain(t *testing.T) {
 	k := &failAtomicKernel{cap: 2 << 20, size: 2 << 20}
-	require.Equal(t, 2<<20, largestBufferSize(2<<20, 2<<20, k.set, k.inspect))
-	require.Equal(t, 3<<20, largestBufferSize(3<<20, 2<<20, k.set, k.inspect),
-		"desired below current should return current untouched")
+	got, err := largestBufferSize(2<<20, 2<<20, k.set, k.inspect)
+	require.NoError(t, err)
+	require.Equal(t, 2<<20, got)
+	got, err = largestBufferSize(3<<20, 2<<20, k.set, k.inspect)
+	require.NoError(t, err)
+	require.Equal(t, 3<<20, got, "desired below current should return current untouched")
 }
 
 func TestLargestBufferSizeInspectFailure(t *testing.T) {
-	set := func(int) error { return nil }
-	inspect := func() (int, error) { return 0, errors.New("not supported") }
-	require.Equal(t, 41600, largestBufferSize(41600, 7<<20, set, inspect),
-		"unverifiable probing should report the last known size")
+	// If inspection fails after a set may have changed the socket, the
+	// probed size is unverifiable and the error must be propagated.
+	k := &failAtomicKernel{cap: 2 << 20, size: 41600}
+	inspectErr := errors.New("not supported")
+	_, err := largestBufferSize(41600, 7<<20, k.set, func() (int, error) { return 0, inspectErr })
+	require.ErrorIs(t, err, inspectErr)
 }

--- a/sys_conn_buffers_common_test.go
+++ b/sys_conn_buffers_common_test.go
@@ -1,0 +1,71 @@
+package quic
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// failAtomicKernel models kernels like OpenBSD and Darwin: setting a buffer
+// size above the cap fails outright, leaving the previous value in place.
+type failAtomicKernel struct {
+	cap  int
+	size int
+}
+
+func (k *failAtomicKernel) set(n int) error {
+	if n > k.cap {
+		return errors.New("no buffer space available")
+	}
+	k.size = n
+	return nil
+}
+
+func (k *failAtomicKernel) inspect() (int, error) { return k.size, nil }
+
+// clampingKernel models Linux: setting always succeeds, but the value is
+// silently clamped to the cap.
+type clampingKernel struct {
+	cap  int
+	size int
+}
+
+func (k *clampingKernel) set(n int) error {
+	k.size = min(n, k.cap)
+	return nil
+}
+
+func (k *clampingKernel) inspect() (int, error) { return k.size, nil }
+
+func TestLargestBufferSizeFailAtomicKernel(t *testing.T) {
+	// OpenBSD 7.9: default 41600, SB_MAX caps buffers at exactly 2 MiB,
+	// larger requests fail with ENOBUFS. quic-go desires 7 MiB.
+	k := &failAtomicKernel{cap: 2 << 20, size: 41600}
+	got := largestBufferSize(41600, 7<<20, k.set, k.inspect)
+	require.Equal(t, 2<<20, got)
+	require.Equal(t, 2<<20, k.size, "socket should be left at the discovered size")
+}
+
+func TestLargestBufferSizeClampingKernel(t *testing.T) {
+	// Linux with a low rmem_max: sets succeed but silently clamp, so the
+	// search must rely on reading the value back, not on the set error.
+	k := &clampingKernel{cap: 416 << 10, size: 208 << 10}
+	got := largestBufferSize(208<<10, 7<<20, k.set, k.inspect)
+	require.Equal(t, 416<<10, got)
+	require.Equal(t, 416<<10, k.size)
+}
+
+func TestLargestBufferSizeNothingToGain(t *testing.T) {
+	k := &failAtomicKernel{cap: 2 << 20, size: 2 << 20}
+	require.Equal(t, 2<<20, largestBufferSize(2<<20, 2<<20, k.set, k.inspect))
+	require.Equal(t, 3<<20, largestBufferSize(3<<20, 2<<20, k.set, k.inspect),
+		"desired below current should return current untouched")
+}
+
+func TestLargestBufferSizeInspectFailure(t *testing.T) {
+	set := func(int) error { return nil }
+	inspect := func() (int, error) { return 0, errors.New("not supported") }
+	require.Equal(t, 41600, largestBufferSize(41600, 7<<20, set, inspect),
+		"unverifiable probing should report the last known size")
+}

--- a/sys_conn_buffers_write.go
+++ b/sys_conn_buffers_write.go
@@ -56,6 +56,15 @@ func setSendBuffer(c net.PacketConn) error {
 			return fmt.Errorf("failed to determine send buffer size: %w", err)
 		}
 	}
+	if err == nil && newSize < protocol.DesiredSendBufferSize {
+		// Some kernels (e.g. OpenBSD, Darwin) reject sizes exceeding their
+		// limit outright instead of clamping. Probe for the largest size the
+		// kernel accepts.
+		newSize = largestBufferSize(newSize, protocol.DesiredSendBufferSize,
+			conn.SetWriteBuffer,
+			func() (int, error) { return inspectWriteBuffer(syscallConn) },
+		)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to determine send buffer size: %w", err)
 	}

--- a/sys_conn_buffers_write.go
+++ b/sys_conn_buffers_write.go
@@ -60,7 +60,7 @@ func setSendBuffer(c net.PacketConn) error {
 		// Some kernels (e.g. OpenBSD, Darwin) reject sizes exceeding their
 		// limit outright instead of clamping. Probe for the largest size the
 		// kernel accepts.
-		newSize = largestBufferSize(newSize, protocol.DesiredSendBufferSize,
+		newSize, err = largestBufferSize(newSize, protocol.DesiredSendBufferSize,
 			conn.SetWriteBuffer,
 			func() (int, error) { return inspectWriteBuffer(syscallConn) },
 		)

--- a/sys_conn_no_oob.go
+++ b/sys_conn_no_oob.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !linux && !freebsd && !windows
+//go:build !darwin && !linux && !freebsd && !windows && !openbsd
 
 package quic
 

--- a/sys_conn_openbsd.go
+++ b/sys_conn_openbsd.go
@@ -1,0 +1,43 @@
+//go:build openbsd
+
+package quic
+
+import (
+	"net"
+	"net/netip"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func newConn(c net.PacketConn, supportsDF bool) (*basicConn, error) {
+	return &basicConn{PacketConn: c, supportsDF: supportsDF}, nil
+}
+
+func inspectReadBuffer(c syscall.RawConn) (int, error) {
+	var size int
+	var serr error
+	if err := c.Control(func(fd uintptr) {
+		size, serr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUF)
+	}); err != nil {
+		return 0, err
+	}
+	return size, serr
+}
+
+func inspectWriteBuffer(c syscall.RawConn) (int, error) {
+	var size int
+	var serr error
+	if err := c.Control(func(fd uintptr) {
+		size, serr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUF)
+	}); err != nil {
+		return 0, err
+	}
+	return size, serr
+}
+
+type packetInfo struct {
+	addr netip.Addr
+}
+
+func (i *packetInfo) OOB() []byte { return nil }


### PR DESCRIPTION
Addresses #3476.

Some kernels reject `SO_RCVBUF` / `SO_SNDBUF` requests exceeding their limit outright instead of clamping, leaving the buffer at its (much smaller) default. `setReceiveBuffer` ignores the `SetReadBuffer` error and verifies via readback — correct on Linux, where oversized requests clamp to `rmem_max`, but on fail-atomic kernels the socket silently stays at the default.

Measured on OpenBSD 7.9/amd64: the kernel caps both buffer directions at exactly 2,097,152 bytes (`SB_MAX`, compile-time); larger requests fail with `ENOBUFS` and keep the previous value. Defaults are 41,600 B receive / 9,216 B send — so quic-go currently runs at ~41 kB receive and ~9 kB send there, with the OS willing to grant 2 MB of each.

This PR:

1. **Probes for the largest size the kernel accepts** when the desired size didn't take effect (after the `RCVBUFFORCE` attempt on Linux): a binary search verified by reading the value back, so Linux's silent clamping is handled and Linux/Windows behavior is unchanged. The helper lives in a separate file so the `go:generate`'d send-buffer twin shares it. Unit tests cover fail-atomic kernels, silently-clamping kernels, and inspection failure.
2. **Implements `inspectReadBuffer` / `inspectWriteBuffer` on OpenBSD** (same `GetsockoptInt` pattern as FreeBSD/Windows). Previously the stubs returned 0, which is why the warning on OpenBSD reported the fabricated "got 0 kiB".

Validated on OpenBSD 7.9 (no OpenBSD CI exists, so measurements below are from a clean OpenBSD 7.9/amd64 VM, Go 1.26.5):

- before: `failed to increase receive buffer size (wanted: 7168 kiB, got 0 kiB)` — socket left at 41,600 B
- after: `failed to sufficiently increase receive buffer size (was: 40 kiB, wanted: 7168 kiB, got: 2048 kiB)` — socket at exactly 2,097,152 B

To be clear about intent: this does **not** silence the buffer warning. On OpenBSD it still fires — now with accurate numbers — since 2 MB remains below the desired size. The change just stops leaving the OS maximum on the table. The same mechanism should help other fail-atomic platforms, e.g. Darwin at `kern.ipc.maxsockbuf` (#5018).

Happy to also add an OpenBSD section to the [UDP Buffer Sizes wiki page](https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes) (`SB_MAX` is compile-time; there is no sysctl to raise it).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Probe for largest supported socket receive and send buffer size via binary search
> - When `setReceiveBuffer` or `setSendBuffer` successfully sets a buffer but the result is below the desired size, a binary search is now performed between the current and desired sizes to find the largest value the kernel will accept.
> - The search is implemented in a new `largestBufferSize` helper in [sys_conn_buffers_common.go](https://github.com/quic-go/quic-go/pull/5785/files#diff-f5c8486c5f6099d81250f0d98e337f074ddb414e2e65b9b27a5d6b82cf376274), which uses a setter and an inspector (via `RawConn.Control` getsockopt) to determine the effective buffer size after each attempt.
> - Adds OpenBSD-specific implementations of `inspectReadBuffer` and `inspectWriteBuffer` in [sys_conn_openbsd.go](https://github.com/quic-go/quic-go/pull/5785/files#diff-d425a765b802e8a32d5adef3ca590c69699e5deafca3727593092f51bf3ffafa), along with a stub `newConn` and `packetInfo` to support the platform.
> - The build constraint in [sys_conn_no_oob.go](https://github.com/quic-go/quic-go/pull/5785/files#diff-e5560981ca2a90c26bde7300a04ea096bc86dc7640148ce3a9c17e5a3b2bbe51) is updated to exclude OpenBSD now that it has its own file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b84d824.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added connection support for OpenBSD.
  - Improved socket buffer sizing to identify the largest value accepted by the operating system when requested sizes are capped or rejected.
  - Applied the improved sizing behavior to both receive and send buffers.

- **Bug Fixes**
  - Prevented buffer configuration from settling below the requested size when larger values are supported.

- **Tests**
  - Added coverage for capped, clamped, already-sufficient, and inspection-failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->