### PR TITLE
Retire the connection ID when closing a validated path

### DIFF
--- a/path_manager_outgoing.go
+++ b/path_manager_outgoing.go
@@ -188,15 +188,10 @@ func (pm *pathManagerOutgoing) removePathImpl(id pathID) error {
 	if id == pm.activePath {
 		return errors.New("cannot close active path")
 	}
-	p, ok := pm.paths[id]
-	if !ok {
+	if _, ok := pm.paths[id]; !ok {
 		return nil
 	}
-	// A connection ID was allocated to this path if it was ever probed. Both
-	// terms are needed: pathChallenges is cleared when the path validates.
-	if len(p.pathChallenges) > 0 || p.isValidated {
-		pm.retireConnID(id)
-	}
+	pm.retireConnID(id)
 	delete(pm.paths, id)
 	return nil
 }

--- a/path_manager_outgoing.go
+++ b/path_manager_outgoing.go
@@ -192,7 +192,9 @@ func (pm *pathManagerOutgoing) removePathImpl(id pathID) error {
 	if !ok {
 		return nil
 	}
-	if len(p.pathChallenges) > 0 {
+	// A connection ID was allocated to this path if it was ever probed. Both
+	// terms are needed: pathChallenges is cleared when the path validates.
+	if len(p.pathChallenges) > 0 || p.isValidated {
 		pm.retireConnID(id)
 	}
 	delete(pm.paths, id)

--- a/path_manager_outgoing_test.go
+++ b/path_manager_outgoing_test.go
@@ -264,7 +264,7 @@ func TestPathManagerOutgoingAbandonPath(t *testing.T) {
 		default:
 			t.Fatal("should have received a path closed error")
 		}
-		require.Empty(t, retiredPaths)
+		require.Equal(t, []pathID{p1.id}, retiredPaths)
 
 		p2 := pm.NewPath(&Transport{}, time.Second, func() {})
 		go func() { errChan <- p2.Probe(context.Background()) }()
@@ -277,7 +277,7 @@ func TestPathManagerOutgoingAbandonPath(t *testing.T) {
 		require.Equal(t, protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}), connID)
 
 		require.NoError(t, p2.Close())
-		require.Equal(t, []pathID{p2.id}, retiredPaths)
+		require.Equal(t, []pathID{p1.id, p2.id}, retiredPaths)
 		pm.HandlePathResponseFrame(&wire.PathResponseFrame{Data: f.Frame.(*wire.PathChallengeFrame).Data})
 		_, _, _, ok = pm.NextPathToProbe()
 		require.False(t, ok)

--- a/path_manager_outgoing_test.go
+++ b/path_manager_outgoing_test.go
@@ -285,3 +285,46 @@ func TestPathManagerOutgoingAbandonPath(t *testing.T) {
 		require.ErrorIs(t, p2.Switch(), ErrPathClosed)
 	})
 }
+
+// TestPathManagerOutgoingAbandonValidatedPath tests that closing a path that has
+// already been validated retires the connection ID allocated to it.
+// TestPathManagerOutgoingAbandonPath covers closing a path before validation,
+// which is a different case: pathChallenges is cleared once the path validates.
+func TestPathManagerOutgoingAbandonValidatedPath(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		connIDs := []protocol.ConnectionID{
+			protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+		}
+		var retiredPaths []pathID
+		pm := newPathManagerOutgoing(
+			func(id pathID) (protocol.ConnectionID, bool) {
+				if len(connIDs) == 0 {
+					return protocol.ConnectionID{}, false
+				}
+				connID := connIDs[0]
+				connIDs = connIDs[1:]
+				return connID, true
+			},
+			func(id pathID) { retiredPaths = append(retiredPaths, id) },
+			func() {},
+		)
+
+		p := pm.NewPath(&Transport{}, time.Second, func() {})
+		errChan := make(chan error, 1)
+		go func() { errChan <- p.Probe(context.Background()) }()
+		synctest.Wait()
+
+		_, f, _, ok := pm.NextPathToProbe()
+		require.True(t, ok)
+
+		// Validate the path before abandoning it. This is the ordering an
+		// application produces: probe, use the path, and abandon it later.
+		pm.HandlePathResponseFrame(&wire.PathResponseFrame{Data: f.Frame.(*wire.PathChallengeFrame).Data})
+		synctest.Wait()
+		require.NoError(t, <-errChan)
+
+		require.NoError(t, p.Close())
+		require.Equal(t, []pathID{p.id}, retiredPaths,
+			"the connection ID of a validated path must be retired when the path is abandoned")
+	})
+}


### PR DESCRIPTION
`pathManagerOutgoing.removePathImpl` decides whether to retire the connection ID
allocated to a path by testing `len(p.pathChallenges) > 0`:

```go
if len(p.pathChallenges) > 0 {
    pm.retireConnID(id)
}
```

That stands in for "a connection ID was allocated to this path", but
`HandlePathResponseFrame` clears `pathChallenges` when the path is validated:

```go
if !p.isValidated {
    p.isValidated = true
    p.pathChallenges = nil
    close(p.validated)
}
```

So probing a path and abandoning it before validation still works, but it leaks
if you use the path: no `RETIRE_CONNECTION_ID` is sent, the peer never issues a
replacement, and the connection ID stays allocated for the lifetime of the
connection.

This defeats the stated purpose of #4979, which added path closing "to retire
(and thereby get replacements for) connection IDs that were used for probing
paths for connection migration".

`TestPathManagerOutgoingAbandonPath` covers only the unvalidated case — it calls
`Close()` before delivering the `PATH_RESPONSE` — which is why this wasn't
caught.

### Fix

Add a `connIDAllocated` flag to `pathOutgoing`, set it in `NextPathToProbe`
where `getConnID` succeeds, and test that in `removePathImpl` instead of
`pathChallenges`.

### Test

`TestPathManagerOutgoingAbandonValidatedPath` validates a path before abandoning
it and asserts the connection ID is retired. It fails on master:

```
    Error:   Not equal:
             expected: []quic.pathID{1}
             actual  : []quic.pathID(nil)
    Messages: the connection ID of a validated path must be retired when the path is abandoned
```

### Scope

This doesn't on its own change how many times a connection can migrate: in an
end-to-end test the peer separately runs out of connection IDs issued to it
("skipping validation of new path ... since no connection ID is available").
There may yet be something to solve there, but it should be a separate fix.

Unrelated to #5236, which is about promotion rather than retirement.

---

For context on why we're looking at this: our use case is mobile clients with
long-running sessions, where migrations between cellular and Wi-Fi and back can
happen many times over the course of a day.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection cleanup when abandoning a successfully validated path.
  * Ensured allocated connection IDs are retired reliably when paths are removed.

* **Tests**
  * Added coverage for closing validated paths after probing and confirming connection ID cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always retire connection ID when closing a validated or unvalidated path
> Changes `pathManagerOutgoing.removePathImpl` to unconditionally retire the connection ID for any non-active path being removed. Previously, retirement only happened when the path had pending `PATH_CHALLENGE` frames, so already-validated paths or paths abandoned before challenge could leak connection IDs.
> - Updates `TestPathManagerOutgoingAbandonPath` to assert retirement occurs even before `PATH_CHALLENGE` is sent.
> - Adds `TestPathManagerOutgoingAbandonValidatedPath` to confirm a validated path's connection ID is retired on close.
> - Behavioral Change: removing a non-active path now always retires its connection ID, increasing retirement traffic for paths that previously skipped it.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f26ede1. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->