### PR TITLE
http3: add support for handling RFC 9218 PRIORITY_UPDATE frames

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -202,6 +202,10 @@ func (c *ClientConn) handleControlStream(str *quic.ReceiveStream, fp *frameParse
 	for {
 		f, err := fp.ParseNext(c.qlogger)
 		if err != nil {
+			if errors.Is(err, errPriorityUpdateForPush) {
+				c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
+				return
+			}
 			var serr *quic.StreamError
 			if err == io.EOF || errors.As(err, &serr) {
 				c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeClosedCriticalStream), "")

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -256,9 +256,7 @@ func (c *rawConn) handleControlStream(str *quic.ReceiveStream) {
 		})
 	}
 
-	if c.controlStrHandler != nil {
-		c.controlStrHandler(str, fp)
-	}
+	c.controlStrHandler(str, fp)
 }
 
 func (c *rawConn) sendDatagram(streamID quic.StreamID, b []byte) error {

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -123,6 +123,16 @@ func (c *rawConn) TrackStream(str *quic.Stream) *stateTrackingStream {
 	return hstr
 }
 
+func (c *rawConn) UpdateStreamPriority(id quic.StreamID, urgency int8, incremental bool) {
+	c.streamMx.Lock()
+	str := c.streams[id]
+	c.streamMx.Unlock()
+	// A PRIORITY_UPDATE can arrive before its request stream. We deliberately ignore such reordered frames.
+	if str != nil {
+		str.SetPriority(urgency, incremental)
+	}
+}
+
 func (c *rawConn) RemoteAddr() net.Addr {
 	return c.conn.RemoteAddr()
 }
@@ -206,6 +216,10 @@ func (c *rawConn) handleControlStream(str *quic.ReceiveStream) {
 	fp := &frameParser{closeConn: c.conn.CloseWithError, r: str, streamID: str.StreamID()}
 	f, err := fp.ParseNext(c.qlogger)
 	if err != nil {
+		if errors.Is(err, errPriorityUpdateForPush) {
+			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeMissingSettings), "")
+			return
+		}
 		var serr *quic.StreamError
 		if err == io.EOF || errors.As(err, &serr) {
 			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeClosedCriticalStream), "")

