### PR TITLE
link API references in documentation

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,7 +60,7 @@ func DialAddrEarly(ctx context.Context, addr string, tlsConf *tls.Config, conf *
 	return conn, nil
 }
 
-// DialEarly establishes a new 0-RTT QUIC connection to a server using a net.PacketConn.
+// DialEarly establishes a new 0-RTT QUIC connection to a server using a [net.PacketConn].
 // See [Dial] for more details.
 func DialEarly(ctx context.Context, c net.PacketConn, addr net.Addr, tlsConf *tls.Config, conf *Config) (*Conn, error) {
 	dl, err := setupTransport(c, tlsConf, false)
@@ -75,11 +75,12 @@ func DialEarly(ctx context.Context, c net.PacketConn, addr net.Addr, tlsConf *tl
 	return conn, nil
 }
 
-// Dial establishes a new QUIC connection to a server using a net.PacketConn.
+// Dial establishes a new QUIC connection to a server using a [net.PacketConn].
 // If the PacketConn satisfies the [OOBCapablePacketConn] interface (as a [net.UDPConn] does),
-// ECN and packet info support will be enabled. In this case, ReadMsgUDP and WriteMsgUDP
-// will be used instead of ReadFrom and WriteTo to read/write packets.
-// The [tls.Config] must define an application protocol (using tls.Config.NextProtos).
+// ECN and packet info support will be enabled. In this case, [OOBCapablePacketConn.ReadMsgUDP]
+// and [OOBCapablePacketConn.WriteMsgUDP] will be used instead of [net.PacketConn.ReadFrom]
+// and [net.PacketConn.WriteTo] to read/write packets.
+// The [tls.Config] must define an application protocol using [tls.Config.NextProtos].
 //
 // This is a convenience function. More advanced use cases should instantiate a [Transport],
 // which offers configuration options for a more fine-grained control of the connection establishment,

--- a/connection.go
+++ b/connection.go
@@ -3034,7 +3034,7 @@ func (c *Conn) updateStreamPriority(id protocol.StreamID) {
 // There is no delivery guarantee for DATAGRAM frames, they are not retransmitted if lost.
 // The payload of the datagram needs to fit into a single QUIC packet.
 // In addition, a datagram may be dropped before being sent out if the available packet size suddenly decreases.
-// If the payload is too large to be sent at the current time, a DatagramTooLargeError is returned.
+// If the payload is too large to be sent at the current time, a [DatagramTooLargeError] is returned.
 func (c *Conn) SendDatagram(p []byte) error {
 	if !c.supportsDatagrams() {
 		return errors.New("datagram support disabled")

--- a/errors.go
+++ b/errors.go
@@ -72,7 +72,8 @@ const (
 )
 
 // A StreamError is used to signal stream cancellations.
-// It is returned from the Read and Write methods of the [ReceiveStream], [SendStream] and [Stream].
+// It can be returned by stream methods such as [ReceiveStream.Read], [SendStream.Write],
+// [Stream.Read], and [Stream.Write].
 type StreamError struct {
 	StreamID  StreamID
 	ErrorCode StreamErrorCode
@@ -92,7 +93,7 @@ func (e *StreamError) Error() string {
 	return fmt.Sprintf("stream %d canceled by %s with error code %d", e.StreamID, pers, e.ErrorCode)
 }
 
-// DatagramTooLargeError is returned from Conn.SendDatagram if the payload is too large to be sent.
+// DatagramTooLargeError is returned from [Conn.SendDatagram] if the payload is too large to be sent.
 type DatagramTooLargeError struct {
 	MaxDatagramPayloadSize int64
 }

--- a/http3/body.go
+++ b/http3/body.go
@@ -12,10 +12,10 @@ import (
 // Settingser allows waiting for and retrieving the peer's HTTP/3 settings.
 type Settingser interface {
 	// ReceivedSettings returns a channel that is closed once the peer's SETTINGS frame was received.
-	// Settings can be obtained from the Settings method after the channel was closed.
+	// The settings can be obtained from [Settingser.Settings] after the channel is closed.
 	ReceivedSettings() <-chan struct{}
 	// Settings returns the settings received on this connection.
-	// It is only valid to call this function after the channel returned by ReceivedSettings was closed.
+	// It is only valid to call this method after the channel returned by [Settingser.ReceivedSettings] is closed.
 	Settings() *Settings
 }
 

--- a/http3/capsule.go
+++ b/http3/capsule.go
@@ -19,7 +19,7 @@ func (*noCopy) Lock()   {}
 func (*noCopy) Unlock() {}
 
 // CapsuleParser parses a sequence of capsules.
-// A capsule's contents must be fully consumed or discarded before calling Next again.
+// A capsule's contents must be fully consumed or discarded before calling [CapsuleParser.Next] again.
 type CapsuleParser struct {
 	noCopy noCopy
 
@@ -40,7 +40,7 @@ var (
 )
 
 // Next returns the type and contents of the next capsule.
-// The previous capsule's contents must be fully consumed or discarded before calling Next.
+// The previous capsule's contents must be fully consumed or discarded before calling this method again.
 func (p *CapsuleParser) Next() (CapsuleType, CapsuleReader, error) {
 	if p.remaining > 0 {
 		return 0, CapsuleReader{}, errCapsuleNotConsumed
@@ -71,7 +71,7 @@ func (p *CapsuleParser) Next() (CapsuleType, CapsuleReader, error) {
 }
 
 // CapsuleReader reads the contents of a capsule.
-// It becomes invalid when the parser advances to the next capsule.
+// It becomes invalid after [CapsuleParser.Next] successfully advances to the next capsule.
 type CapsuleReader struct {
 	parser     *CapsuleParser
 	generation uint64

--- a/http3/client.go
+++ b/http3/client.go
@@ -339,13 +339,13 @@ func (c *ClientConn) roundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // ReceivedSettings returns a channel that is closed once the server's HTTP/3 settings were received.
-// Settings can be obtained from the Settings method after the channel was closed.
+// The settings can be obtained from [ClientConn.Settings] after the channel is closed.
 func (c *ClientConn) ReceivedSettings() <-chan struct{} {
 	return c.rawConn.ReceivedSettings()
 }
 
 // Settings returns the HTTP/3 settings for this connection.
-// It is only valid to call this function after the channel returned by ReceivedSettings was closed.
+// It is only valid to call this method after the channel returned by [ClientConn.ReceivedSettings] is closed.
 func (c *ClientConn) Settings() *Settings {
 	return c.rawConn.Settings()
 }

--- a/http3/error.go
+++ b/http3/error.go
@@ -7,8 +7,9 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-// Error is returned from the round tripper (for HTTP clients)
-// and inside the HTTP handler (for HTTP servers) if an HTTP/3 error occurs.
+// Error is returned by [Transport.RoundTrip], [Transport.RoundTripOpt], and
+// [ClientConn.RoundTrip] for HTTP clients, and from request-body reads and response
+// writes inside HTTP handlers for HTTP servers, when an HTTP/3 error occurs.
 // See section 8 of RFC 9114.
 type Error struct {
 	Remote       bool

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -16,7 +16,8 @@ import (
 	"golang.org/x/net/http/httpguts"
 )
 
-// The HTTPStreamer allows taking over a HTTP/3 stream. The interface is implemented by the http.ResponseWriter.
+// HTTPStreamer allows an HTTP handler to take over an HTTP/3 stream.
+// It is implemented by the [http.ResponseWriter] passed to HTTP/3 handlers.
 // When a stream is taken over, it's the caller's responsibility to close the stream.
 type HTTPStreamer interface {
 	HTTPStream() *Stream

--- a/http3/server.go
+++ b/http3/server.go
@@ -43,8 +43,8 @@ type QUICListener interface {
 
 var _ QUICListener = &quic.EarlyListener{}
 
-// ConfigureTLSConfig creates a new tls.Config which can be used
-// to create a quic.Listener meant for serving HTTP/3.
+// ConfigureTLSConfig creates a new [tls.Config] which can be used
+// to create a [quic.Listener] meant for serving HTTP/3.
 func ConfigureTLSConfig(tlsConf *tls.Config) *tls.Config {
 	return configureTLSConfig(tlsConf, nil)
 }
@@ -109,15 +109,15 @@ type contextKey struct {
 func (k *contextKey) String() string { return "quic-go/http3 context value " + k.name }
 
 // ServerContextKey is a context key. It can be used in HTTP
-// handlers with Context.Value to access the server that
+// handlers with [context.Context.Value] to access the server that
 // started the handler. The associated value will be of
-// type *http3.Server.
+// type [*Server].
 var ServerContextKey = &contextKey{"http3-server"}
 
 // RemoteAddrContextKey is a context key. It can be used in
-// HTTP handlers with Context.Value to access the remote
+// HTTP handlers with [context.Context.Value] to access the remote
 // address of the connection. The associated value will be of
-// type net.Addr.
+// type [net.Addr].
 //
 // Use this value instead of [http.Request.RemoteAddr] if you
 // require access to the remote address of the connection rather
@@ -138,16 +138,16 @@ type Server struct {
 	// Addr optionally specifies the UDP address for the server to listen on,
 	// in the form "host:port".
 	//
-	// When used by ListenAndServe and ListenAndServeTLS methods, if empty,
-	// ":https" (port 443) is used. See net.Dial for details of the address
+	// When used by [Server.ListenAndServe] and [Server.ListenAndServeTLS], if empty,
+	// ":https" (port 443) is used. See [net.Dial] for details of the address
 	// format.
 	//
 	// Otherwise, if Port is not set and underlying QUIC listeners do not
 	// have valid port numbers, the port part is used in Alt-Svc headers set
-	// with SetQUICHeaders.
+	// with [Server.SetQUICHeaders].
 	Addr string
 
-	// Port is used in Alt-Svc response headers set with SetQUICHeaders. If
+	// Port is used in Alt-Svc response headers set with [Server.SetQUICHeaders]. If
 	// needed Port can be manually set when the Server is created.
 	//
 	// This is useful when a Layer 4 firewall is redirecting UDP traffic and
@@ -156,26 +156,23 @@ type Server struct {
 	Port int
 
 	// TLSConfig provides a TLS configuration for use by server. It must be
-	// set for ListenAndServe and Serve methods.
+	// set for [Server.ListenAndServe] and [Server.Serve].
 	TLSConfig *tls.Config
 
-	// QUICConfig provides the parameters for QUIC connection created with Serve.
+	// QUICConfig provides the parameters for QUIC connections created with [Server.Serve].
 	// If nil, it uses reasonable default values.
-	//
-	// Configured versions are also used in Alt-Svc response header set with SetQUICHeaders.
 	QUICConfig *quic.Config
 
-	// Handler is the HTTP request handler to use. If not set, defaults to
-	// http.NotFound.
+	// Handler is the HTTP request handler. If nil, [http.DefaultServeMux] is used.
 	Handler http.Handler
 
 	// EnableDatagrams enables support for HTTP/3 datagrams (RFC 9297).
-	// If set to true, QUICConfig.EnableDatagrams will be set.
+	// For connections created by the server, this also enables [quic.Config.EnableDatagrams].
 	EnableDatagrams bool
 
 	// MaxHeaderBytes controls the maximum number of bytes the server will
 	// read parsing the request HEADERS frame. It does not limit the size of
-	// the request body. If zero or negative, http.DefaultMaxHeaderBytes is
+	// the request body. If zero or negative, [http.DefaultMaxHeaderBytes] is
 	// used.
 	MaxHeaderBytes int
 
@@ -209,9 +206,10 @@ type Server struct {
 	altSvcHeader string
 }
 
-// ListenAndServe listens on the UDP address s.Addr and calls s.Handler to handle HTTP/3 requests on incoming connections.
+// ListenAndServe listens on the UDP address [Server.Addr] and calls [Server.Handler]
+// to handle HTTP/3 requests on incoming connections.
 //
-// If s.Addr is blank, ":https" is used.
+// If [Server.Addr] is blank, ":https" is used.
 func (s *Server) ListenAndServe() error {
 	ln, err := s.setupListenerForConn(s.TLSConfig, nil)
 	if err != nil {
@@ -222,9 +220,10 @@ func (s *Server) ListenAndServe() error {
 	return s.serveListener(*ln)
 }
 
-// ListenAndServeTLS listens on the UDP address s.Addr and calls s.Handler to handle HTTP/3 requests on incoming connections.
+// ListenAndServeTLS listens on the UDP address [Server.Addr] and calls [Server.Handler]
+// to handle HTTP/3 requests on incoming connections.
 //
-// If s.Addr is blank, ":https" is used.
+// If [Server.Addr] is blank, ":https" is used.
 func (s *Server) ListenAndServeTLS(certFile, keyFile string) error {
 	var err error
 	certs := make([]tls.Certificate, 1)
@@ -290,10 +289,10 @@ func (s *Server) ServeQUICConn(conn *quic.Conn) error {
 }
 
 // ServeListener serves an existing QUIC listener.
-// Make sure you use http3.ConfigureTLSConfig to configure a tls.Config
-// and use it to construct a http3-friendly QUIC listener.
-// Closing the server does not close the listener. It is the application's responsibility to close them.
-// ServeListener always returns a non-nil error. After Shutdown or Close, the returned error is http.ErrServerClosed.
+// Use [ConfigureTLSConfig] to configure a [tls.Config] for the QUIC listener.
+// Closing the server does not close the listener; closing the listener is the application's responsibility.
+// ServeListener always returns a non-nil error. After [Server.Shutdown] or [Server.Close],
+// it returns [http.ErrServerClosed].
 func (s *Server) ServeListener(ln QUICListener) error {
 	s.mutex.Lock()
 	if err := s.addListener(&ln, false); err != nil {
@@ -603,9 +602,10 @@ func (s *Server) maxHeaderBytes() int {
 	return s.MaxHeaderBytes
 }
 
-// Close the server immediately, aborting requests and sending CONNECTION_CLOSE frames to connected clients.
-// Close in combination with ListenAndServe() (instead of Serve()) may race if it is called before a UDP socket is established.
-// It is the caller's responsibility to close any connection passed to ServeQUICConn.
+// Close closes the server immediately, aborting requests and sending CONNECTION_CLOSE frames to connected clients.
+// Calling Close concurrently with [Server.ListenAndServe] may race with UDP socket creation;
+// use [Server.Serve] to avoid this.
+// It is the caller's responsibility to close any connection passed to [Server.ServeQUICConn].
 func (s *Server) Close() error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -634,9 +634,9 @@ func (s *Server) Close() error {
 }
 
 // Shutdown gracefully shuts down the server without interrupting any active connections.
-// The server sends a GOAWAY frame first, then or for all running requests to complete.
-// Shutdown in combination with ListenAndServe may race if it is called before a UDP socket is established.
-// It is recommended to use Serve instead.
+// The server sends a GOAWAY frame first, then waits for all running requests to complete.
+// Calling Shutdown concurrently with [Server.ListenAndServe] may race with UDP socket creation;
+// use [Server.Serve] to avoid this.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.mutex.Lock()
 	s.closed = true
@@ -679,17 +679,17 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 }
 
-// ErrNoAltSvcPort is the error returned by SetQUICHeaders when no port was found
-// for Alt-Svc to announce. This can happen if listening on a PacketConn without a port
-// (UNIX socket, for example) and no port is specified in Server.Port or Server.Addr.
+// ErrNoAltSvcPort is returned by [Server.SetQUICHeaders] when no port was found
+// for Alt-Svc to announce. This can happen if listening on a [net.PacketConn] without a port
+// (UNIX socket, for example) and no port is specified in [Server.Port] or [Server.Addr].
 var ErrNoAltSvcPort = errors.New("no port can be announced, specify it explicitly using Server.Port or Server.Addr")
 
 // SetQUICHeaders can be used to set the proper headers that announce that this server supports HTTP/3.
 // The values set by default advertise all the ports the server is listening on, but can be
-// changed to a specific port by setting Server.Port before launching the server.
-// If no listener's Addr().String() returns an address with a valid port, Server.Addr will be used
-// to extract the port, if specified.
-// For example, a server launched using ListenAndServe on an address with port 443 would set:
+// changed to a specific port by setting [Server.Port] before launching the server.
+// If none of the server's listeners report a valid port through [QUICListener.Addr],
+// [Server.Addr] is used to extract the port, if specified.
+// For example, a server launched using [Server.ListenAndServe] on an address with port 443 would set:
 //
 //	Alt-Svc: h3=":443"; ma=2592000
 func (s *Server) SetQUICHeaders(hdr http.Header) error {
@@ -705,7 +705,7 @@ func (s *Server) SetQUICHeaders(hdr http.Header) error {
 }
 
 // ListenAndServeQUIC listens on the UDP network address addr and calls the
-// handler for HTTP/3 requests on incoming connections. http.DefaultServeMux is
+// handler for HTTP/3 requests on incoming connections. [http.DefaultServeMux] is
 // used when handler is nil.
 func ListenAndServeQUIC(addr, certFile, keyFile string, handler http.Handler) error {
 	server := &Server{
@@ -717,7 +717,7 @@ func ListenAndServeQUIC(addr, certFile, keyFile string, handler http.Handler) er
 
 // ListenAndServeTLS listens on the given network address for both TLS/TCP and QUIC
 // connections in parallel. It returns if one of the two returns an error.
-// http.DefaultServeMux is used when handler is nil.
+// [http.DefaultServeMux] is used when handler is nil.
 // The correct Alt-Svc headers for QUIC are set.
 func ListenAndServeTLS(addr, certFile, keyFile string, handler http.Handler) error {
 	// Load certs

--- a/http3/server_conn.go
+++ b/http3/server_conn.go
@@ -79,7 +79,7 @@ func (c *RawServerConn) CloseWithError(code quic.ApplicationErrorCode, msg strin
 }
 
 // HandleRequestStream handles an HTTP/3 request on a bidirectional request stream.
-// The stream can either be obtained by calling AcceptStream on the underlying QUIC connection,
+// The stream can either be obtained by calling [quic.Conn.AcceptStream] on the underlying QUIC connection,
 // or (internally) by using the server's stream accept loop.
 func (c *RawServerConn) HandleRequestStream(str *quic.Stream) {
 	hstr := c.rawConn.TrackStream(str)

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -226,8 +226,8 @@ func newRequestStream(
 
 // Read reads data from the underlying stream.
 //
-// It can only be used after the request has been sent (using SendRequestHeader)
-// and the response has been consumed (using ReadResponse).
+// It can only be used after the request has been sent using [RequestStream.SendRequestHeader]
+// and [RequestStream.ReadResponse] has returned the response.
 func (s *RequestStream) Read(b []byte) (int, error) {
 	if s.responseBody == nil {
 		return 0, errors.New("http3: invalid use of RequestStream.Read before ReadResponse")
@@ -242,7 +242,7 @@ func (s *RequestStream) StreamID() quic.StreamID {
 
 // Write writes data to the stream.
 //
-// It can only be used after the request has been sent (using SendRequestHeader).
+// It can only be used after the request has been sent using [RequestStream.SendRequestHeader].
 func (s *RequestStream) Write(b []byte) (int, error) {
 	if !s.sentRequest {
 		return 0, errors.New("http3: invalid use of RequestStream.Write before SendRequestHeader")
@@ -251,7 +251,7 @@ func (s *RequestStream) Write(b []byte) (int, error) {
 }
 
 // TryWriteAll writes b if the entire DATA frame can be queued immediately.
-// It can only be used after the request has been sent (using SendRequestHeader).
+// It can only be used after the request has been sent using [RequestStream.SendRequestHeader].
 func (s *RequestStream) TryWriteAll(b []byte) error {
 	if !s.sentRequest {
 		return errors.New("http3: invalid use of RequestStream.TryWriteAll before SendRequestHeader")
@@ -283,23 +283,23 @@ func (s *RequestStream) Context() context.Context {
 	return s.str.Context()
 }
 
-// SetReadDeadline sets the deadline for Read calls.
+// SetReadDeadline sets the deadline for [RequestStream.Read] calls.
 func (s *RequestStream) SetReadDeadline(t time.Time) error {
 	return s.str.SetReadDeadline(t)
 }
 
-// SetWriteDeadline sets the deadline for Write calls.
+// SetWriteDeadline sets the deadline for [RequestStream.Write] calls.
 func (s *RequestStream) SetWriteDeadline(t time.Time) error {
 	return s.str.SetWriteDeadline(t)
 }
 
 // SetDeadline sets the read and write deadlines associated with the stream.
-// It is equivalent to calling both SetReadDeadline and SetWriteDeadline.
+// It is equivalent to calling both [RequestStream.SetReadDeadline] and [RequestStream.SetWriteDeadline].
 func (s *RequestStream) SetDeadline(t time.Time) error {
 	return s.str.SetDeadline(t)
 }
 
-// SendDatagrams send a new HTTP Datagram (RFC 9297).
+// SendDatagram sends a new HTTP Datagram (RFC 9297).
 //
 // It is only possible to send datagrams if the server enabled support for this extension.
 // It is recommended (though not required) to send the request before calling this method,
@@ -310,17 +310,15 @@ func (s *RequestStream) SendDatagram(b []byte) error {
 
 // ReceiveDatagram receives HTTP Datagrams (RFC 9297).
 //
-// It is only possible if support for HTTP Datagrams was enabled, using the EnableDatagram
-// option on the [Transport].
+// It is only possible if HTTP Datagram support was enabled using [Transport.EnableDatagrams].
 func (s *RequestStream) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 	return s.str.ReceiveDatagram(ctx)
 }
 
 // SendRequestHeader sends the HTTP request.
 //
-// It can only used for requests that don't have a request body.
+// It can only be used for requests that don't have a request body.
 // It is invalid to call it more than once.
-// It is invalid to call it after Write has been called.
 func (s *RequestStream) SendRequestHeader(req *http.Request) error {
 	if req.Body != nil && req.Body != http.NoBody {
 		return errors.New("http3: invalid use of RequestStream.SendRequestHeader with a request that has a request body")
@@ -349,10 +347,9 @@ func (s *RequestStream) sendRequestTrailer(req *http.Request) error {
 
 // ReadResponse reads the HTTP response from the stream.
 //
-// It must be called after sending the request (using SendRequestHeader).
+// It must be called after sending the request using [RequestStream.SendRequestHeader].
 // It is invalid to call it more than once.
-// It doesn't set Response.Request and Response.TLS.
-// It is invalid to call it after Read has been called.
+// It doesn't set [http.Response.Request] or [http.Response.TLS].
 func (s *RequestStream) ReadResponse() (*http.Response, error) {
 	if !s.sentRequest {
 		return nil, errors.New("http3: invalid use of RequestStream.ReadResponse before SendRequestHeader")

--- a/http3/transport.go
+++ b/http3/transport.go
@@ -30,10 +30,10 @@ type Settings struct {
 	Other map[uint64]uint64
 }
 
-// RoundTripOpt are options for the Transport.RoundTripOpt method.
+// RoundTripOpt contains options for [Transport.RoundTripOpt].
 type RoundTripOpt struct {
 	// OnlyCachedConn controls whether the Transport may create a new QUIC connection.
-	// If set true and no cached connection is available, RoundTripOpt will return ErrNoCachedConn.
+	// If true and no cached connection is available, [Transport.RoundTripOpt] returns [ErrNoCachedConn].
 	OnlyCachedConn bool
 }
 
@@ -62,24 +62,24 @@ func (r *roundTripperWithCount) Close() error {
 	return nil
 }
 
-// Transport implements the http.RoundTripper interface
+// Transport implements the [http.RoundTripper] interface.
 type Transport struct {
 	// TLSClientConfig specifies the TLS configuration to use with
-	// tls.Client. If nil, the default configuration is used.
+	// [tls.Client]. If nil, the default configuration is used.
 	TLSClientConfig *tls.Config
 
-	// QUICConfig is the quic.Config used for dialing new connections.
+	// QUICConfig is the [quic.Config] used for dialing new connections.
 	// If nil, reasonable default values will be used.
 	QUICConfig *quic.Config
 
 	// Dial specifies an optional dial function for creating QUIC
 	// connections for requests.
-	// If Dial is nil, a UDPConn will be created at the first request
+	// If [Transport.Dial] is nil, a [net.UDPConn] will be created at the first request
 	// and will be reused for subsequent connections to other servers.
 	Dial func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error)
 
 	// Enable support for HTTP/3 datagrams (RFC 9297).
-	// If a QUICConfig is set, datagram support also needs to be enabled on the QUIC layer by setting EnableDatagrams.
+	// If [Transport.QUICConfig] is set, [quic.Config.EnableDatagrams] must also be enabled.
 	EnableDatagrams bool
 
 	// Additional HTTP/3 settings.
@@ -118,9 +118,11 @@ var (
 )
 
 var (
-	// ErrNoCachedConn is returned when Transport.OnlyCachedConn is set
+	// ErrNoCachedConn is returned by [Transport.RoundTripOpt] when [RoundTripOpt.OnlyCachedConn]
+	// is true and no cached connection is available.
 	ErrNoCachedConn = errors.New("http3: no cached connection was available")
-	// ErrTransportClosed is returned when attempting to use a closed Transport
+	// ErrTransportClosed is returned by [Transport.RoundTrip] and [Transport.RoundTripOpt]
+	// after the transport is closed.
 	ErrTransportClosed = errors.New("http3: transport is closed")
 )
 
@@ -164,7 +166,7 @@ func (t *Transport) init() error {
 	return nil
 }
 
-// RoundTripOpt is like RoundTrip, but takes options.
+// RoundTripOpt is like [Transport.RoundTrip], but takes options.
 func (t *Transport) RoundTripOpt(req *http.Request, opt RoundTripOpt) (*http.Response, error) {
 	rsp, err := t.roundTripOpt(req, opt)
 	if err != nil {
@@ -426,10 +428,10 @@ func (t *Transport) removeClient(hostname string) {
 }
 
 // NewClientConn creates a new HTTP/3 client connection on top of a QUIC connection.
-// Most users should use RoundTrip instead of creating a connection directly.
+// Most users should use [Transport.RoundTrip] instead of creating a connection directly.
 // Specifically, it is not needed to perform GET, POST, HEAD and CONNECT requests.
 //
-// Obtaining a ClientConn is only needed for more advanced use cases, such as
+// Obtaining a [ClientConn] is only needed for more advanced use cases, such as
 // using Extended CONNECT for WebTransport or the various MASQUE protocols.
 func (t *Transport) NewClientConn(conn *quic.Conn) *ClientConn {
 	c := newClientConn(
@@ -453,9 +455,9 @@ func (t *Transport) NewClientConn(conn *quic.Conn) *ClientConn {
 }
 
 // NewRawClientConn creates a new low-level HTTP/3 client connection on top of a QUIC connection.
-// Unlike NewClientConn, the returned RawClientConn allows the application to take control
-// of the stream accept loops, by calling HandleUnidirectionalStream for incoming unidirectional
-// streams and HandleBidirectionalStream for incoming bidirectional streams.
+// Unlike [Transport.NewClientConn], the returned [RawClientConn] allows the application to take control
+// of the stream accept loops by calling [RawClientConn.HandleUnidirectionalStream] for incoming
+// unidirectional streams and [ClientConn.HandleBidirectionalStream] for incoming bidirectional streams.
 func (t *Transport) NewRawClientConn(conn *quic.Conn) *RawClientConn {
 	return &RawClientConn{
 		ClientConn: newClientConn(
@@ -525,7 +527,7 @@ func isNotToken(r rune) bool {
 // CloseIdleConnections closes any QUIC connections in the transport's pool that are currently idle.
 // An idle connection is one that was previously used for requests but is now sitting unused.
 // This method does not interrupt any connections currently in use.
-// It also does not affect connections obtained via NewClientConn.
+// It also does not affect connections obtained via [Transport.NewClientConn].
 func (t *Transport) CloseIdleConnections() {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()

--- a/interface.go
+++ b/interface.go
@@ -50,10 +50,10 @@ type TokenStore interface {
 	Put(key string, token *ClientToken)
 }
 
-// Err0RTTRejected is the returned from:
-//   - Open{Uni}Stream{Sync}
-//   - Accept{Uni}Stream
-//   - Stream.Read and Stream.Write
+// Err0RTTRejected can be returned by methods such as:
+//   - [Conn.OpenStream], [Conn.OpenStreamSync], [Conn.OpenUniStream], and [Conn.OpenUniStreamSync]
+//   - [Conn.AcceptStream] and [Conn.AcceptUniStream]
+//   - [Stream.Read] and [Stream.Write]
 //
 // when the server rejects a 0-RTT connection attempt.
 var Err0RTTRejected = errors.New("0-RTT rejected")
@@ -65,7 +65,7 @@ var ErrWouldBlock = errors.New("operation would block")
 var ErrWriteLimitReached = errors.New("write limit reached")
 
 // QUICVersionContextKey can be used to find out the QUIC version of a TLS handshake from the
-// context returned by tls.Config.ClientInfo.Context.
+// context returned by [tls.ClientHelloInfo.Context].
 var QUICVersionContextKey = handshake.QUICVersionContextKey
 
 // StatelessResetKey is a key used to derive stateless reset tokens.
@@ -190,9 +190,10 @@ type ClientInfo struct {
 	// RemoteAddr is the remote address on the Initial packet.
 	// Unless AddrVerified is set, the address is not yet verified, and could be a spoofed IP address.
 	RemoteAddr net.Addr
-	// AddrVerified says if the remote address was verified using QUIC's Retry mechanism.
-	// Note that the Retry mechanism costs one network roundtrip,
-	// and is not performed unless Transport.MaxUnvalidatedHandshakes is surpassed.
+	// AddrVerified reports whether the remote address was verified by a valid address validation token,
+	// including a token received in a NEW_TOKEN frame.
+	// The Retry mechanism costs one network roundtrip and is only used when
+	// [Transport.VerifySourceAddress] requests it.
 	AddrVerified bool
 }
 

--- a/path_manager_outgoing.go
+++ b/path_manager_outgoing.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	// ErrPathClosed is returned when trying to switch to a path that has been closed.
+	// ErrPathClosed can be returned by [Path.Probe] or [Path.Switch] after the path has been closed.
 	ErrPathClosed = errors.New("path closed")
-	// ErrPathNotValidated is returned when trying to use a path before path probing has completed.
+	// ErrPathNotValidated is returned by [Path.Switch] when the path has not yet been validated.
 	ErrPathNotValidated = errors.New("path not yet validated")
 )
 
@@ -88,7 +88,7 @@ func (p *Path) Switch() error {
 
 // Close abandons a path.
 // It is not possible to close the path that’s currently active.
-// After closing, it is not possible to probe this path again.
+// After closing, the path cannot be successfully probed again with [Path.Probe].
 func (p *Path) Close() error {
 	select {
 	case <-p.abandon:

--- a/qlog/event.go
+++ b/qlog/event.go
@@ -434,7 +434,7 @@ func (e MTUUpdated) Encode(enc *jsontext.Encoder, _ time.Time) error {
 
 // MetricsUpdated logs RTT and congestion metrics as defined in the
 // recovery:metrics_updated event.
-// The PTO count is logged via PTOCountUpdated.
+// The PTO count is logged via [PTOCountUpdated].
 type MetricsUpdated struct {
 	MinRTT           time.Duration
 	SmoothedRTT      time.Duration

--- a/qlogwriter/writer.go
+++ b/qlogwriter/writer.go
@@ -28,16 +28,16 @@ type Trace interface {
 // It is safe for concurrent use by multiple goroutines.
 type Recorder interface {
 	// RecordEvent records a single Event to the trace.
-	// It must not be called after Close.
+	// It must not be called after the recorder has been closed.
 	RecordEvent(Event)
 	// Close signals that this producer is done recording events.
 	// When all producers are closed, the underlying trace is closed.
-	// It must not be called concurrently with RecordEvent.
+	// It must not be called concurrently with [Recorder.RecordEvent].
 	io.Closer
 }
 
 // Event represents a qlog event that can be encoded to JSON.
-// Each event must provide its name and a method to encode itself using a jsontext.Encoder.
+// Each event must implement [Event.Name] and [Event.Encode].
 type Event interface {
 	// Name returns the name of the event, as it should appear in the qlog output
 	Name() string
@@ -59,7 +59,7 @@ const eventChanSize = 50
 
 // FileSeq represents a qlog trace using the JSON-SEQ format,
 // https://www.ietf.org/archive/id/draft-ietf-quic-qlog-main-schema-12.html#section-5
-// qlog event producers can be created by calling AddProducer.
+// qlog event producers can be created by calling [FileSeq.AddProducer].
 // The underlying io.WriteCloser is closed when the last producer is removed.
 type FileSeq struct {
 	w             io.WriteCloser

--- a/receive_stream.go
+++ b/receive_stream.go
@@ -269,9 +269,9 @@ func (s *ReceiveStream) isRemoteCancellationEffective() bool {
 
 // Peek fills b with stream data, without consuming the stream data.
 // It blocks until len(b) bytes are available, or an error occurs.
-// It respects the stream deadline set by SetReadDeadline.
+// It respects the stream deadline set by [ReceiveStream.SetReadDeadline].
 // If the stream ends before len(b) bytes are available,
-// it returns the number of bytes peeked along with io.EOF.
+// it returns the number of bytes peeked along with [io.EOF].
 func (s *ReceiveStream) Peek(b []byte) (int, error) {
 	if len(b) == 0 {
 		return 0, nil
@@ -395,8 +395,8 @@ func (s *ReceiveStream) dequeueNextFrame() {
 
 // CancelRead aborts receiving on this stream.
 // It instructs the peer to stop transmitting stream data.
-// Read will unblock immediately, and future Read calls will fail.
-// When called multiple times or after reading the io.EOF it is a no-op.
+// [ReceiveStream.Read] will unblock immediately, and future calls to it will fail.
+// When called multiple times or after [ReceiveStream.Read] returns [io.EOF], it is a no-op.
 func (s *ReceiveStream) CancelRead(errorCode StreamErrorCode) {
 	s.mutex.Lock()
 	queuedNewControlFrame := s.cancelReadImpl(errorCode)
@@ -547,9 +547,9 @@ func (s *ReceiveStream) getControlFrame(now monotime.Time) (_ ackhandler.Frame, 
 	}, true, false
 }
 
-// SetReadDeadline sets the deadline for future Read calls and
-// any currently-blocked Read call.
-// A zero value for t means Read will not time out.
+// SetReadDeadline sets the deadline for future [ReceiveStream.Read] calls and
+// any currently blocked call.
+// A zero value for t means [ReceiveStream.Read] will not time out.
 func (s *ReceiveStream) SetReadDeadline(t time.Time) error {
 	s.mutex.Lock()
 	s.deadline = monotime.FromTime(t)

--- a/send_stream.go
+++ b/send_stream.go
@@ -576,9 +576,9 @@ func (s *SendStream) isNewlyCompleted() bool {
 }
 
 // Close closes the write-direction of the stream.
-// Future calls to Write are not permitted after calling Close.
-// It must not be called concurrently with Write.
-// It must not be called after calling CancelWrite.
+// Future calls to [SendStream.Write] are not permitted after calling Close.
+// It must not be called concurrently with [SendStream.Write].
+// It must not be called after calling [SendStream.CancelWrite].
 func (s *SendStream) Close() error {
 	s.mutex.Lock()
 	if s.shutdownErr != nil || s.finishedWriting {
@@ -636,9 +636,9 @@ func (s *SendStream) returnFramesToPool() {
 
 // CancelWrite aborts sending on this stream.
 // Data already written, but not yet delivered to the peer is not guaranteed to be delivered reliably.
-// Write will unblock immediately, and future calls to Write will fail.
+// [SendStream.Write] will unblock immediately, and future calls to it will fail.
 // When called multiple times it is a no-op.
-// When called after Close, it aborts reliable delivery of outstanding stream data.
+// When called after [SendStream.Close], it aborts reliable delivery of outstanding stream data.
 // Note that there is no guarantee if the peer will receive the FIN or the cancellation error first.
 func (s *SendStream) CancelWrite(errorCode StreamErrorCode) {
 	s.mutex.Lock()
@@ -816,19 +816,19 @@ func (s *SendStream) SetPriority(urgency int8, incremental bool) {
 }
 
 // The Context is canceled as soon as the write-side of the stream is closed.
-// This happens when Close() or CancelWrite() is called, or when the peer
+// This happens when [SendStream.Close] or [SendStream.CancelWrite] is called, or when the peer
 // cancels the read-side of their stream.
 // The cancellation cause is set to the error that caused the stream to
-// close, or `context.Canceled` in case the stream is closed without error.
+// close, or [context.Canceled] in case the stream is closed without error.
 func (s *SendStream) Context() context.Context {
 	return s.ctx
 }
 
-// SetWriteDeadline sets the deadline for future Write calls
-// and any currently-blocked Write call.
+// SetWriteDeadline sets the deadline for future [SendStream.Write] calls
+// and any currently blocked call.
 // Even if write times out, it may return n > 0, indicating that
 // some data was successfully written.
-// A zero value for t means Write will not time out.
+// A zero value for t means [SendStream.Write] will not time out.
 func (s *SendStream) SetWriteDeadline(t time.Time) error {
 	s.mutex.Lock()
 	s.deadline = monotime.FromTime(t)

--- a/server.go
+++ b/server.go
@@ -19,7 +19,8 @@ import (
 	"github.com/quic-go/quic-go/qlogwriter"
 )
 
-// ErrServerClosed is returned by the [Listener] or [EarlyListener]'s Accept method after a call to Close.
+// ErrServerClosed is returned by [Listener.Accept] or [EarlyListener.Accept]
+// after [Listener.Close] or [EarlyListener.Close] is called, respectively.
 var ErrServerClosed = errServerClosed{}
 
 type errServerClosed struct{}
@@ -132,7 +133,7 @@ func (l *Listener) Accept(ctx context.Context) (*Conn, error) {
 }
 
 // Close closes the listener.
-// Accept will return [ErrServerClosed] as soon as all connections in the accept queue have been accepted.
+// [Listener.Accept] will return [ErrServerClosed] as soon as all connections in the accept queue have been accepted.
 // QUIC handshakes that are still in flight will be rejected with a CONNECTION_REFUSED error.
 // Already established (accepted) connections will be unaffected.
 func (l *Listener) Close() error {
@@ -164,7 +165,7 @@ func (l *EarlyListener) Accept(ctx context.Context) (*Conn, error) {
 }
 
 // Close closes the listener.
-// Accept will return [ErrServerClosed] as soon as all connections in the accept queue have been accepted.
+// [EarlyListener.Accept] will return [ErrServerClosed] as soon as all connections in the accept queue have been accepted.
 // Early connections that are still in flight will be rejected with a CONNECTION_REFUSED error.
 // Already established (accepted) connections will be unaffected.
 func (l *EarlyListener) Close() error {
@@ -211,15 +212,16 @@ func listenUDP(addr string) (*net.UDPConn, error) {
 	return net.ListenUDP("udp", udpAddr)
 }
 
-// Listen listens for QUIC connections on a given net.PacketConn.
+// Listen listens for QUIC connections on a given [net.PacketConn].
 // If the PacketConn satisfies the [OOBCapablePacketConn] interface (as a [net.UDPConn] does),
-// ECN and packet info support will be enabled. In this case, ReadMsgUDP and WriteMsgUDP
-// will be used instead of ReadFrom and WriteTo to read/write packets.
-// A single net.PacketConn can only be used for a single call to Listen.
+// ECN and packet info support will be enabled. In this case, [OOBCapablePacketConn.ReadMsgUDP]
+// and [OOBCapablePacketConn.WriteMsgUDP] will be used instead of [net.PacketConn.ReadFrom]
+// and [net.PacketConn.WriteTo] to read/write packets.
+// A single [net.PacketConn] can only be used for a single call to Listen.
 //
-// The tls.Config must not be nil and must contain a certificate configuration.
-// Furthermore, it must define an application control (using [NextProtos]).
-// The quic.Config may be nil, in that case the default values will be used.
+// The [tls.Config] must not be nil and must contain a certificate configuration.
+// Furthermore, it must define an application protocol using [tls.Config.NextProtos].
+// The [Config] may be nil, in which case the default values will be used.
 //
 // This is a convenience function. More advanced use cases should instantiate a [Transport],
 // which offers configuration options for a more fine-grained control of the connection establishment,

--- a/stream.go
+++ b/stream.go
@@ -126,9 +126,9 @@ func (s *Stream) Read(p []byte) (int, error) {
 
 // Peek fills b with stream data, without consuming the stream data.
 // It blocks until len(b) bytes are available, or an error occurs.
-// It respects the stream deadline set by SetReadDeadline.
+// It respects the stream deadline set by [Stream.SetReadDeadline].
 // If the stream ends before len(b) bytes are available,
-// it returns the number of bytes peeked along with io.EOF.
+// it returns the number of bytes peeked along with [io.EOF].
 func (s *Stream) Peek(b []byte) (int, error) {
 	return s.receiveStr.Peek(b)
 }
@@ -224,20 +224,20 @@ func (s *Stream) getControlFrame(now monotime.Time) (_ ackhandler.Frame, ok, has
 	return s.receiveStr.getControlFrame(now)
 }
 
-// SetReadDeadline sets the deadline for future Read calls.
+// SetReadDeadline sets the deadline for future [Stream.Read] calls.
 // See [ReceiveStream.SetReadDeadline] for more details.
 func (s *Stream) SetReadDeadline(t time.Time) error {
 	return s.receiveStr.SetReadDeadline(t)
 }
 
-// SetWriteDeadline sets the deadline for future Write calls.
+// SetWriteDeadline sets the deadline for future [Stream.Write] calls.
 // See [SendStream.SetWriteDeadline] for more details.
 func (s *Stream) SetWriteDeadline(t time.Time) error {
 	return s.sendStr.SetWriteDeadline(t)
 }
 
 // SetDeadline sets the read and write deadlines associated with the stream.
-// It is equivalent to calling both SetReadDeadline and SetWriteDeadline.
+// It is equivalent to calling both [Stream.SetReadDeadline] and [Stream.SetWriteDeadline].
 func (s *Stream) SetDeadline(t time.Time) error {
 	_ = s.receiveStr.SetReadDeadline(t) // SetReadDeadline never errors
 	_ = s.sendStr.SetWriteDeadline(t)   // SetWriteDeadline never errors

--- a/streams_map.go
+++ b/streams_map.go
@@ -11,8 +11,8 @@ import (
 	"github.com/quic-go/quic-go/internal/wire"
 )
 
-// StreamLimitReachedError is returned from Conn.OpenStream and Conn.OpenUniStream
-// when it is not possible to open a new stream because the number of opens streams reached
+// StreamLimitReachedError is returned from [Conn.OpenStream] and [Conn.OpenUniStream]
+// when it is not possible to open a new stream because the number of open streams has reached
 // the peer's stream limit.
 type StreamLimitReachedError struct{}
 

--- a/sys_conn.go
+++ b/sys_conn.go
@@ -41,7 +41,8 @@ type rawConn interface {
 
 // OOBCapablePacketConn is a connection that allows the reading of ECN bits from the IP header.
 // If the PacketConn passed to the [Transport] satisfies this interface, quic-go will use it.
-// In this case, ReadMsgUDP() will be used instead of ReadFrom() to read packets.
+// In this case, [OOBCapablePacketConn.ReadMsgUDP] will be used instead of
+// [net.PacketConn.ReadFrom] to read packets.
 type OOBCapablePacketConn interface {
 	net.PacketConn
 	SyscallConn() (syscall.RawConn, error)

--- a/transport.go
+++ b/transport.go
@@ -18,7 +18,8 @@ import (
 	"github.com/quic-go/quic-go/qlogwriter"
 )
 
-// ErrTransportClosed is returned by the [Transport]'s Listen or Dial method after it was closed.
+// ErrTransportClosed is returned by [Transport.Listen], [Transport.ListenEarly], [Transport.Dial],
+// or [Transport.DialEarly] after [Transport.Close] is called.
 var ErrTransportClosed = &errTransportClosed{}
 
 type errTransportClosed struct {
@@ -51,14 +52,14 @@ type closePacket struct {
 // QUIC demultiplexes connections based on their QUIC Connection IDs, not based on the 4-tuple.
 // This means that a single UDP socket can be used for listening for incoming connections, as well as
 // for dialing an arbitrary number of outgoing connections.
-// A Transport handles a single net.PacketConn, and offers a range of configuration options
+// A Transport handles a single [net.PacketConn], and offers a range of configuration options
 // compared to the simple helper functions like [Listen] and [Dial] that this package provides.
 type Transport struct {
-	// A single net.PacketConn can only be handled by one Transport.
+	// A single [net.PacketConn] can only be handled by one Transport.
 	// Bad things will happen if passed to multiple Transports.
 	//
-	// A number of optimizations will be enabled if the connections implements the OOBCapablePacketConn interface,
-	// as a *net.UDPConn does.
+	// A number of optimizations will be enabled if the connection implements [OOBCapablePacketConn],
+	// as a [net.UDPConn] does.
 	// 1. It enables the Don't Fragment (DF) bit on the IP header.
 	//    This is required to run DPLPMTUD (Path MTU Discovery, RFC 8899).
 	// 2. It enables reading of the ECN bits from the IP header.
@@ -66,7 +67,9 @@ type Transport struct {
 	// 3. It uses batched syscalls (recvmmsg) to more efficiently receive packets from the socket.
 	// 4. It uses Generic Segmentation Offload (GSO) to efficiently send batches of packets (on Linux).
 	//
-	// After passing the connection to the Transport, it's invalid to call ReadFrom or WriteTo on the connection.
+	// After passing the connection to the Transport, it's invalid to call [net.PacketConn.ReadFrom],
+	// [net.PacketConn.WriteTo], [OOBCapablePacketConn.ReadMsgUDP], or
+	// [OOBCapablePacketConn.WriteMsgUDP] on the connection.
 	Conn net.PacketConn
 
 	// The length of the connection ID in bytes.
@@ -123,15 +126,15 @@ type Transport struct {
 	// The context is closed when the connection is closed, or when the handshake fails for any reason.
 	// The context returned from the callback is used to derive every other context used during the
 	// lifetime of the connection:
-	// * the context passed to crypto/tls (and used on the tls.ClientHelloInfo)
-	// * the context used in Config.QlogTrace
-	// * the context returned from Conn.Context
-	// * the context returned from SendStream.Context
+	// * the context passed to crypto/tls (and used on the [tls.ClientHelloInfo])
+	// * the context used by [Config.Tracer]
+	// * the context returned from [Conn.Context]
+	// * the context returned from [SendStream.Context]
 	// It is not used for dialed connections.
 	ConnContext func(context.Context, *ClientInfo) (context.Context, error)
 
 	// A Tracer traces events that don't belong to a single QUIC connection.
-	// Recorder.Close is called when the transport is closed.
+	// The [qlogwriter.Recorder] is closed when the transport is closed.
 	Tracer qlogwriter.Recorder
 
 	mutex       sync.Mutex
@@ -450,7 +453,7 @@ func (t *Transport) runSendQueue() {
 	}
 }
 
-// Close stops listening for UDP datagrams on the Transport.Conn.
+// Close stops listening for UDP datagrams on [Transport.Conn].
 // It abruptly terminates all existing connections, without sending a CONNECTION_CLOSE
 // to the peers. It is the application's responsibility to cleanly terminate existing
 // connections prior to calling Close.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add link-style API cross-references to documentation comments across the codebase
> Updates doc comments throughout the library to use Go's `[Type.Method]` link syntax, replacing plain-text references with navigable hyperlinks in generated documentation. Changes span public types, methods, variables, and fields across core QUIC and HTTP/3 packages. No code logic is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff271f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved public API documentation with consistent Go links and clearer cross-references.
  * Clarified connection, stream, datagram, deadline, error, listener, and transport behavior.
  * Added guidance for HTTP/3 settings, capsule handling, server lifecycle, request streams, and connection ownership.
  * Corrected descriptions of TLS configuration, retries, propagation points, listener behavior, and tracer handling.
  * No runtime behavior or public API signatures changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->