### PR TITLE
use tls.ClientHelloInfo.HelloRetryRequest in tests

### DIFF
--- a/integrationtests/self/handshake_rtt_test.go
+++ b/integrationtests/self/handshake_rtt_test.go
@@ -49,7 +49,13 @@ func testHandshakeRTTRetry(t *testing.T, doRetry bool) {
 func TestHandshakeRTTHelloRetryRequest(t *testing.T) {
 	tlsConf := getTLSConfig()
 	tlsConf.CurvePreferences = []tls.CurveID{tls.CurveP384}
+	var helloRetryRequest bool
+	tlsConf.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		helloRetryRequest = info.HelloRetryRequest
+		return nil, nil
+	}
 	rtts := testHandshakeMeasureHandshake(t, nil, tlsConf, getQuicConfig(nil))
+	require.True(t, helloRetryRequest)
 	require.GreaterOrEqual(t, rtts, float64(2))
 	require.Less(t, rtts, float64(2.1))
 }

--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -232,6 +232,11 @@ func TestHandshake(t *testing.T) {
 func TestHelloRetryRequest(t *testing.T) {
 	clientConf, serverConf := getTLSConfigs()
 	serverConf.CurvePreferences = []tls.CurveID{tls.CurveP384}
+	var helloRetryRequest bool
+	serverConf.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		helloRetryRequest = info.HelloRetryRequest
+		return nil, nil
+	}
 	_, _, clientErr, _, _, serverErr := handshakeWithTLSConf(
 		t,
 		clientConf, serverConf,
@@ -241,6 +246,7 @@ func TestHelloRetryRequest(t *testing.T) {
 	)
 	require.NoError(t, clientErr)
 	require.NoError(t, serverErr)
+	require.True(t, helloRetryRequest)
 }
 
 func TestWithClientAuth(t *testing.T) {


### PR DESCRIPTION
No functional change expected.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `tls.ClientHelloInfo.HelloRetryRequest` in tests and migrate to `errors.AsType[T]`
> - Replaces all `errors.As` calls with generic `errors.AsType[T]` across the codebase, including [connection.go](https://github.com/quic-go/quic-go/pull/5802/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7), [http3/](https://github.com/quic-go/quic-go/pull/5802/files#diff-fea2105a7518b61f93653427f414ca256e9e1a1c1d32768e98f9106f96ebde7f), [internal/handshake/crypto_setup.go](https://github.com/quic-go/quic-go/pull/5802/files#diff-c1eebd1c52f66da524b99c57f22669500f22784ae80475fbf2b786bc0d1ba278), and [transport.go](https://github.com/quic-go/quic-go/pull/5802/files#diff-5982a4ca350449c8a5deba675bc4bc4bb0f1823c45e6c7ba0076cc6b159fef8f)
> - Adds `GetCertificate` callbacks in [integrationtests/self/handshake_rtt_test.go](https://github.com/quic-go/quic-go/pull/5802/files#diff-ae30e881ec10b3f3612110ff41ea969b4e770e74f4e42839a4564c7d54799383) and [internal/handshake/crypto_setup_test.go](https://github.com/quic-go/quic-go/pull/5802/files#diff-1ca5123c2e9935decd5adafab51d3f1f245f509dfefde8919a5aed26bfe16006) to track and assert `tls.ClientHelloInfo.HelloRetryRequest` is true
> - Removes the `pointer[T]` helper in [http3/frames.go](https://github.com/quic-go/quic-go/pull/5802/files#diff-5058d763be915b41b872950ae8225c436f514184bb1f13fbf6c0350627bdee4b) and replaces usages with `new(true)`/`new(false)` for `SettingsFrame` boolean pointer fields
> - Bumps `go.mod` directive from 1.25.0 to 1.26.0 and updates all CI workflow Go matrices to test 1.26.x and 1.27.x
> - Risk: `go.mod` now requires Go 1.26.0 minimum; consumers on older Go versions can no longer build the module. The `errors.AsType[T]` generic API must be available in the targeted Go version
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25cb4b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that TLS clients correctly observe HelloRetryRequest messages during handshakes.
  * Strengthened handshake integration and internal validation for retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->