--- a/http3/conn_test.go
+++ b/http3/conn_test.go
@@ -16,11 +16,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func nopControlStrHandler(*quic.ReceiveStream, *frameParser) {}
+
 func TestConnReceiveSettings(t *testing.T) {
 	var eventRecorder events.Recorder
 	clientConn, serverConn := newConnPair(t, withServerRecorder(&eventRecorder))
 
-	conn := newRawConn(serverConn, false, nil, nil, &eventRecorder, nil)
+	conn := newRawConn(serverConn, false, nil, nopControlStrHandler, &eventRecorder, nil)
 	b := quicvarint.Append(nil, streamTypeControlStream)
 	sf := &settingsFrame{
 		MaxFieldSectionSize: 1234,
@@ -89,7 +91,7 @@ func TestConnRejectDuplicateStreams(t *testing.T) {
 func testConnRejectDuplicateStreams(t *testing.T, typ uint64) {
 	clientConn, serverConn := newConnPair(t)
 
-	conn := newRawConn(serverConn, false, nil, nil, nil, nil)
+	conn := newRawConn(serverConn, false, nil, nopControlStrHandler, nil, nil)
 	b := quicvarint.Append(nil, typ)
 	if typ == streamTypeControlStream {
 		b = (&settingsFrame{}).Append(b)
@@ -140,7 +142,7 @@ func testConnRejectDuplicateStreams(t *testing.T, typ uint64) {
 func TestConnResetUnknownUniStream(t *testing.T) {
 	clientConn, serverConn := newConnPair(t)
 
-	conn := newRawConn(serverConn, false, nil, nil, nil, nil)
+	conn := newRawConn(serverConn, false, nil, nopControlStrHandler, nil, nil)
 	buf := bytes.NewBuffer(quicvarint.Append(nil, 0x1337))
 	str, err := clientConn.OpenUniStream()
 	require.NoError(t, err)
@@ -192,7 +194,7 @@ func TestConnControlStreamFailures(t *testing.T) {
 func testConnControlStreamFailures(t *testing.T, data []byte, readErr error, expectedErr ErrCode) {
 	clientConn, serverConn := newConnPair(t)
 
-	conn := newRawConn(clientConn, false, nil, nil, nil, nil)
+	conn := newRawConn(clientConn, false, nil, nopControlStrHandler, nil, nil)
 	controlStr, err := serverConn.OpenUniStream()
 	require.NoError(t, err)
 	_, err = controlStr.Write(quicvarint.Append(nil, streamTypeControlStream))
@@ -240,19 +242,10 @@ func testConnControlStreamFailures(t *testing.T, data []byte, readErr error, exp
 }
 
 func TestConnControlStreamHandler(t *testing.T) {
-	t.Run("with handler", func(t *testing.T) { testConnControlStreamHandler(t, true) })
-	t.Run("without handler", func(t *testing.T) { testConnControlStreamHandler(t, false) })
-}
-
-func testConnControlStreamHandler(t *testing.T, useHandler bool) {
 	localConn, peerConn := newConnPair(t)
 
 	handlerCalled := make(chan struct{})
-	var controlStrHandler func(*quic.ReceiveStream, *frameParser)
-	if useHandler {
-		controlStrHandler = func(*quic.ReceiveStream, *frameParser) { close(handlerCalled) }
-	}
-	conn := newRawConn(localConn, false, nil, controlStrHandler, nil, nil)
+	conn := newRawConn(localConn, false, nil, func(*quic.ReceiveStream, *frameParser) { close(handlerCalled) }, nil, nil)
 
 	b := quicvarint.Append(nil, streamTypeControlStream)
 	b = (&settingsFrame{}).Append(b)
@@ -266,29 +259,17 @@ func testConnControlStreamHandler(t *testing.T, useHandler bool) {
 	localStr, err := localConn.AcceptUniStream(ctx)
 	require.NoError(t, err)
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		conn.handleUnidirectionalStream(localStr, false)
-	}()
+	go conn.handleUnidirectionalStream(localStr, false)
 
 	select {
 	case <-conn.ReceivedSettings():
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for settings")
 	}
-	if useHandler {
-		select {
-		case <-handlerCalled:
-		case <-time.After(time.Second):
-			t.Fatal("timeout waiting for handler to be called")
-		}
-	} else {
-		select {
-		case <-done:
-		case <-time.After(time.Second):
-			t.Fatal("timeout waiting for handler to return")
-		}
+	select {
+	case <-handlerCalled:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for handler to be called")
 	}
 }
 
@@ -304,7 +285,7 @@ func TestConnRejectPushStream(t *testing.T) {
 func testConnRejectPushStream(t *testing.T, isServer bool, expectedErr ErrCode) {
 	localConn, peerConn := newConnPair(t)
 
-	conn := newRawConn(localConn, false, nil, nil, nil, nil)
+	conn := newRawConn(localConn, false, nil, nopControlStrHandler, nil, nil)
 	buf := bytes.NewBuffer(quicvarint.Append(nil, streamTypePushStream))
 	str, err := peerConn.OpenUniStream()
 	require.NoError(t, err)
@@ -340,7 +321,7 @@ func testConnRejectPushStream(t *testing.T, isServer bool, expectedErr ErrCode) 
 func TestConnInconsistentDatagramSupport(t *testing.T) {
 	clientConn, serverConn := newConnPair(t)
 
-	conn := newRawConn(clientConn, true, nil, nil, nil, nil)
+	conn := newRawConn(clientConn, true, nil, nopControlStrHandler, nil, nil)
 	b := quicvarint.Append(nil, streamTypeControlStream)
 	b = (&settingsFrame{Datagram: true}).Append(b)
 	controlStr, err := serverConn.OpenUniStream()
@@ -373,7 +354,7 @@ func TestConnSendAndReceiveDatagram(t *testing.T) {
 	var eventRecorder events.Recorder
 	clientConn, serverConn := newConnPair(t, withDatagrams(), withClientRecorder(&eventRecorder))
 
-	conn := newRawConn(clientConn, true, nil, nil, &eventRecorder, nil)
+	conn := newRawConn(clientConn, true, nil, nopControlStrHandler, &eventRecorder, nil)
 	b := quicvarint.Append(nil, streamTypeControlStream)
 	b = (&settingsFrame{Datagram: true}).Append(b)
 	controlStr, err := serverConn.OpenUniStream()
@@ -465,7 +446,7 @@ func TestConnDatagramFailures(t *testing.T) {
 func testConnDatagramFailures(t *testing.T, datagram []byte) {
 	localConn, peerConn := newConnPair(t, withDatagrams())
 
-	conn := newRawConn(localConn, true, nil, nil, nil, nil)
+	conn := newRawConn(localConn, true, nil, nopControlStrHandler, nil, nil)
 
 	b := quicvarint.Append(nil, streamTypeControlStream)
 	b = (&settingsFrame{Datagram: true}).Append(b)

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -18,6 +18,8 @@ type FrameType uint64
 
 type frame any
 
+var errPriorityUpdateForPush = errors.New("http3: PRIORITY_UPDATE frame for push")
+
 // The maximum length of an encoded HTTP/3 frame header is 16:
 // The frame has a type and length field, both QUIC varints (maximum 8 bytes in length)
 const frameHeaderLen = 16
@@ -101,6 +103,10 @@ func (p *frameParser) ParseNext(qlogger qlogwriter.Recorder) (frame, error) {
 			}
 		case 0x7: // GOAWAY
 			return parseGoAwayFrame(r, l, p.streamID, qlogger)
+		case 0xf0700: // PRIORITY_UPDATE for a request stream
+			return parsePriorityUpdateFrame(r, l)
+		case 0xf0701: // PRIORITY_UPDATE for a push stream
+			return nil, errPriorityUpdateForPush
 		case 0xd: // unsupported: MAX_PUSH_ID
 			if qlogger != nil {
 				qlogger.RecordEvent(qlog.FrameParsed{
@@ -178,8 +184,10 @@ func pointer[T any](v T) *T {
 	return &v
 }
 
+const maxSettingsFrameSize = 8 << 10
+
 func parseSettingsFrame(r *countingByteReader, l uint64, streamID quic.StreamID, qlogger qlogwriter.Recorder) (*settingsFrame, error) {
-	if l > 8*(1<<10) {
+	if l > maxSettingsFrameSize {
 		return nil, fmt.Errorf("unexpected size for SETTINGS frame: %d", l)
 	}
 	buf := make([]byte, l)
@@ -324,4 +332,33 @@ func (f *goAwayFrame) Append(b []byte) []byte {
 	b = quicvarint.Append(b, 0x7)
 	b = quicvarint.Append(b, uint64(quicvarint.Len(uint64(f.StreamID))))
 	return quicvarint.Append(b, uint64(f.StreamID))
+}
+
+// PRIORITY_UPDATE, RFC 9218
+type priorityUpdateFrame struct {
+	ElementID          uint64
+	PriorityFieldValue string
+}
+
+const maxPriorityUpdateFrameSize = 4 << 10
+
+func parsePriorityUpdateFrame(r *countingByteReader, l uint64) (*priorityUpdateFrame, error) {
+	if l > maxPriorityUpdateFrameSize {
+		return nil, fmt.Errorf("unexpected size for PRIORITY_UPDATE frame: %d", l)
+	}
+	buf := make([]byte, l)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		if err == io.ErrUnexpectedEOF {
+			return nil, io.EOF
+		}
+		return nil, err
+	}
+	id, n, err := quicvarint.Parse(buf)
+	if err != nil {
+		return nil, err
+	}
+	return &priorityUpdateFrame{
+		ElementID:          id,
+		PriorityFieldValue: string(buf[n:]),
+	}, nil
 }

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -417,6 +417,25 @@ func TestParserGoAwayFrame(t *testing.T) {
 	require.Equal(t, f, f2)
 }
 
+func TestParserPriorityUpdateFrame(t *testing.T) {
+	frame := &priorityUpdateFrame{ElementID: 12, PriorityFieldValue: "u=1, i"}
+	payload := quicvarint.Append(nil, frame.ElementID)
+	payload = append(payload, frame.PriorityFieldValue...)
+	data := quicvarint.Append(nil, 0xf0700)
+	data = quicvarint.Append(data, uint64(len(payload)))
+	data = append(data, payload...)
+	testFrameParserEOF(t, data)
+
+	parsed, err := (&frameParser{r: bytes.NewReader(data)}).ParseNext(nil)
+	require.NoError(t, err)
+	require.Equal(t, frame, parsed)
+
+	data = quicvarint.Append(nil, 0xf0701)
+	data = quicvarint.Append(data, 42) // the payload is intentionally omitted
+	_, err = (&frameParser{r: bytes.NewReader(data)}).ParseNext(nil)
+	require.ErrorIs(t, err, errPriorityUpdateForPush)
+}
+
 func FuzzFrameParser(f *testing.F) {
 	corpus := ossfuzzseeds.New(f)
 

--- a/http3/priority.go
+++ b/http3/priority.go
@@ -6,8 +6,9 @@ const defaultPriorityUrgency int8 = 3
 
 // parsePriority parses the RFC 9218 Priority header field value. It only
 // recognizes the u and i parameters; malformed members return both defaults.
-func parsePriority(value string, defaultUrgency int8, defaultIncremental bool) (urgency int8, incremental bool) {
-	urgency, incremental = defaultUrgency, defaultIncremental
+func parsePriority(value string) (urgency int8, incremental bool) {
+	urgency = defaultPriorityUrgency
+
 	var inString, escapes bool
 	for i, start := 0, 0; i <= len(value); i++ {
 		switch {
@@ -16,7 +17,7 @@ func parsePriority(value string, defaultUrgency int8, defaultIncremental bool) (
 			start = i + 1
 			key, item, hasValue := strings.Cut(member, "=")
 			if key == "" || hasValue && item == "" {
-				return defaultUrgency, defaultIncremental
+				return defaultPriorityUrgency, false
 			}
 			switch key {
 			case "u":
@@ -38,7 +39,7 @@ func parsePriority(value string, defaultUrgency int8, defaultIncremental bool) (
 		}
 	}
 	if inString {
-		return defaultUrgency, defaultIncremental
+		return defaultPriorityUrgency, false
 	}
 	return urgency, incremental
 }

--- a/http3/priority_test.go
+++ b/http3/priority_test.go
@@ -9,34 +9,31 @@ import (
 )
 
 func TestParsePriority(t *testing.T) {
-	// 6 is not a value that any of the test cases sets, so it's easy to spot an unmodified default
-	const defaultUrgency int8 = 6
-
 	tests := []struct {
 		name            string
 		value           string
 		wantUrgency     int8
 		wantIncremental bool
 	}{
-		{name: "empty", wantUrgency: defaultUrgency},
+		{name: "empty", wantUrgency: defaultPriorityUrgency},
 		{name: "urgency", value: "u=0", wantUrgency: 0},
-		{name: "implicit incremental", value: "i", wantUrgency: defaultUrgency, wantIncremental: true},
-		{name: "explicit incremental", value: "i=?1", wantUrgency: defaultUrgency, wantIncremental: true},
+		{name: "implicit incremental", value: "i", wantUrgency: defaultPriorityUrgency, wantIncremental: true},
+		{name: "explicit incremental", value: "i=?1", wantUrgency: defaultPriorityUrgency, wantIncremental: true},
 		{name: "urgency and non-incremental", value: "i=?0, u=4", wantUrgency: 4},
 		{name: "unknown fields", value: "some=data;someparam;u=fake, u=1;foo, i;bar", wantUrgency: 1, wantIncremental: true},
 		{name: "repeated fields", value: "u=1,i,u=5,i=?0", wantUrgency: 5},
-		{name: "wrong types", value: `u="ignored", i=1`, wantUrgency: defaultUrgency},
-		{name: "out of range urgency", value: "u=8", wantUrgency: defaultUrgency},
+		{name: "wrong types", value: `u="ignored", i=1`, wantUrgency: defaultPriorityUrgency},
+		{name: "out of range urgency", value: "u=8", wantUrgency: defaultPriorityUrgency},
 		{name: "valid unknown SFV types", value: `a=(1 "two" ?1);x, b=:YWJj:, c=%"hello%20world", u=2`, wantUrgency: 2},
 		{name: "semicolon inside an extension value", value: `a="x;y";q=1, u=2`, wantUrgency: 2},
 		{name: "known fields inside extension values", value: `future="x\",u=0,i", u=5`, wantUrgency: 5},
 		{name: "backslash inside a display string", value: `future=%"x\", u=5`, wantUrgency: 5},
-		{name: "invalid member", value: "u=0, bad=", wantUrgency: defaultUrgency},
-		{name: "unterminated string", value: `u=1,i, invalid="`, wantUrgency: defaultUrgency},
+		{name: "invalid member", value: "u=0, bad=", wantUrgency: defaultPriorityUrgency},
+		{name: "unterminated string", value: `u=1,i, invalid="`, wantUrgency: defaultPriorityUrgency},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			urgency, incremental := parsePriority(test.value, defaultUrgency, false)
+			urgency, incremental := parsePriority(test.value)
 			require.Equal(t, test.wantUrgency, urgency)
 			require.Equal(t, test.wantIncremental, incremental)
 		})
@@ -48,7 +45,7 @@ func FuzzParsePriority(f *testing.F) {
 		f.Add(value)
 	}
 	f.Fuzz(func(t *testing.T, value string) {
-		urgency, _ := parsePriority(value, defaultPriorityUrgency, false)
+		urgency, _ := parsePriority(value)
 		if urgency < 0 || urgency > 7 {
 			t.Fatalf("invalid urgency: %d", urgency)
 		}
@@ -64,7 +61,7 @@ func TestServerRequestPriority(t *testing.T) {
 			return defaultPriorityUrgency, !conn.priorityAware.Load()
 		}
 		conn.priorityAware.Store(true)
-		return parsePriority(strings.Join(values, ","), defaultPriorityUrgency, false)
+		return parsePriority(strings.Join(values, ","))
 	}
 
 	urgency, incremental := requestPriority(http.Header{})

--- a/http3/priority_test.go
+++ b/http3/priority_test.go
@@ -2,6 +2,7 @@ package http3
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -57,29 +58,38 @@ func FuzzParsePriority(f *testing.F) {
 func TestServerRequestPriority(t *testing.T) {
 	conn := &RawServerConn{}
 
-	urgency, incremental := conn.requestPriority(http.Header{})
+	requestPriority := func(header http.Header) (int8, bool) {
+		values, ok := header["Priority"]
+		if !ok {
+			return defaultPriorityUrgency, !conn.priorityAware.Load()
+		}
+		conn.priorityAware.Store(true)
+		return parsePriority(strings.Join(values, ","), defaultPriorityUrgency, false)
+	}
+
+	urgency, incremental := requestPriority(http.Header{})
 	require.Equal(t, defaultPriorityUrgency, urgency)
 	require.True(t, incremental)
 
 	header := http.Header{}
 	header.Set("Priority", "u=0")
-	urgency, incremental = conn.requestPriority(header)
+	urgency, incremental = requestPriority(header)
 	require.Equal(t, int8(0), urgency)
 	require.False(t, incremental)
 	require.True(t, conn.priorityAware.Load())
 
-	urgency, incremental = conn.requestPriority(http.Header{})
+	urgency, incremental = requestPriority(http.Header{})
 	require.Equal(t, defaultPriorityUrgency, urgency)
 	require.False(t, incremental)
 
 	header.Set("Priority", "i")
-	urgency, incremental = conn.requestPriority(header)
+	urgency, incremental = requestPriority(header)
 	require.Equal(t, defaultPriorityUrgency, urgency)
 	require.True(t, incremental)
 
 	conn = &RawServerConn{}
 	header.Set("Priority", `u=0, invalid="`)
-	urgency, incremental = conn.requestPriority(header)
+	urgency, incremental = requestPriority(header)
 	require.Equal(t, defaultPriorityUrgency, urgency)
 	require.False(t, incremental)
 	require.True(t, conn.priorityAware.Load())

--- a/http3/server_conn.go
+++ b/http3/server_conn.go
@@ -55,7 +55,7 @@ func newRawServerConn(
 		qlogger:        qlogger,
 		logger:         logger,
 	}
-	c.rawConn = *newRawConn(conn, enableDatagrams, c.onStreamsEmpty, nil, qlogger, logger)
+	c.rawConn = *newRawConn(conn, enableDatagrams, c.onStreamsEmpty, c.handleControlStream, qlogger, logger)
 	if idleTimeout > 0 {
 		c.idleTimer = time.AfterFunc(idleTimeout, func() {
 			conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeNoError), "idle timeout")
@@ -113,6 +113,10 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 	fp := &frameParser{closeConn: conn.CloseWithError, r: str, streamID: str.StreamID()}
 	frame, err := fp.ParseNext(qlogger)
 	if err != nil {
+		if errors.Is(err, errPriorityUpdateForPush) {
+			conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
+			return
+		}
 		str.CancelRead(quic.StreamErrorCode(ErrCodeRequestIncomplete))
 		str.CancelWrite(quic.StreamErrorCode(ErrCodeRequestIncomplete))
 		return
@@ -188,7 +192,14 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 	// A Priority response header is only transmitted so that potential intermediaries can use it,
 	// it doesn't affect local scheduling.
 	// This mirrors the behavior of HTTP/2, see https://github.com/golang/go/issues/75500.
-	urgency, incremental := c.requestPriority(req.Header)
+	var urgency int8
+	var incremental bool
+	if values, ok := req.Header["Priority"]; !ok {
+		urgency, incremental = defaultPriorityUrgency, !c.priorityAware.Load()
+	} else {
+		c.priorityAware.Store(true)
+		urgency, incremental = parsePriority(strings.Join(values, ","), defaultPriorityUrgency, false)
+	}
 	hstr.SetPriority(urgency, incremental)
 
 	body := newRequestBody(hstr, contentLength, connCtx, conn.ReceivedSettings(), conn.Settings)
@@ -256,13 +267,40 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 	str.Close()
 }
 
-func (c *RawServerConn) requestPriority(header http.Header) (int8, bool) {
-	values, ok := header["Priority"]
-	if !ok {
-		return defaultPriorityUrgency, !c.priorityAware.Load()
+func (c *RawServerConn) handleControlStream(_ *quic.ReceiveStream, fp *frameParser) {
+	for {
+		f, err := fp.ParseNext(c.qlogger)
+		if err != nil {
+			if errors.Is(err, errPriorityUpdateForPush) {
+				// Server push is not supported. Since we never send PUSH_PROMISE frames,
+				// the client can't reference a valid push ID.
+				c.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
+				return
+			}
+			var streamErr *quic.StreamError
+			if err == io.EOF || errors.As(err, &streamErr) {
+				c.CloseWithError(quic.ApplicationErrorCode(ErrCodeClosedCriticalStream), "")
+				return
+			}
+			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameError), "")
+			return
+		}
+		switch frame := f.(type) {
+		case *priorityUpdateFrame:
+			if frame.ElementID%4 != 0 {
+				c.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
+				return
+			}
+			c.priorityAware.Store(true)
+			urgency, incremental := parsePriority(frame.PriorityFieldValue, defaultPriorityUrgency, false)
+			c.rawConn.UpdateStreamPriority(quic.StreamID(frame.ElementID), urgency, incremental)
+		case *goAwayFrame:
+			// Server push is not supported, so there is no push state to update.
+		default:
+			c.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
+			return
+		}
 	}
-	c.priorityAware.Store(true)
-	return parsePriority(strings.Join(values, ","), defaultPriorityUrgency, false)
 }
 
 func (c *RawServerConn) rejectWithHeaderFieldsTooLarge(str *stateTrackingStream) {

--- a/http3/server_conn.go
+++ b/http3/server_conn.go
@@ -198,7 +198,7 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 		urgency, incremental = defaultPriorityUrgency, !c.priorityAware.Load()
 	} else {
 		c.priorityAware.Store(true)
-		urgency, incremental = parsePriority(strings.Join(values, ","), defaultPriorityUrgency, false)
+		urgency, incremental = parsePriority(strings.Join(values, ","))
 	}
 	hstr.SetPriority(urgency, incremental)
 
@@ -292,7 +292,7 @@ func (c *RawServerConn) handleControlStream(_ *quic.ReceiveStream, fp *framePars
 				return
 			}
 			c.priorityAware.Store(true)
-			urgency, incremental := parsePriority(frame.PriorityFieldValue, defaultPriorityUrgency, false)
+			urgency, incremental := parsePriority(frame.PriorityFieldValue)
 			c.rawConn.UpdateStreamPriority(quic.StreamID(frame.ElementID), urgency, incremental)
 		case *goAwayFrame:
 			// Server push is not supported, so there is no push state to update.

--- a/http3/server_test.go
+++ b/http3/server_test.go
@@ -253,6 +253,31 @@ func TestServerFirstFrameNotHeaders(t *testing.T) {
 	}
 }
 
+func TestServerRejectsPriorityUpdateForPush(t *testing.T) {
+	clientConn, serverConn := newConnPair(t)
+	go (&Server{}).ServeQUICConn(serverConn)
+
+	str, err := clientConn.OpenUniStream()
+	require.NoError(t, err)
+	b := quicvarint.Append(nil, streamTypeControlStream)
+	b = (&settingsFrame{}).Append(b)
+	b = quicvarint.Append(b, 0xf0701)
+	b = quicvarint.Append(b, 42)
+	b = append(b, make([]byte, 42)...)
+	_, err = str.Write(b)
+	require.NoError(t, err)
+
+	select {
+	case <-clientConn.Context().Done():
+		require.ErrorIs(t,
+			context.Cause(clientConn.Context()),
+			&quic.ApplicationError{Remote: true, ErrorCode: quic.ApplicationErrorCode(ErrCodeIDError)},
+		)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for close")
+	}
+}
+
 func TestServerHandlerBodyNotRead(t *testing.T) {
 	t.Run("GET request with a body", func(t *testing.T) {
 		testServerHandlerBodyNotRead(t,

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -78,6 +78,9 @@ func (s *Stream) Read(b []byte) (int, error) {
 		for {
 			frame, err := s.frameParser.ParseNext(s.qlogger)
 			if err != nil {
+				if errors.Is(err, errPriorityUpdateForPush) {
+					s.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
+				}
 				return 0, err
 			}
 			switch f := frame.(type) {
@@ -356,6 +359,10 @@ func (s *RequestStream) ReadResponse() (*http.Response, error) {
 	}
 	frame, err := s.str.frameParser.ParseNext(s.str.qlogger)
 	if err != nil {
+		if errors.Is(err, errPriorityUpdateForPush) {
+			s.str.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
+			return nil, err
+		}
 		s.str.CancelRead(quic.StreamErrorCode(ErrCodeFrameError))
 		s.str.CancelWrite(quic.StreamErrorCode(ErrCodeFrameError))
 		return nil, fmt.Errorf("http3: parsing frame failed: %w", err)

--- a/http3/stream_test.go
+++ b/http3/stream_test.go
@@ -40,7 +40,7 @@ func TestStreamReadDataFrames(t *testing.T) {
 	clientConn, _ := newConnPair(t, withClientRecorder(&eventRecorder))
 	str := newStream(
 		qstr,
-		newRawConn(clientConn, false, nil, nil, &eventRecorder, nil),
+		newRawConn(clientConn, false, nil, nopControlStrHandler, &eventRecorder, nil),
 		nil,
 		func(io.Reader, *headersFrame) error { return nil },
 		&eventRecorder,
@@ -108,7 +108,7 @@ func TestStreamInvalidFrame(t *testing.T) {
 
 	str := newStream(
 		qstr,
-		newRawConn(clientConn, false, nil, nil, nil, nil),
+		newRawConn(clientConn, false, nil, nopControlStrHandler, nil, nil),
 		nil,
 		func(io.Reader, *headersFrame) error { return nil },
 		nil,
@@ -209,7 +209,7 @@ func TestRequestStream(t *testing.T) {
 	str := newRequestStream(
 		newStream(
 			qstr,
-			newRawConn(clientConn, false, nil, nil, nil, nil),
+			newRawConn(clientConn, false, nil, nopControlStrHandler, nil, nil),
 			&httptrace.ClientTrace{},
 			func(io.Reader, *headersFrame) error { return nil },
 			nil,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RFC 9218 PRIORITY_UPDATE frame handling to HTTP/3 server and client
> - Adds parsing of `PRIORITY_UPDATE` frames (type `0xf0700`) in [http3/frames.go](https://github.com/quic-go/quic-go/pull/5789/files#diff-5058d763be915b41b872950ae8225c436f514184bb1f13fbf6c0350627bdee4b); push-priority frames (`0xf0701`) return a sentinel error `errPriorityUpdateForPush`.
> - The server's control stream handler in [http3/server_conn.go](https://github.com/quic-go/quic-go/pull/5789/files#diff-1f6b117a2ea0aa678aae54139e07ae729d9580f0f3014517c0a4d094c1ef52a2) now processes `PRIORITY_UPDATE` frames, validates the element ID is a client-initiated stream (`StreamID%4==0`), and updates the stream's scheduling priority via the new `rawConn.UpdateStreamPriority` method.
> - Invalid push-priority updates or bad element IDs close the connection with `ID_ERROR`; receiving a push-priority frame on request streams or during response parsing closes with `FRAME_UNEXPECTED`.
> - Refactors `parsePriority` in [http3/priority.go](https://github.com/quic-go/quic-go/pull/5789/files#diff-82e143ff4833958bbe26161c53b6fb1025db74193ef8fb295e5773298b253c86) to remove caller-supplied defaults, always returning `defaultPriorityUrgency` and `incremental=false` on invalid input.
> - Behavioral Change: server connections now always invoke the control stream handler after SETTINGS; previously this was conditional on a non-nil handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85634a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for HTTP/3 `PRIORITY_UPDATE` frames on request streams.
  - Stream priorities now update dynamically when valid priority changes are received.

- **Bug Fixes**
  - Invalid, malformed, unsupported, or oversized priority updates now trigger appropriate connection errors.
  - Improved handling of incomplete priority frame data and invalid push-stream updates.

- **Tests**
  - Added coverage for priority parsing, round-tripping, stream priority updates, invalid push-stream updates, and connection closure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->