### PR TITLE
stop using deprecated net.Error.Temporary in the transport's read loop

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -527,18 +527,17 @@ var setBufferWarningOnce sync.Once
 func (t *Transport) listen(conn rawConn) {
 	for {
 		p, err := conn.ReadPacket()
-		//nolint:staticcheck // SA1019 ignore this!
-		// TODO: This code is used to ignore wsa errors on Windows.
-		// Since net.Error.Temporary is deprecated as of Go 1.18, we should find a better solution.
-		// See https://github.com/quic-go/quic-go/issues/1737 for details.
-		if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
+		// Shutting down the transport wakes up this loop by setting a read deadline on the
+		// conn (see Transport.Close and maybeStopListening).
+		// Timeout errors must therefore not close the transport.
+		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
 			t.mutex.Lock()
 			closed := t.closeErr != nil
 			t.mutex.Unlock()
 			if closed {
 				return
 			}
-			t.logger.Debugf("Temporary error reading from conn: %w", err)
+			t.logger.Debugf("Timeout error reading from conn: %s", err)
 			continue
 		}
 		if err != nil {

--- a/transport_test.go
+++ b/transport_test.go
@@ -46,6 +46,13 @@ func (c *mockPacketConn) SetDeadline(t time.Time) error                      { r
 func (c *mockPacketConn) SetReadDeadline(t time.Time) error                  { return nil }
 func (c *mockPacketConn) SetWriteDeadline(t time.Time) error                 { return nil }
 
+// a net.Error that is temporary, but not a timeout
+type temporaryNetError struct{}
+
+func (temporaryNetError) Error() string   { return "temporary error" }
+func (temporaryNetError) Temporary() bool { return true }
+func (temporaryNetError) Timeout() bool   { return false }
+
 type mockPacketHandler struct {
 	packets     chan<- receivedPacket
 	destruction chan<- error
@@ -173,14 +180,14 @@ func TestTransportErrFromConn(t *testing.T) {
 		ph := &mockPacketHandler{destruction: errChan}
 		(*packetHandlerMap)(&tr).Add(protocol.ParseConnectionID([]byte{1, 2, 3, 4}), ph)
 
-		// temporary errors don't lead to a shutdown...
-		var tempErr deadlineError
-		require.True(t, tempErr.Temporary())
-		readErrChan <- tempErr
+		// timeout errors don't lead to a shutdown...
+		var timeoutErr deadlineError
+		require.True(t, timeoutErr.Timeout())
+		readErrChan <- timeoutErr
 		// don't expect any calls to phm.Close
 		synctest.Wait()
 
-		// ...but non-temporary errors do
+		// ...but other errors do
 		readErrChan <- errors.New("read failed")
 		synctest.Wait()
 
@@ -193,6 +200,41 @@ func TestTransportErrFromConn(t *testing.T) {
 
 		_, err := tr.Listen(&tls.Config{}, nil)
 		require.ErrorIs(t, err, ErrTransportClosed)
+	})
+}
+
+func TestTransportTemporaryErrFromConn(t *testing.T) {
+	t.Setenv("QUIC_GO_DISABLE_RECEIVE_BUFFER_WARNING", "true")
+
+	synctest.Test(t, func(t *testing.T) {
+		readErrChan := make(chan error, 1)
+		tr := Transport{
+			Conn: &mockPacketConn{
+				readErrs:  readErrChan,
+				localAddr: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234},
+			},
+		}
+		defer tr.Close()
+		tr.init(true)
+
+		errChan := make(chan error, 1)
+		ph := &mockPacketHandler{destruction: errChan}
+		(*packetHandlerMap)(&tr).Add(protocol.ParseConnectionID([]byte{1, 2, 3, 4}), ph)
+
+		// temporary errors that are not timeouts close the transport
+		var tempErr temporaryNetError
+		require.True(t, tempErr.Temporary())
+		require.False(t, tempErr.Timeout())
+		readErrChan <- tempErr
+		synctest.Wait()
+
+		select {
+		case err := <-errChan:
+			require.ErrorIs(t, err, ErrTransportClosed)
+			require.ErrorIs(t, err, tempErr)
+		case <-time.After(time.Second):
+			t.Fatal("timeout")
+		}
 	})
 }
 


### PR DESCRIPTION
Removes the deprecated `net.Error.Temporary()` check from the transport's read loop, resolving the TODO that points at #1737.

The check was added (#2806) to tolerate asynchronous ICMP errors that Windows surfaces on UDP reads. Two things make it obsolete:

1. It never matched the `WSAENETRESET` error reported in #1737. On Windows, `syscall.Errno.Temporary()` only covers `EINTR`, `EMFILE` and timeouts, and `net.OpError.Temporary()` only special-cases `accept` — in every Go version from 1.15 through master. That's consistent with it being called a "partial fix" at the time, and with the downstream reports that kept coming in afterwards.
2. Since Go 1.25, the standard library disables both `SIO_UDP_CONNRESET` (Go 1.4, golang/go#5834) and `SIO_UDP_NETRESET` (golang/go#68614, https://go-review.googlesource.com/c/go/+/601397) on UDP sockets, so Windows no longer reports these errors at all. This module already requires `go 1.25.0`.

Timeout errors still must not close the transport: `Transport.Close` wakes up the read loop by setting a read deadline on the conn (`maybeStopListening`), and callers may set read deadlines on the conn they pass in. The loop now checks `net.Error.Timeout()` directly instead of relying on `Temporary()` covering timeouts.

Behavior change: an error that reports `Temporary() == true` but `Timeout() == false` from a caller-supplied `net.PacketConn` now closes the transport instead of being skipped. A new test pins this. No error returned by stdlib UDP reads on Go ≥ 1.25 falls into that category: on Unix, `Errno.Temporary()` additionally covers `EINTR`, `EMFILE` and `ENFILE`, but `EMFILE`/`ENFILE` are only returned by fd-creating calls, and `EINTR` is only returned by blocking calls — the runtime issues `recvmsg`/`recvmmsg` on a non-blocking fd after the poller reports readiness, and x/net retries `EAGAIN` internally.

Also fixes the `%w` verb in the accompanying `Debugf` call (`%w` is only handled by `fmt.Errorf`; it rendered as `%!w(...)`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transport stability when network timeouts occur during active connections.
  * Timeout errors now allow continued communication instead of unnecessarily closing the transport.
  * Non-timeout network errors continue to close the transport and report the original error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop treating non-timeout temporary errors as ignorable in `Transport.listen`
> - Replaces the `net.Error.Temporary()` check (deprecated) with `net.Error.Timeout()` in the read loop of [transport.go](https://github.com/quic-go/quic-go/pull/5786/files#diff-5982a4ca350449c8a5deba675bc4bc4bb0f1823c45e6c7ba0076cc6b159fef8f); only timeout errors are now silently ignored.
> - The motivation is that `Temporary()` is deprecated in Go and its semantics were too broad — non-timeout temporary errors now close the transport instead of being skipped.
> - Behavioral Change: temporary errors that are not timeouts will now shut down the transport, where previously they were ignored. The debug log message wording also changes from "Temporary error" to "Timeout error".
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c39eb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->