### PR TITLE
README: organize specifications and list related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,29 @@
 [![Code Coverage](https://img.shields.io/codecov/c/github/quic-go/quic-go/master.svg?style=flat-square)](https://codecov.io/gh/quic-go/quic-go/)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/quic-go.svg)](https://issues.oss-fuzz.com/issues?q=quic-go)
 
-quic-go is an implementation of the QUIC protocol ([RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000), [RFC 9001](https://datatracker.ietf.org/doc/html/rfc9001), [RFC 9002](https://datatracker.ietf.org/doc/html/rfc9002)) in Go. It has support for HTTP/3 ([RFC 9114](https://datatracker.ietf.org/doc/html/rfc9114)), including QPACK ([RFC 9204](https://datatracker.ietf.org/doc/html/rfc9204)) and HTTP Datagrams ([RFC 9297](https://datatracker.ietf.org/doc/html/rfc9297)).
+quic-go is an implementation of the QUIC protocol ([RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000), [RFC 9001](https://datatracker.ietf.org/doc/html/rfc9001), [RFC 9002](https://datatracker.ietf.org/doc/html/rfc9002)) in Go.
 
-In addition to these base RFCs, it also implements the following RFCs:
+Other QUIC specifications:
 
 * Unreliable Datagram Extension ([RFC 9221](https://datatracker.ietf.org/doc/html/rfc9221))
 * Datagram Packetization Layer Path MTU Discovery (DPLPMTUD, [RFC 8899](https://datatracker.ietf.org/doc/html/rfc8899))
-* Extensible Prioritization Scheme for HTTP ([RFC 9218](https://datatracker.ietf.org/doc/html/rfc9218))
 * QUIC Version 2 ([RFC 9369](https://datatracker.ietf.org/doc/html/rfc9369))
 * QUIC Event Logging using qlog ([draft-ietf-quic-qlog-main-schema](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-main-schema/) and [draft-ietf-quic-qlog-quic-events](https://datatracker.ietf.org/doc/draft-ietf-quic-qlog-quic-events/))
 * QUIC Stream Resets with Partial Delivery ([draft-ietf-quic-reliable-stream-reset-07](https://datatracker.ietf.org/doc/html/draft-ietf-quic-reliable-stream-reset-07) and [draft-ietf-quic-reliable-stream-reset-09](https://datatracker.ietf.org/doc/html/draft-ietf-quic-reliable-stream-reset-09))
 
-Support for WebTransport over HTTP/3 ([draft-ietf-webtrans-http3](https://datatracker.ietf.org/doc/draft-ietf-webtrans-http3/)) is implemented in [webtransport-go](https://github.com/quic-go/webtransport-go).
+quic-go also supports HTTP/3 ([RFC 9114](https://datatracker.ietf.org/doc/html/rfc9114)).
+
+Other HTTP/3 specifications:
+
+* QPACK: Field Compression for HTTP/3 ([RFC 9204](https://datatracker.ietf.org/doc/html/rfc9204))
+* Extensible Prioritization Scheme for HTTP ([RFC 9218](https://datatracker.ietf.org/doc/html/rfc9218))
+* HTTP Datagrams and the Capsule Protocol ([RFC 9297](https://datatracker.ietf.org/doc/html/rfc9297))
+
+Related projects:
+
+* [webtransport-go](https://github.com/quic-go/webtransport-go) implements WebTransport over HTTP/3 ([draft-ietf-webtrans-http3](https://datatracker.ietf.org/doc/draft-ietf-webtrans-http3/)).
+* [masque-go](https://github.com/quic-go/masque-go) implements CONNECT-UDP ([RFC 9298](https://datatracker.ietf.org/doc/html/rfc9298)).
+* [connect-ip-go](https://github.com/quic-go/connect-ip-go) implements CONNECT-IP ([RFC 9484](https://datatracker.ietf.org/doc/html/rfc9484)).
 
 Detailed documentation can be found on [quic-go.net](https://quic-go.net/docs/).
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Reorganize README to separate QUIC and HTTP/3 specifications and add related projects
- Splits the single QUIC section into separate 'Other QUIC specifications' and 'Other HTTP/3 specifications' sections in [README.md](https://github.com/quic-go/quic-go/pull/5793/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), grouping RFCs by protocol.
- Adds explicit mention that quic-go supports HTTP/3, with QPACK (RFC 9204), HTTP Prioritization (RFC 9218), and HTTP Datagrams (RFC 9297) listed under HTTP/3.
- Replaces the single-sentence WebTransport reference with a 'Related projects' section covering webtransport-go, masque-go (RFC 9298), and connect-ip-go (RFC 9484).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9755c6.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized protocol support information into separate QUIC and HTTP/3 sections.
  * Added details about supported QUIC extensions, HTTP/3 specifications, and related projects.
  * Removed the previous combined support overview and RFC list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->