### PR TITLE
http3: add qlog support for PRIORITY_UPDATE frames

### DIFF
--- a/http3/frames.go
+++ b/http3/frames.go
@@ -104,7 +104,7 @@ func (p *frameParser) ParseNext(qlogger qlogwriter.Recorder) (frame, error) {
 		case 0x7: // GOAWAY
 			return parseGoAwayFrame(r, l, p.streamID, qlogger)
 		case 0xf0700: // PRIORITY_UPDATE for a request stream
-			return parsePriorityUpdateFrame(r, l)
+			return parsePriorityUpdateFrame(r, l, p.streamID, qlogger)
 		case 0xf0701: // PRIORITY_UPDATE for a push stream
 			return nil, errPriorityUpdateForPush
 		case 0xd: // unsupported: MAX_PUSH_ID
@@ -342,7 +342,7 @@ type priorityUpdateFrame struct {
 
 const maxPriorityUpdateFrameSize = 4 << 10
 
-func parsePriorityUpdateFrame(r *countingByteReader, l uint64) (*priorityUpdateFrame, error) {
+func parsePriorityUpdateFrame(r *countingByteReader, l uint64, streamID quic.StreamID, qlogger qlogwriter.Recorder) (*priorityUpdateFrame, error) {
 	if l > maxPriorityUpdateFrameSize {
 		return nil, fmt.Errorf("unexpected size for PRIORITY_UPDATE frame: %d", l)
 	}
@@ -357,8 +357,19 @@ func parsePriorityUpdateFrame(r *countingByteReader, l uint64) (*priorityUpdateF
 	if err != nil {
 		return nil, err
 	}
-	return &priorityUpdateFrame{
+	frame := &priorityUpdateFrame{
 		ElementID:          id,
 		PriorityFieldValue: string(buf[n:]),
-	}, nil
+	}
+	if qlogger != nil {
+		qlogger.RecordEvent(qlog.FrameParsed{
+			StreamID: streamID,
+			Raw:      qlog.RawInfo{Length: r.NumRead, PayloadLength: int(l)},
+			Frame: qlog.Frame{Frame: qlog.PriorityUpdateFrame{
+				StreamID:           quic.StreamID(frame.ElementID),
+				PriorityFieldValue: frame.PriorityFieldValue,
+			}},
+		})
+	}
+	return frame, nil
 }

--- a/http3/frames_test.go
+++ b/http3/frames_test.go
@@ -418,6 +418,7 @@ func TestParserGoAwayFrame(t *testing.T) {
 }
 
 func TestParserPriorityUpdateFrame(t *testing.T) {
+	var eventRecorder events.Recorder
 	frame := &priorityUpdateFrame{ElementID: 12, PriorityFieldValue: "u=1, i"}
 	payload := quicvarint.Append(nil, frame.ElementID)
 	payload = append(payload, frame.PriorityFieldValue...)
@@ -426,9 +427,20 @@ func TestParserPriorityUpdateFrame(t *testing.T) {
 	data = append(data, payload...)
 	testFrameParserEOF(t, data)
 
-	parsed, err := (&frameParser{r: bytes.NewReader(data)}).ParseNext(nil)
+	parsed, err := (&frameParser{streamID: 42, r: bytes.NewReader(data)}).ParseNext(&eventRecorder)
 	require.NoError(t, err)
 	require.Equal(t, frame, parsed)
+	require.Equal(t,
+		[]qlogwriter.Event{qlog.FrameParsed{
+			StreamID: 42,
+			Raw:      qlog.RawInfo{Length: len(data), PayloadLength: len(payload)},
+			Frame: qlog.Frame{Frame: qlog.PriorityUpdateFrame{
+				StreamID:           12,
+				PriorityFieldValue: "u=1, i",
+			}},
+		}},
+		eventRecorder.Events(qlog.FrameParsed{}),
+	)
 
 	data = quicvarint.Append(nil, 0xf0701)
 	data = quicvarint.Append(data, 42) // the payload is intentionally omitted

--- a/http3/qlog/frame.go
+++ b/http3/qlog/frame.go
@@ -26,6 +26,8 @@ func (f Frame) encode(enc *jsontext.Encoder) error {
 		return frame.encode(enc)
 	case MaxPushIDFrame:
 		return frame.encode(enc)
+	case PriorityUpdateFrame:
+		return frame.encode(enc)
 	case ReservedFrame:
 		return frame.encode(enc)
 	case UnknownFrame:
@@ -183,6 +185,25 @@ func (f *MaxPushIDFrame) encode(enc *jsontext.Encoder) error {
 	h.WriteToken(jsontext.BeginObject)
 	h.WriteToken(jsontext.String("frame_type"))
 	h.WriteToken(jsontext.String("max_push_id"))
+	h.WriteToken(jsontext.EndObject)
+	return h.err
+}
+
+// A PriorityUpdateFrame is a PRIORITY_UPDATE frame for a request stream.
+type PriorityUpdateFrame struct {
+	StreamID           quic.StreamID
+	PriorityFieldValue string
+}
+
+func (f *PriorityUpdateFrame) encode(enc *jsontext.Encoder) error {
+	h := encoderHelper{enc: enc}
+	h.WriteToken(jsontext.BeginObject)
+	h.WriteToken(jsontext.String("frame_type"))
+	h.WriteToken(jsontext.String("priority_update"))
+	h.WriteToken(jsontext.String("stream_id"))
+	h.WriteToken(jsontext.Uint(uint64(f.StreamID)))
+	h.WriteToken(jsontext.String("priority_field_value"))
+	h.WriteToken(jsontext.String(f.PriorityFieldValue))
 	h.WriteToken(jsontext.EndObject)
 	return h.err
 }

--- a/http3/qlog/frame_test.go
+++ b/http3/qlog/frame_test.go
@@ -189,6 +189,14 @@ func TestMaxPushIDFrame(t *testing.T) {
 	})
 }
 
+func TestPriorityUpdateFrame(t *testing.T) {
+	check(t, PriorityUpdateFrame{StreamID: 12, PriorityFieldValue: "u=1, i"}, map[string]any{
+		"frame_type":           "priority_update",
+		"stream_id":            12,
+		"priority_field_value": "u=1, i",
+	})
+}
+
 func TestReservedFrame(t *testing.T) {
 	check(t, ReservedFrame{Type: 0x1f}, map[string]any{
 		"frame_type":       "reserved",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add qlog support for PRIORITY_UPDATE frames in http3
- Extends `parsePriorityUpdateFrame` in [frames.go](https://github.com/quic-go/quic-go/pull/5790/files#diff-5058d763be915b41b872950ae8225c436f514184bb1f13fbf6c0350627bdee4b) to accept a `streamID` and `qlogger`, recording a `FrameParsed` qlog event when a logger is present.
- Adds `PriorityUpdateFrame` to [http3/qlog/frame.go](https://github.com/quic-go/quic-go/pull/5790/files#diff-22a7daedbdea552500d57e924abecc08c3a2d261fdddd3fe59f731af8a27fad6) with JSON encoding that emits `frame_type`, `stream_id`, and `priority_field_value`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1263dcc.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added qlog support for HTTP/3 priority update frames.
  * Priority update events now include the stream ID and priority field value.

* **Tests**
  * Added coverage verifying priority update frame parsing, event recording, and JSON output.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->