### PR TITLE
update to Go 1.27, drop Go 1.25

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "1.27.x"
           check-latest: true
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3

--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.25.x", "1.26.x", "1.27.0-rc.1" ]
+        go: [ "1.26.x", "1.27.x" ]
     runs-on: ${{ fromJSON(vars['CROSS_COMPILE_RUNNER_UBUNTU'] || '"ubuntu-latest"') }}
     name: "Cross Compilation (Go ${{matrix.go}})"
     timeout-minutes: 30

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "1.27.x"
           check-latest: true
       - name: Run govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,17 +8,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu" ]
-        go: [ "1.25.x", "1.26.x", "1.27.0-rc.1" ]
+        go: [ "1.26.x", "1.27.x" ]
         race: [ false ]
         include:
           - os: "ubuntu"
-            go: "1.25.x"
+            go: "1.27.x"
             race: true
           - os: "windows"
-            go: "1.25.x"
+            go: "1.27.x"
             race: false
           - os: "macos"
-            go: "1.25.x"
+            go: "1.27.x"
             race: false
     runs-on: ${{ fromJSON(vars[format('INTEGRATION_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
     timeout-minutes: 30
@@ -49,7 +49,7 @@ jobs:
       - name: Run version negotiation tests
         run: go test ${{ env.RACEFLAG }} -v -timeout 30s -shuffle=on ./integrationtests/versionnegotiation ${{ env.QLOGFLAG }} 2>&1 | go-junit-report -set-exit-code -iocopy -out report_versionnegotiation.xml
       - name: Run FIPS 140 tests
-        if: ${{ matrix.go != '1.25.x' && (success() || failure()) }}
+        if: success() || failure()
         working-directory: integrationtests/fips
         run: go test -v -timeout 1m -shuffle=on . 2>&1 | go-junit-report -set-exit-code -iocopy -out ../../report_fips.xml
       - name: Run self tests, using QUIC v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,11 @@ jobs:
         run: go mod tidy -diff
       - name: Run go fix
         if: success() || failure() # run this step even if the previous one failed
-        run: go fix -diff ./...
+        run: |
+          set -o pipefail
+          # slices.Backward is measurably slower in receivedPacketHistory.
+          go list ./... | grep -v '/internal/ackhandler$' | xargs go fix -diff
+          go fix -diff -slicesbackward=false ./internal/ackhandler
       - name: Run code generators
         if: success() || failure() # run this step even if the previous one failed
         run: .github/workflows/go-generate.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "1.27.x"
           check-latest: true
       - name: Check for //go:build ignore in .go files
         run: |
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.25.x", "1.26.x" ]
+        go: [ "1.26.x", "1.27.x" ]
     env:
       GOLANGCI_LINT_VERSION: v2.13.0
     name: golangci-lint (Go ${{ matrix.go }})

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu", "windows", "macos" ]
-        go: [ "1.25.x", "1.26.x", "1.27.0-rc.1" ]
+        go: [ "1.26.x", "1.27.x" ]
     runs-on: ${{ fromJSON(vars[format('UNIT_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
     name: Unit tests (${{ matrix.os}}, Go ${{ matrix.go }})
     timeout-minutes: 30
@@ -45,7 +45,6 @@ jobs:
           TIMESCALE_FACTOR: 20
         run: go test -v -shuffle on ./...
       - name: Run handshake tests in FIPS140 mode
-        if: ${{ matrix.go != '1.25.x' }}
         env:
           GODEBUG: fips140=only
         run: go test -v ./internal/handshake -run 'TestToken|TestRetry|TestInitial|TestDecode|TestEncrypt'

--- a/connection.go
+++ b/connection.go
@@ -745,7 +745,7 @@ runLoop:
 	c.sendQueue.Close() // close the send queue before sending the CONNECTION_CLOSE
 	c.handleCloseError(closeErr)
 	if c.qlogger != nil {
-		if e := (&errCloseForRecreating{}); !errors.As(closeErr.err, &e) {
+		if _, ok := errors.AsType[*errCloseForRecreating](closeErr.err); !ok {
 			c.qlogger.Close()
 		}
 	}
@@ -1435,8 +1435,7 @@ func (c *Conn) handleUnpackError(err error, p receivedPacket, pt qlog.PacketType
 		c.logger.Debugf("Dropping %s packet (%d bytes) that could not be unpacked. Error: %s", pt, p.Size(), err)
 		return false, nil
 	default:
-		var headerErr *headerParseError
-		if errors.As(err, &headerErr) {
+		if _, ok := errors.AsType[*headerParseError](err); ok {
 			// This might be a packet injected by an attacker. Drop it.
 			if c.qlogger != nil {
 				connID, _ := wire.ParseConnectionID(p.data, c.srcConnIDLen)
@@ -2846,11 +2845,9 @@ func (c *Conn) sendPackedCoalescedPacket(packet *coalescedPacket, ecn protocol.E
 func (c *Conn) sendConnectionClose(e error) ([]byte, error) {
 	var packet *coalescedPacket
 	var err error
-	var transportErr *qerr.TransportError
-	var applicationErr *qerr.ApplicationError
-	if errors.As(e, &transportErr) {
+	if transportErr, ok := errors.AsType[*qerr.TransportError](e); ok {
 		packet, err = c.packer.PackConnectionClose(transportErr, c.maxPacketSize(), c.version)
-	} else if errors.As(e, &applicationErr) {
+	} else if applicationErr, ok := errors.AsType[*qerr.ApplicationError](e); ok {
 		packet, err = c.packer.PackApplicationClose(applicationErr, c.maxPacketSize(), c.version)
 	} else {
 		packet, err = c.packer.PackConnectionClose(&qerr.TransportError{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quic-go/quic-go
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/quic-go/go-ossfuzz-seeds v0.1.0

--- a/http3/client.go
+++ b/http3/client.go
@@ -206,8 +206,8 @@ func (c *ClientConn) handleControlStream(str *quic.ReceiveStream, fp *frameParse
 				c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
 				return
 			}
-			var serr *quic.StreamError
-			if err == io.EOF || errors.As(err, &serr) {
+			_, isStreamError := errors.AsType[*quic.StreamError](err)
+			if err == io.EOF || isStreamError {
 				c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeClosedCriticalStream), "")
 				return
 			}

--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -60,7 +60,7 @@ func testClientSettings(t *testing.T, enableDatagrams bool, other map[uint64]uin
 
 	var datagramValue *bool
 	if enableDatagrams {
-		datagramValue = pointer(true)
+		datagramValue = new(true)
 	}
 	require.Equal(t,
 		[]qlogwriter.Event{

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -96,10 +96,10 @@ func (c *rawConn) openControlStream(settings *settingsFrame) (*quic.SendStream, 
 			Other:               maps.Clone(settings.Other),
 		}
 		if settings.Datagram {
-			sf.Datagram = pointer(true)
+			sf.Datagram = new(true)
 		}
 		if settings.ExtendedConnect {
-			sf.ExtendedConnect = pointer(true)
+			sf.ExtendedConnect = new(true)
 		}
 		c.qlogger.RecordEvent(qlog.FrameCreated{
 			StreamID: str.StreamID(),

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -220,8 +220,8 @@ func (c *rawConn) handleControlStream(str *quic.ReceiveStream) {
 			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeMissingSettings), "")
 			return
 		}
-		var serr *quic.StreamError
-		if err == io.EOF || errors.As(err, &serr) {
+		_, isStreamError := errors.AsType[*quic.StreamError](err)
+		if err == io.EOF || isStreamError {
 			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeClosedCriticalStream), "")
 			return
 		}

--- a/http3/conn_test.go
+++ b/http3/conn_test.go
@@ -65,8 +65,8 @@ func TestConnReceiveSettings(t *testing.T) {
 				Frame: qlog.Frame{
 					Frame: qlog.SettingsFrame{
 						MaxFieldSectionSize: 1234,
-						Datagram:            pointer(true),
-						ExtendedConnect:     pointer(true),
+						Datagram:            new(true),
+						ExtendedConnect:     new(true),
 						Other:               map[uint64]uint64{1337: 42},
 					},
 				},

--- a/http3/frames.go
+++ b/http3/frames.go
@@ -180,10 +180,6 @@ type settingsFrame struct {
 	Other           map[uint64]uint64 // all settings that we don't explicitly recognize
 }
 
-func pointer[T any](v T) *T {
-	return &v
-}
-
 const maxSettingsFrameSize = 8 << 10
 
 func parseSettingsFrame(r *countingByteReader, l uint64, streamID quic.StreamID, qlogger qlogwriter.Recorder) (*settingsFrame, error) {
@@ -229,7 +225,7 @@ func parseSettingsFrame(r *countingByteReader, l uint64, streamID quic.StreamID,
 			}
 			frame.ExtendedConnect = val == 1
 			if qlogger != nil {
-				settingsFrame.ExtendedConnect = pointer(frame.ExtendedConnect)
+				settingsFrame.ExtendedConnect = new(frame.ExtendedConnect)
 			}
 		case settingDatagram:
 			if readDatagram {
@@ -241,7 +237,7 @@ func parseSettingsFrame(r *countingByteReader, l uint64, streamID quic.StreamID,
 			}
 			frame.Datagram = val == 1
 			if qlogger != nil {
-				settingsFrame.Datagram = pointer(frame.Datagram)
+				settingsFrame.Datagram = new(frame.Datagram)
 			}
 		default:
 			if _, ok := frame.Other[id]; ok {

--- a/http3/qlog/frame_test.go
+++ b/http3/qlog/frame_test.go
@@ -80,10 +80,6 @@ func TestGoAwayFrame(t *testing.T) {
 	})
 }
 
-func pointer[T any](v T) *T {
-	return &v
-}
-
 func TestSettingsFrame(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -94,7 +90,7 @@ func TestSettingsFrame(t *testing.T) {
 			name: "datagram: true",
 			frame: SettingsFrame{
 				MaxFieldSectionSize: -1,
-				Datagram:            pointer(true),
+				Datagram:            new(true),
 			},
 			expected: map[string]any{
 				"frame_type": "settings",
@@ -108,7 +104,7 @@ func TestSettingsFrame(t *testing.T) {
 			name: "extended_connect: false",
 			frame: SettingsFrame{
 				MaxFieldSectionSize: -1,
-				ExtendedConnect:     pointer(false),
+				ExtendedConnect:     new(false),
 			},
 			expected: map[string]any{
 				"frame_type": "settings",
@@ -133,8 +129,8 @@ func TestSettingsFrame(t *testing.T) {
 			name: "datagram: false, extended_connect: false",
 			frame: SettingsFrame{
 				MaxFieldSectionSize: -1,
-				Datagram:            pointer(false),
-				ExtendedConnect:     pointer(false),
+				Datagram:            new(false),
+				ExtendedConnect:     new(false),
 			},
 			expected: map[string]any{
 				"frame_type": "settings",

--- a/http3/server.go
+++ b/http3/server.go
@@ -540,8 +540,8 @@ func (s *Server) handleConn(conn *quic.Conn) error {
 		if err != nil {
 			// the underlying connection was closed (by either side)
 			if conn.Context().Err() != nil {
-				var appErr *quic.ApplicationError
-				if !errors.As(err, &appErr) || appErr.ErrorCode != quic.ApplicationErrorCode(ErrCodeNoError) {
+				appErr, ok := errors.AsType[*quic.ApplicationError](err)
+				if !ok || appErr.ErrorCode != quic.ApplicationErrorCode(ErrCodeNoError) {
 					handleErr = fmt.Errorf("accepting stream failed: %w", err)
 				}
 				break
@@ -554,8 +554,8 @@ func (s *Server) handleConn(conn *quic.Conn) error {
 			}
 			inGracefulShutdown = s.graceCtx.Err() != nil
 			if !inGracefulShutdown {
-				var appErr *quic.ApplicationError
-				if !errors.As(err, &appErr) || appErr.ErrorCode != quic.ApplicationErrorCode(ErrCodeNoError) {
+				appErr, ok := errors.AsType[*quic.ApplicationError](err)
+				if !ok || appErr.ErrorCode != quic.ApplicationErrorCode(ErrCodeNoError) {
 					handleErr = fmt.Errorf("accepting stream failed: %w", err)
 				}
 				break

--- a/http3/server_conn.go
+++ b/http3/server_conn.go
@@ -160,8 +160,7 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 		}
 
 		errCode := ErrCodeMessageError
-		var qpackErr *qpackError
-		if errors.As(err, &qpackErr) {
+		if _, ok := errors.AsType[*qpackError](err); ok {
 			errCode = ErrCodeQPACKDecompressionFailed
 		}
 		str.CancelRead(quic.StreamErrorCode(errCode))
@@ -277,8 +276,8 @@ func (c *RawServerConn) handleControlStream(_ *quic.ReceiveStream, fp *framePars
 				c.CloseWithError(quic.ApplicationErrorCode(ErrCodeIDError), "")
 				return
 			}
-			var streamErr *quic.StreamError
-			if err == io.EOF || errors.As(err, &streamErr) {
+			_, isStreamError := errors.AsType[*quic.StreamError](err)
+			if err == io.EOF || isStreamError {
 				c.CloseWithError(quic.ApplicationErrorCode(ErrCodeClosedCriticalStream), "")
 				return
 			}

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -394,8 +394,7 @@ func (s *RequestStream) ReadResponse() (*http.Response, error) {
 	}
 	if err != nil {
 		errCode := ErrCodeMessageError
-		var qpackErr *qpackError
-		if errors.As(err, &qpackErr) {
+		if _, ok := errors.AsType[*qpackError](err); ok {
 			errCode = ErrCodeQPACKDecompressionFailed
 		}
 		s.str.CancelRead(quic.StreamErrorCode(errCode))

--- a/http3/transport.go
+++ b/http3/transport.go
@@ -258,15 +258,14 @@ func (t *Transport) doRoundTripOpt(req *http.Request, opt RoundTripOpt, isRetrie
 
 func canRetryRequest(err error, req *http.Request) (*http.Request, error) {
 	// error occurred while opening the stream, we can be sure that the request wasn't sent out
-	var connErr *errConnUnusable
-	if errors.As(err, &connErr) {
+	if _, ok := errors.AsType[*errConnUnusable](err); ok {
 		return req, nil
 	}
 
 	// If the request stream is reset, we can only be sure that the request wasn't processed
 	// if the error code is H3_REQUEST_REJECTED.
-	var e *Error
-	if !errors.As(err, &e) || e.ErrorCode != ErrCodeRequestRejected {
+	e, ok := errors.AsType[*Error](err)
+	if !ok || e.ErrorCode != ErrCodeRequestRejected {
 		return nil, err
 	}
 	// if the body is nil (or http.NoBody), it's safe to reuse this request and its body

--- a/integrationtests/gomodvendor/go.mod
+++ b/integrationtests/gomodvendor/go.mod
@@ -1,6 +1,6 @@
 module test
 
-go 1.25.0
+go 1.26.0
 
 // The version doesn't matter here, as we're replacing it with the currently checked out code anyway.
 require github.com/quic-go/quic-go v0.21.0

--- a/integrationtests/self/handshake_test.go
+++ b/integrationtests/self/handshake_test.go
@@ -107,12 +107,12 @@ func TestHandshakeServerMismatch(t *testing.T) {
 	defer cancel()
 	_, err = quic.Dial(ctx, newUDPConnLocalhost(t), server.Addr(), conf, getQuicConfig(nil))
 	require.Error(t, err)
-	var transportErr *quic.TransportError
-	require.True(t, errors.As(err, &transportErr))
+	transportErr, ok := errors.AsType[*quic.TransportError](err)
+	require.True(t, ok)
 	require.True(t, transportErr.ErrorCode.IsCryptoError())
 	require.Contains(t, transportErr.Error(), "x509: certificate is valid for localhost, not foo.bar")
-	var certErr *tls.CertificateVerificationError
-	require.True(t, errors.As(transportErr, &certErr))
+	_, ok = errors.AsType[*tls.CertificateVerificationError](transportErr)
+	require.True(t, ok)
 }
 
 func TestHandshakeCipherSuites(t *testing.T) {

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -521,8 +521,8 @@ func TestHTTPErrAbortHandler(t *testing.T) {
 	require.NoError(t, err)
 	body, err := io.ReadAll(resp.Body)
 	require.Error(t, err)
-	var h3Err *http3.Error
-	require.True(t, errors.As(err, &h3Err))
+	h3Err, ok := errors.AsType[*http3.Error](err)
+	require.True(t, ok)
 	require.Equal(t, http3.ErrCodeInternalError, h3Err.ErrorCode)
 	// the body will be a prefix of what's written
 	require.True(t, bytes.HasPrefix([]byte("foobar"), body))
@@ -698,8 +698,8 @@ func TestHTTPClientRequestContextCancellation(t *testing.T) {
 		select {
 		case err := <-errChan:
 			require.Error(t, err)
-			var http3Err *http3.Error
-			require.True(t, errors.As(err, &http3Err))
+			http3Err, ok := errors.AsType[*http3.Error](err)
+			require.True(t, ok)
 			require.Equal(t, http3.ErrCodeRequestCanceled, http3Err.ErrorCode)
 			require.True(t, http3Err.Remote)
 		case <-time.After(time.Second):
@@ -707,8 +707,8 @@ func TestHTTPClientRequestContextCancellation(t *testing.T) {
 		}
 
 		_, err = resp.Body.Read([]byte{0})
-		var http3Err *http3.Error
-		require.True(t, errors.As(err, &http3Err))
+		http3Err, ok := errors.AsType[*http3.Error](err)
+		require.True(t, ok)
 		require.Equal(t, http3.ErrCodeRequestCanceled, http3Err.ErrorCode)
 		require.False(t, http3Err.Remote)
 	})

--- a/integrationtests/self/self_suite_linux_test.go
+++ b/integrationtests/self/self_suite_linux_test.go
@@ -13,8 +13,7 @@ import (
 // It's not clear why this happens.
 // See https://github.com/golang/go/issues/63322.
 func isPermissionError(err error) bool {
-	var serr *os.SyscallError
-	if errors.As(err, &serr) {
+	if serr, ok := errors.AsType[*os.SyscallError](err); ok {
 		return serr.Syscall == "sendmsg" && serr.Err == unix.EPERM
 	}
 	return false

--- a/integrationtests/self/timeout_test.go
+++ b/integrationtests/self/timeout_test.go
@@ -30,8 +30,8 @@ func requireIdleTimeoutError(t *testing.T, err error) {
 	var idleTimeoutErr *quic.IdleTimeoutError
 	require.ErrorAs(t, err, &idleTimeoutErr)
 	require.True(t, idleTimeoutErr.Timeout())
-	var nerr net.Error
-	require.True(t, errors.As(err, &nerr))
+	nerr, ok := errors.AsType[net.Error](err)
+	require.True(t, ok)
 	require.True(t, nerr.Timeout())
 }
 
@@ -477,8 +477,8 @@ func testFaultyPacketConn(t *testing.T, pers protocol.Perspective) {
 		if pers == protocol.PerspectiveClient {
 			require.Contains(t, clientErr.Error(), io.ErrClosedPipe.Error())
 		} else {
-			var nerr net.Error
-			require.True(t, errors.As(clientErr, &nerr))
+			nerr, ok := errors.AsType[net.Error](clientErr)
+			require.True(t, ok)
 			require.True(t, nerr.Timeout())
 		}
 
@@ -488,8 +488,8 @@ func testFaultyPacketConn(t *testing.T, pers protocol.Perspective) {
 			if pers == protocol.PerspectiveServer {
 				require.Contains(t, serverErr.Error(), io.ErrClosedPipe.Error())
 			} else {
-				var nerr net.Error
-				require.True(t, errors.As(serverErr, &nerr))
+				nerr, ok := errors.AsType[net.Error](serverErr)
+				require.True(t, ok)
 				require.True(t, nerr.Timeout())
 			}
 		default: // The handshake didn't complete

--- a/integrationtests/versionnegotiation/handshake_test.go
+++ b/integrationtests/versionnegotiation/handshake_test.go
@@ -185,8 +185,8 @@ func TestServerDisablesVersionNegotiation(t *testing.T) {
 		}),
 	)
 	require.Error(t, err)
-	var nerr net.Error
-	require.True(t, errors.As(err, &nerr))
+	nerr, ok := errors.AsType[net.Error](err)
+	require.True(t, ok)
 	require.True(t, nerr.Timeout())
 	require.Empty(t, clientEventTracer.Events(qlog.VersionNegotiationReceived{}))
 }

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -682,7 +682,7 @@ func (h *cryptoSetup) ConnectionState() ConnectionState {
 }
 
 func wrapError(err error) error {
-	if alertErr := tls.AlertError(0); errors.As(err, &alertErr) {
+	if alertErr, ok := errors.AsType[tls.AlertError](err); ok {
 		return qerr.NewLocalCryptoError(uint8(alertErr), err)
 	}
 	return &qerr.TransportError{ErrorCode: qerr.InternalError, ErrorMessage: err.Error()}

--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -76,9 +76,9 @@ func TestErrorBeforeClientHelloGeneration(t *testing.T) {
 		protocol.Version1,
 	)
 
-	var terr *qerr.TransportError
 	err := cl.StartHandshake(context.Background())
-	require.True(t, errors.As(err, &terr))
+	terr, ok := errors.AsType[*qerr.TransportError](err)
+	require.True(t, ok)
 	require.Equal(t, uint64(0x100+0x50), uint64(terr.ErrorCode))
 	require.Contains(t, err.Error(), "tls: invalid NextProtos value")
 }

--- a/internal/qerr/errors_test.go
+++ b/internal/qerr/errors_test.go
@@ -65,9 +65,9 @@ var _ error = myError(0)
 func (e myError) Error() string { return fmt.Sprintf("my error %d", e) }
 
 func TestCryptoError(t *testing.T) {
-	var myErr myError
 	err := NewLocalCryptoError(0x42, myError(1337))
-	require.True(t, errors.As(err, &myErr))
+	myErr, ok := errors.AsType[myError](err)
+	require.True(t, ok)
 	require.Equal(t, myError(1337), myErr)
 
 	err = NewLocalCryptoError(0x42, assert.AnError)

--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -5,7 +5,7 @@ RUN echo "TARGETPLATFORM: ${TARGETPLATFORM}"
 
 RUN apt-get update && apt-get install -y wget tar git && rm -rf /var/lib/apt/lists/*
 
-ENV GOVERSION=1.26.0
+ENV GOVERSION=1.27.0
 
 RUN platform=$(echo ${TARGETPLATFORM} | tr '/' '-') && \
   filename="go${GOVERSION}.${platform}.tar.gz" && \

--- a/sys_conn_helper_linux.go
+++ b/sys_conn_helper_linux.go
@@ -96,8 +96,7 @@ func appendUDPSegmentSizeMsg(b []byte, size uint16) []byte {
 }
 
 func isGSOError(err error) bool {
-	var serr *os.SyscallError
-	if errors.As(err, &serr) {
+	if serr, ok := errors.AsType[*os.SyscallError](err); ok {
 		// EIO is returned by udp_send_skb() if the device driver does not have tx checksums enabled,
 		// which is a hard requirement of UDP_SEGMENT. See:
 		// https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man7/udp.7?id=806eabd74910447f21005160e90957bde4db0183#n228
@@ -111,8 +110,7 @@ func isGSOError(err error) bool {
 // It's not clear why this happens.
 // See https://github.com/golang/go/issues/63322.
 func isPermissionError(err error) bool {
-	var serr *os.SyscallError
-	if errors.As(err, &serr) {
+	if serr, ok := errors.AsType[*os.SyscallError](err); ok {
 		return serr.Syscall == "sendmsg" && serr.Err == unix.EPERM
 	}
 	return false

--- a/transport.go
+++ b/transport.go
@@ -327,8 +327,7 @@ func (t *Transport) doDial(
 	recreateChan := make(chan errCloseForRecreating, 1)
 	go func() {
 		err := conn.run()
-		var recreateErr *errCloseForRecreating
-		if errors.As(err, &recreateErr) {
+		if recreateErr, ok := errors.AsType[*errCloseForRecreating](err); ok {
 			recreateChan <- *recreateErr
 			return
 		}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update to Go 1.27, drop Go 1.25, and migrate `errors.As` to `errors.AsType`
> - Bumps the minimum Go version in [go.mod](https://github.com/quic-go/quic-go/pull/5801/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6) and [integrationtests/gomodvendor/go.mod](https://github.com/quic-go/quic-go/pull/5801/files#diff-f2d1ee04d9bfcd87171ae87cde3e06381e41209cc75554be444d3d9320fa4f2a) from 1.25.0 to 1.26.0, and updates all CI workflow Go matrices to test `1.26.x` and `1.27.x` only
> - Replaces `errors.As` with `errors.AsType[...]` throughout connection handling, HTTP/3, handshake, transport, and integration test code for typed error detection
> - FIPS 140 handshake and integration tests now run unconditionally instead of being skipped on Go 1.25.x
> - [lint.yml](https://github.com/quic-go/quic-go/pull/5801/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2) applies a selective `go fix` strategy: `slicesbackward=false` for `internal/ackhandler` to avoid `slices.Backward` usage
> - Risk: `errors.AsType` is a newer API — builds will fail on Go versions that predate its introduction; the `go.mod` bump to 1.26.0 enforces this floor
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96be4f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s required Go version to 1.26.
  * Refreshed build, testing, linting, benchmarking, security, and cross-platform validation for Go 1.26 and 1.27.
  * Updated the interoperability build environment to Go 1.27.

* **Tests**
  * FIPS-related tests now run consistently across supported Go versions.
  * Simplified test setup while preserving existing behavior and expected results.
  * Updated error handling checks without changing connection, retry, or stream behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->