### PR TITLE
remove receive-side checks from connection flow controller reset

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -2311,7 +2311,8 @@ func (c *Conn) dropEncryptionLevel(encLevel protocol.EncryptionLevel, now monoti
 	case protocol.Encryption0RTT:
 		c.streamsMap.ResetFor0RTT()
 		c.framer.Handle0RTTRejection()
-		return c.connFlowController.Reset()
+		c.connFlowController.Reset()
+		return nil
 	}
 	return c.cryptoStreamManager.Drop(encLevel)
 }

--- a/flow_controller_connection.go
+++ b/flow_controller_connection.go
@@ -1,7 +1,6 @@
 package quic
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -169,18 +168,11 @@ func (c *connectionFlowController) EnsureMinimumWindowSize(inc protocol.ByteCoun
 // Reset rests the flow controller. This happens when 0-RTT is rejected.
 // All stream data is invalidated, it's as if we had never opened a stream and never sent any data.
 // At that point, we only have sent stream data, but we didn't have the keys to open 1-RTT keys yet.
-func (c *connectionFlowController) Reset() error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	if c.bytesRead > 0 || c.highestReceived > 0 || !c.epochStartTime.IsZero() {
-		return errors.New("flow controller reset after reading data")
-	}
+func (c *connectionFlowController) Reset() {
 	c.sendMutex.Lock()
 	defer c.sendMutex.Unlock()
 
 	c.bytesSent = 0
 	c.lastBlockedAt = 0
 	c.sendWindow = 0
-	return nil
 }

--- a/flow_controller_connection_test.go
+++ b/flow_controller_connection_test.go
@@ -66,12 +66,6 @@ func TestConnectionFlowControllerReset(t *testing.T) {
 	fc.UpdateSendWindow(100)
 	require.True(t, fc.TryAddBytesSent(10))
 	require.Equal(t, protocol.ByteCount(90), fc.SendWindowSize())
-	require.NoError(t, fc.Reset())
+	fc.Reset()
 	require.Zero(t, fc.SendWindowSize())
-}
-
-func TestConnectionFlowControllerResetAfterReading(t *testing.T) {
-	fc := newConnectionFlowController(0, 0, nil, utils.NewRTTStats(), utils.DefaultLogger)
-	fc.AddBytesRead(1)
-	require.EqualError(t, fc.Reset(), "flow controller reset after reading data")
 }


### PR DESCRIPTION
Reset is only called when 0-RTT is rejected, before the client obtains 1-RTT read keys. It therefore cannot have received stream data, making the receive-side check redundant.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove error return and receive-side checks from `connectionFlowController.Reset`
> - [`connectionFlowController.Reset`](https://github.com/quic-go/quic-go/pull/5791/files#diff-e203be0a2d1185e963708bac6dc7f33fdb0283900c92f2c1b9f93a778b333121) no longer returns an error and no longer validates read state or epoch before resetting; it unconditionally zeroes `bytesSent`, `lastBlockedAt`, and `sendWindow`.
> - [`Conn.dropEncryptionLevel`](https://github.com/quic-go/quic-go/pull/5791/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7) is updated to ignore the (now absent) error return from `Reset` and always returns `nil` in the 0-RTT case.
> - The test for the error-on-read-before-reset path is removed from [`flow_controller_connection_test.go`](https://github.com/quic-go/quic-go/pull/5791/files#diff-c3220f80e80a55797fb322fe24557ba3b13f851b45d3df68f984a0afc27a6b13).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f17c40b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection flow-control reset behavior during early connection key removal.
  * Reset operations now reliably clear send-side flow-control state without unnecessary validation failures.
* **Tests**
  * Updated flow-control reset coverage to reflect the streamlined reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->