### PR TITLE
perf: reduce frame sorter gap tracking overhead

### DIFF
--- a/frame_sorter.go
+++ b/frame_sorter.go
@@ -2,22 +2,14 @@ package quic
 
 import (
 	"errors"
-	"sync"
 
 	"github.com/quic-go/quic-go/internal/protocol"
-	list "github.com/quic-go/quic-go/internal/utils/linkedlist"
 )
 
 // byteInterval is an interval from one ByteCount to the other
 type byteInterval struct {
 	Start protocol.ByteCount
 	End   protocol.ByteCount
-}
-
-var byteIntervalElementPool sync.Pool
-
-func init() {
-	byteIntervalElementPool = *list.NewPool[byteInterval]()
 }
 
 type frameSorterEntry struct {
@@ -28,17 +20,16 @@ type frameSorterEntry struct {
 type frameSorter struct {
 	queue   map[protocol.ByteCount]frameSorterEntry
 	readPos protocol.ByteCount
-	gaps    *list.List[byteInterval]
+	gaps    gapSet
 }
 
 var errDuplicateStreamData = errors.New("duplicate stream data")
 
 func newFrameSorter() *frameSorter {
 	s := frameSorter{
-		gaps:  list.NewWithPool[byteInterval](&byteIntervalElementPool),
 		queue: make(map[protocol.ByteCount]frameSorterEntry),
 	}
-	s.gaps.PushFront(byteInterval{Start: 0, End: protocol.MaxByteCount})
+	s.gaps.InsertAt(0, byteInterval{Start: 0, End: protocol.MaxByteCount})
 	return &s
 }
 
@@ -61,25 +52,38 @@ func (s *frameSorter) push(data []byte, offset protocol.ByteCount, doneCb func()
 	start := offset
 	end := offset + protocol.ByteCount(len(data))
 
-	if end <= s.gaps.Front().Value.Start {
+	var startGapIndex, endGapIndex int
+	var startGap, endGap byteInterval
+	var startsInGap, endsInGap bool
+	if s.gaps.Len() == 1 {
+		startGap = s.gaps.First()
+		if startGap.End < start || startGap.Start > end {
+			return errDuplicateStreamData
+		}
+		endGap = startGap
+		startsInGap = start >= startGap.Start && start <= startGap.End
+		endsInGap = end >= startGap.Start && end < startGap.End
+	} else {
+		var ok bool
+		startGapIndex, endGapIndex, startsInGap, endsInGap, ok = s.gaps.Find(start, end)
+		if !ok {
+			return errDuplicateStreamData
+		}
+		startGap = s.gaps.At(startGapIndex)
+		endGap = s.gaps.At(endGapIndex)
+	}
+	startGapEqualsEndGap := startGapIndex == endGapIndex
+
+	if (startGapEqualsEndGap && end <= startGap.Start) ||
+		(!startGapEqualsEndGap && startGap.End >= endGap.Start && end <= startGap.Start) {
 		return errDuplicateStreamData
 	}
 
-	startGap, startsInGap := s.findStartGap(start)
-	endGap, endsInGap := s.findEndGap(startGap, end)
-
-	startGapEqualsEndGap := startGap == endGap
-
-	if (startGapEqualsEndGap && end <= startGap.Value.Start) ||
-		(!startGapEqualsEndGap && startGap.Value.End >= endGap.Value.Start && end <= startGap.Value.Start) {
-		return errDuplicateStreamData
-	}
-
-	startGapNext := startGap.Next()
-	startGapEnd := startGap.Value.End // save it, in case startGap is modified
-	endGapStart := endGap.Value.Start // save it, in case endGap is modified
-	endGapEnd := endGap.Value.End     // save it, in case endGap is modified
+	startGapEnd := startGap.End // save it, in case startGap is modified
+	endGapStart := endGap.Start // save it, in case endGap is modified
+	endGapEnd := endGap.End     // save it, in case endGap is modified
 	var adjustedStartGapEnd bool
+	var deletedStartGap bool
 	var wasCut bool
 
 	pos := start
@@ -113,29 +117,40 @@ func (s *frameSorter) push(data []byte, offset protocol.ByteCount, doneCb func()
 
 	if !startsInGap && !hasReplacedAtLeastOne {
 		// cut the frame, such that it starts at the start of the gap
-		data = data[startGap.Value.Start-start:]
-		start = startGap.Value.Start
+		data = data[startGap.Start-start:]
+		start = startGap.Start
 		wasCut = true
 	}
-	if start <= startGap.Value.Start {
-		if end >= startGap.Value.End {
+	if start <= startGap.Start {
+		if end >= startGap.End {
 			// The frame covers the whole startGap. Delete the gap.
-			s.gaps.Remove(startGap)
+			s.gaps.DeleteAt(startGapIndex)
+			deletedStartGap = true
 		} else {
-			startGap.Value.Start = end
+			startGap.Start = end
+			s.gaps.UpdateAt(startGapIndex, startGap)
 		}
 	} else if !hasReplacedAtLeastOne {
-		startGap.Value.End = start
+		startGap.End = start
+		s.gaps.UpdateAt(startGapIndex, startGap)
 		adjustedStartGapEnd = true
 	}
 
 	if !startGapEqualsEndGap {
 		s.deleteConsecutive(startGapEnd)
-		var nextGap *list.Element[byteInterval]
-		for gap := startGapNext; gap.Value.End < endGapStart; gap = nextGap {
-			nextGap = gap.Next()
-			s.deleteConsecutive(gap.Value.End)
-			s.gaps.Remove(gap)
+		if deletedStartGap {
+			endGapIndex--
+		} else {
+			startGapIndex++
+		}
+		for startGapIndex < endGapIndex {
+			gap := s.gaps.At(startGapIndex)
+			if gap.End >= endGapStart {
+				break
+			}
+			s.deleteConsecutive(gap.End)
+			s.gaps.DeleteAt(startGapIndex)
+			endGapIndex--
 		}
 	}
 
@@ -148,14 +163,15 @@ func (s *frameSorter) push(data []byte, offset protocol.ByteCount, doneCb func()
 	if end == endGapEnd {
 		if !startGapEqualsEndGap {
 			// The frame covers the whole endGap. Delete the gap.
-			s.gaps.Remove(endGap)
+			s.gaps.DeleteAt(endGapIndex)
 		}
 	} else {
 		if startGapEqualsEndGap && adjustedStartGapEnd {
 			// The frame split the existing gap into two.
-			s.gaps.InsertAfter(byteInterval{Start: end, End: startGapEnd}, startGap)
+			s.gaps.InsertAt(startGapIndex+1, byteInterval{Start: end, End: startGapEnd})
 		} else if !startGapEqualsEndGap {
-			endGap.Value.Start = end
+			endGap.Start = end
+			s.gaps.UpdateAt(endGapIndex, endGap)
 		}
 	}
 
@@ -175,30 +191,6 @@ func (s *frameSorter) push(data []byte, offset protocol.ByteCount, doneCb func()
 
 	s.queue[start] = frameSorterEntry{Data: data, DoneCb: doneCb}
 	return nil
-}
-
-func (s *frameSorter) findStartGap(offset protocol.ByteCount) (*list.Element[byteInterval], bool) {
-	for gap := s.gaps.Front(); gap != nil; gap = gap.Next() {
-		if offset >= gap.Value.Start && offset <= gap.Value.End {
-			return gap, true
-		}
-		if offset < gap.Value.Start {
-			return gap, false
-		}
-	}
-	panic("no gap found")
-}
-
-func (s *frameSorter) findEndGap(startGap *list.Element[byteInterval], offset protocol.ByteCount) (*list.Element[byteInterval], bool) {
-	for gap := startGap; gap != nil; gap = gap.Next() {
-		if offset >= gap.Value.Start && offset < gap.Value.End {
-			return gap, true
-		}
-		if offset < gap.Value.Start {
-			return gap.Prev(), false
-		}
-	}
-	panic("no gap found")
 }
 
 // deleteConsecutive deletes consecutive frames from the queue, starting at pos
@@ -225,7 +217,7 @@ func (s *frameSorter) Pop() (protocol.ByteCount, []byte, func()) {
 	delete(s.queue, s.readPos)
 	offset := s.readPos
 	s.readPos += protocol.ByteCount(len(entry.Data))
-	if s.gaps.Front().Value.End <= s.readPos {
+	if s.gaps.First().End <= s.readPos {
 		panic("frame sorter BUG: read position higher than a gap")
 	}
 	return offset, entry.Data, entry.DoneCb

--- a/frame_sorter_benchmark_test.go
+++ b/frame_sorter_benchmark_test.go
@@ -1,0 +1,171 @@
+package quic
+
+import (
+	"testing"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+)
+
+const (
+	benchmarkFrameCount = 256
+	benchmarkFrameSize  = 1200
+)
+
+func BenchmarkFrameSorterPushOrdered(b *testing.B) {
+	payload := make([]byte, benchmarkFrameSize)
+	b.ReportAllocs()
+	b.SetBytes(int64(benchmarkFrameCount * benchmarkFrameSize))
+
+	for b.Loop() {
+		sorter := newFrameSorter()
+		for index := range benchmarkFrameCount {
+			offset := protocol.ByteCount(index * benchmarkFrameSize)
+			if err := sorter.Push(payload, offset, nil); err != nil {
+				b.Fatal(err)
+			}
+			poppedOffset, data, _ := sorter.Pop()
+			if poppedOffset != offset || len(data) != benchmarkFrameSize {
+				b.Fatalf("popped (%d, %d bytes), expected (%d, %d bytes)", poppedOffset, len(data), offset, benchmarkFrameSize)
+			}
+		}
+	}
+}
+
+func BenchmarkFrameSorterPushSlightlyReordered(b *testing.B) {
+	payload := make([]byte, benchmarkFrameSize)
+	b.ReportAllocs()
+	b.SetBytes(int64(benchmarkFrameCount * benchmarkFrameSize))
+
+	for b.Loop() {
+		sorter := newFrameSorter()
+		for index := 0; index < benchmarkFrameCount; {
+			if index%40 == 20 && index+1 < benchmarkFrameCount {
+				for _, reordered := range [...]int{index + 1, index} {
+					offset := protocol.ByteCount(reordered * benchmarkFrameSize)
+					if err := sorter.Push(payload, offset, nil); err != nil {
+						b.Fatal(err)
+					}
+				}
+				for expected := index; expected <= index+1; expected++ {
+					offset, data, _ := sorter.Pop()
+					if offset != protocol.ByteCount(expected*benchmarkFrameSize) || len(data) != benchmarkFrameSize {
+						b.Fatalf("popped (%d, %d bytes), expected frame %d", offset, len(data), expected)
+					}
+				}
+				index += 2
+				continue
+			}
+			offset := protocol.ByteCount(index * benchmarkFrameSize)
+			if err := sorter.Push(payload, offset, nil); err != nil {
+				b.Fatal(err)
+			}
+			poppedOffset, data, _ := sorter.Pop()
+			if poppedOffset != offset || len(data) != benchmarkFrameSize {
+				b.Fatalf("popped (%d, %d bytes), expected (%d, %d bytes)", poppedOffset, len(data), offset, benchmarkFrameSize)
+			}
+			index++
+		}
+	}
+}
+
+func BenchmarkFrameSorterPushReordered(b *testing.B) {
+	payload := make([]byte, benchmarkFrameSize)
+	b.ReportAllocs()
+	b.SetBytes(int64(benchmarkFrameCount * benchmarkFrameSize))
+
+	for b.Loop() {
+		sorter := newFrameSorter()
+		var callbacks int
+		callback := func() { callbacks++ }
+		for windowStart := 0; windowStart < benchmarkFrameCount; windowStart += 32 {
+			for index := windowStart + 16; index < windowStart+32; index++ {
+				offset := protocol.ByteCount(index * benchmarkFrameSize)
+				if err := sorter.Push(payload, offset, callback); err != nil {
+					b.Fatal(err)
+				}
+			}
+			for index := windowStart; index < windowStart+16; index++ {
+				offset := protocol.ByteCount(index * benchmarkFrameSize)
+				if err := sorter.Push(payload, offset, callback); err != nil {
+					b.Fatal(err)
+				}
+			}
+			for index := windowStart; index < windowStart+32; index++ {
+				expectedOffset := protocol.ByteCount(index * benchmarkFrameSize)
+				poppedOffset, data, done := sorter.Pop()
+				if poppedOffset != expectedOffset || len(data) != benchmarkFrameSize || done == nil {
+					b.Fatalf("popped (%d, %d bytes), expected (%d, %d bytes)", poppedOffset, len(data), expectedOffset, benchmarkFrameSize)
+				}
+				done()
+			}
+		}
+		if callbacks != benchmarkFrameCount {
+			b.Fatalf("callbacks = %d, expected %d", callbacks, benchmarkFrameCount)
+		}
+	}
+}
+
+func BenchmarkFrameSorterPushManyGaps(b *testing.B) {
+	separator := make([]byte, benchmarkFrameSize)
+	partial := make([]byte, benchmarkFrameSize/2)
+	b.ReportAllocs()
+	b.SetBytes(int64(benchmarkFrameCount * (len(separator) + len(partial))))
+
+	for b.Loop() {
+		sorter := newFrameSorter()
+		for index := range benchmarkFrameCount {
+			offset := protocol.ByteCount((2*index + 1) * benchmarkFrameSize)
+			if err := sorter.Push(separator, offset, nil); err != nil {
+				b.Fatal(err)
+			}
+		}
+		for index := range benchmarkFrameCount {
+			offset := protocol.ByteCount(2 * index * benchmarkFrameSize)
+			if err := sorter.Push(partial, offset, nil); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if sorter.gaps.Len() != benchmarkFrameCount+1 {
+			b.Fatalf("gap count = %d, want %d", sorter.gaps.Len(), benchmarkFrameCount+1)
+		}
+	}
+}
+
+func BenchmarkFrameSorterPushMaxGaps(b *testing.B) {
+	payload := make([]byte, 6)
+	b.ReportAllocs()
+	b.SetBytes(int64(protocol.MaxStreamFrameSorterGaps * len(payload)))
+
+	for b.Loop() {
+		sorter := newFrameSorter()
+		for index := range protocol.MaxStreamFrameSorterGaps {
+			offset := protocol.ByteCount(index * 7)
+			if err := sorter.Push(payload, offset, nil); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if sorter.gaps.Len() != protocol.MaxStreamFrameSorterGaps {
+			b.Fatalf("gap count = %d, want %d", sorter.gaps.Len(), protocol.MaxStreamFrameSorterGaps)
+		}
+	}
+}
+
+func BenchmarkFrameSorterPushMaxGapsShuffled(b *testing.B) {
+	payload := make([]byte, 6)
+	b.ReportAllocs()
+	b.SetBytes(int64(protocol.MaxStreamFrameSorterGaps * len(payload)))
+
+	for b.Loop() {
+		sorter := newFrameSorter()
+		for index := range protocol.MaxStreamFrameSorterGaps {
+			permuted := index * 499 % protocol.MaxStreamFrameSorterGaps
+			offset := protocol.ByteCount(permuted * 7)
+			if err := sorter.Push(payload, offset, nil); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if sorter.gaps.Len() != protocol.MaxStreamFrameSorterGaps {
+			b.Fatalf("gap count = %d, want %d", sorter.gaps.Len(), protocol.MaxStreamFrameSorterGaps)
+		}
+	}
+}

--- a/frame_sorter_test.go
+++ b/frame_sorter_test.go
@@ -109,18 +109,15 @@ func TestFrameSorterGapHandling(t *testing.T) {
 	}
 
 	checkGaps := func(t *testing.T, s *frameSorter, expectedGaps []byteInterval) {
+		actualGaps := s.gaps.values()
 		if s.gaps.Len() != len(expectedGaps) {
 			fmt.Println("Gaps:")
-			for gap := s.gaps.Front(); gap != nil; gap = gap.Next() {
-				fmt.Printf("\t%d - %d\n", gap.Value.Start, gap.Value.End)
+			for _, gap := range actualGaps {
+				fmt.Printf("\t%d - %d\n", gap.Start, gap.End)
 			}
 			require.Equal(t, len(expectedGaps), s.gaps.Len())
 		}
-		var i int
-		for gap := s.gaps.Front(); gap != nil; gap = gap.Next() {
-			require.Equal(t, expectedGaps[i], gap.Value)
-			i++
-		}
+		require.Equal(t, expectedGaps, actualGaps)
 	}
 
 	// ---xxx--------------
@@ -1452,7 +1449,7 @@ func testFrameSorterRandomized(t *testing.T, dataLen protocol.ByteCount, injectD
 		}
 	}
 	require.Equal(t, 1, s.gaps.Len())
-	require.Equal(t, byteInterval{Start: num * dataLen, End: protocol.MaxByteCount}, s.gaps.Front().Value)
+	require.Equal(t, byteInterval{Start: num * dataLen, End: protocol.MaxByteCount}, s.gaps.First())
 
 	// read all data
 	var read []byte

--- a/gap_set.go
+++ b/gap_set.go
@@ -1,0 +1,122 @@
+package quic
+
+import "github.com/quic-go/quic-go/internal/protocol"
+
+const gapInlineCapacity = 8
+
+// gapSet stores disjoint intervals ordered by Start. This invariant also orders
+// End, allowing binary search on either boundary once the inline store fills.
+type gapSet struct {
+	length int
+	inline [gapInlineCapacity]byteInterval
+	large  []byteInterval
+}
+
+func (s *gapSet) Len() int { return s.length }
+
+func (s *gapSet) First() byteInterval { return s.values()[0] }
+
+func (s *gapSet) At(index int) byteInterval { return s.values()[index] }
+
+func (s *gapSet) Find(start, end protocol.ByteCount) (
+	startIndex, endIndex int,
+	startsInGap, endsInGap, ok bool,
+) {
+	values := s.values()
+	if len(values) == 1 {
+		gap := values[0]
+		if gap.End < start || gap.Start > end {
+			return 0, 0, false, false, false
+		}
+		return 0, 0, start >= gap.Start, end >= gap.Start && end < gap.End, true
+	}
+
+	if len(values) <= gapInlineCapacity {
+		for startIndex < len(values) && values[startIndex].End < start {
+			startIndex++
+		}
+	} else {
+		low, high := 0, len(values)
+		for low < high {
+			middle := int(uint(low+high) >> 1)
+			if values[middle].End < start {
+				low = middle + 1
+			} else {
+				high = middle
+			}
+		}
+		startIndex = low
+	}
+	if startIndex == len(values) || values[startIndex].Start > end {
+		return 0, 0, false, false, false
+	}
+
+	if len(values) <= gapInlineCapacity {
+		endIndex = startIndex
+		for endIndex+1 < len(values) && values[endIndex+1].Start <= end {
+			endIndex++
+		}
+	} else {
+		low, high := startIndex, len(values)
+		for low < high {
+			middle := int(uint(low+high) >> 1)
+			if values[middle].Start <= end {
+				low = middle + 1
+			} else {
+				high = middle
+			}
+		}
+		endIndex = low - 1
+	}
+	startGap, endGap := values[startIndex], values[endIndex]
+	return startIndex, endIndex,
+		start >= startGap.Start && start <= startGap.End,
+		end >= endGap.Start && end < endGap.End,
+		true
+}
+
+func (s *gapSet) InsertAt(index int, value byteInterval) {
+	if s.length < gapInlineCapacity {
+		copy(s.inline[index+1:s.length+1], s.inline[index:s.length])
+		s.inline[index] = value
+		s.length++
+		return
+	}
+	if s.length == gapInlineCapacity {
+		if cap(s.large) < 2*gapInlineCapacity {
+			s.large = make([]byteInterval, s.length+1, 2*gapInlineCapacity)
+		} else {
+			s.large = s.large[:s.length+1]
+		}
+		copy(s.large, s.inline[:])
+	} else {
+		s.large = append(s.large, byteInterval{})
+	}
+	copy(s.large[index+1:], s.large[index:s.length])
+	s.large[index] = value
+	s.length++
+}
+
+func (s *gapSet) DeleteAt(index int) {
+	values := s.values()
+	copy(values[index:], values[index+1:])
+	s.length--
+	values[s.length] = byteInterval{}
+	if len(values) > gapInlineCapacity && s.length == gapInlineCapacity {
+		copy(s.inline[:], values[:gapInlineCapacity])
+		s.large = s.large[:0]
+	} else if len(values) > gapInlineCapacity {
+		s.large = s.large[:s.length]
+	}
+}
+
+func (s *gapSet) UpdateAt(index int, value byteInterval) {
+	s.values()[index] = value
+}
+
+func (s *gapSet) values() []byteInterval {
+	if s.length <= gapInlineCapacity {
+		return s.inline[:s.length]
+	}
+	return s.large[:s.length]
+}

--- a/gap_set_test.go
+++ b/gap_set_test.go
@@ -1,0 +1,68 @@
+package quic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGapSetFindIncludesTouchingIntervals(t *testing.T) {
+	for _, count := range []int{3, 17} {
+		t.Run(fmt.Sprintf("%d gaps", count), func(t *testing.T) {
+			var set gapSet
+			for index := range count {
+				start := protocol.ByteCount(index * 20)
+				set.InsertAt(set.Len(), byteInterval{Start: start, End: start + 10})
+			}
+
+			start, end, startsInGap, endsInGap, ok := set.Find(10, protocol.ByteCount((count-1)*20))
+			require.True(t, ok)
+			require.Equal(t, 0, start)
+			require.Equal(t, count-1, end)
+			require.True(t, startsInGap)
+			require.True(t, endsInGap)
+			_, _, _, _, ok = set.Find(11, 19)
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestGapSetPreservesOrderAcrossPromotionAndMutation(t *testing.T) {
+	var set gapSet
+	const count = 257
+	for index := range count {
+		start := protocol.ByteCount(index * 10)
+		set.InsertAt(set.Len(), byteInterval{Start: start, End: start + 5})
+	}
+
+	set.UpdateAt(129, byteInterval{Start: 1291, End: 1295})
+	for index := count - 1; index >= 0; index-- {
+		if index%7 == 2 {
+			set.DeleteAt(index)
+		}
+	}
+
+	values := set.values()
+	require.Len(t, values, set.Len())
+	for index := 1; index < len(values); index++ {
+		require.Less(t, values[index-1].End, values[index].Start)
+	}
+	require.Equal(t, values[0], set.First())
+	require.Contains(t, values, byteInterval{Start: 1291, End: 1295})
+}
+
+func TestGapSetReusesLargeStorageAfterDemotion(t *testing.T) {
+	var set gapSet
+	for index := range gapInlineCapacity + 1 {
+		start := protocol.ByteCount(index * 10)
+		set.InsertAt(set.Len(), byteInterval{Start: start, End: start + 5})
+	}
+	capacity := cap(set.large)
+	set.DeleteAt(set.Len() - 1)
+	require.Len(t, set.large, 0)
+
+	set.InsertAt(set.Len(), byteInterval{Start: 100, End: 105})
+	require.Equal(t, capacity, cap(set.large))
+}


### PR DESCRIPTION
## What changed

`frameSorter` currently tracks missing STREAM and CRYPTO ranges in a pooled linked list. This replaces that list with a small specialized gap set:

- up to 8 gaps are stored inline;
- larger sets use one dense sorted slice;
- the single-gap path stays direct;
- larger sets use binary search on their ordered boundaries.

The gap set is private to `frameSorter`. There are no exported API, wire format, or stream semantics changes. Callback ownership, touching-boundary behavior, the 1,000-gap limit, and the `Pop` invariant are preserved.

This is an alternative implementation for #300 and overlaps with the older AVL-tree approach in #3471. It keeps the data structure specific to the frame sorter instead of adding a general tree implementation to the repository.

## Why

The linked list is cheap for an ordered stream, but every additional gap needs a list element and searches are pointer-heavy. A compact representation removes almost all gap-tracking allocations and improves locality when STREAM frames arrive substantially out of order, while keeping the ordered path flat.

Lookup is logarithmic once the set leaves inline storage. Inserts and removals can move O(n) intervals in the dense slice, but `frameSorter` already caps the set at 1,000 gaps.

## Benchmarks

Windows/amd64, Ryzen 9 9950X3D2, Go 1.27, `GOMAXPROCS=1`. Values are medians of 10 one-second runs against `cf0c4ffd0ce6`.

```text
name                         linked list    gap set       delta       allocs
PushOrdered                  6.690 us       6.666 us      -0.35%      5 -> 2
PushSlightlyReordered/4.69%  7.702 us       7.050 us      -8.47%      5 -> 2
PushReordered/window-32      12.201 us      12.120 us     -0.66%      14 -> 11
PushManyGaps/257             95.389 us      38.702 us     -59.43%     276 -> 23
PushMaxGaps/1000             517.771 us     70.307 us     -86.42%     1024 -> 30
PushMaxGapsShuffled/1000     318.151 us     111.744 us    -64.88%     1024 -> 30
```

Command:

```sh
GOMAXPROCS=1 go test -run '^$' -bench '^BenchmarkFrameSorterPush' -benchmem -benchtime=1s -count=10 .
```

These are microbenchmarks of the reassembly path. I don't have production or end-to-end QUIC throughput measurements for this implementation.

The slightly-reordered case displaces 12 of 256 arrival positions by swapping six adjacent frame pairs (4.6875%). Its value is the pooled median of an interleaved A/B/A/B run with 20 samples per side; the other rows use 10 samples per side.

## Validation

- `go test ./...` on Go 1.25 and 1.27; an independent Windows run hit `TestGracefulShutdownLongLivedRequest`'s timing limit, and the same failure reproduced on the unmodified base
- `go vet ./...`
- focused gap / frame sorter tests, shuffled, 20 repetitions
- `FuzzFrameSorter` for 30 seconds at the final commit (8.33 million executions)

I couldn't run the race detector on the Windows benchmark host because no C compiler is installed; GitHub's Linux integration race configuration remains the final race check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved frame sorting efficiency, particularly when handling reordered frames and multiple missing intervals.
  * Reduced allocation overhead during frame processing.

* **Bug Fixes**
  * Preserved reliable handling of duplicate data, gap limits, trimming, and frame completion across varied ordering scenarios.

* **Tests**
  * Added coverage for ordered, reordered, and heavily reordered frames.
  * Added validation for gap capacity, interval boundaries, ordering, and storage reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->