### PR TITLE
use tls.ConnectionState.CurveID directly in packet loss tests

### DIFF
--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -306,7 +306,7 @@ func TestHandshakeWithPacketLoss(t *testing.T) {
 								defer ln.Close()
 
 								conn := test.fn(t, ln, clientConn, clientConf, timeout, data)
-								curveID := getCurveID(conn.ConnectionState().TLS)
+								curveID := conn.ConnectionState().TLS.CurveID
 								if conf.postQuantum {
 									require.Equal(t, tls.X25519MLKEM768, curveID)
 								} else {

--- a/integrationtests/self/self_go124_test.go
+++ b/integrationtests/self/self_go124_test.go
@@ -1,9 +1,0 @@
-//go:build !go1.25
-
-package self_test
-
-import "crypto/tls"
-
-func getCurveID(connState tls.ConnectionState) tls.CurveID {
-	return 0
-}

--- a/integrationtests/self/self_go125_test.go
+++ b/integrationtests/self/self_go125_test.go
@@ -1,9 +1,0 @@
-//go:build go1.25
-
-package self_test
-
-import "crypto/tls"
-
-func getCurveID(connState tls.ConnectionState) tls.CurveID {
-	return connState.CurveID
-}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Use `tls.ConnectionState.CurveID` directly in packet loss tests
Replaces the `getCurveID` helper with direct access to `conn.ConnectionState().TLS.CurveID` in [handshake_drop_test.go](https://github.com/quic-go/quic-go/pull/5807/files#diff-c1c613faca7fe74db9d59fe73ca187788327967e341c43fb5e888b8d4b6fcd1e). Deletes the build-tagged helper files [self_go124_test.go](https://github.com/quic-go/quic-go/pull/5807/files#diff-6b9bf92dec1cd9a55fa5f0e8de1b27a7be6f0370323979d26141b455dafddf16) and [self_go125_test.go](https://github.com/quic-go/quic-go/pull/5807/files#diff-3cb0c725514aecfcaf2bb2477defcbbcb0dcab8e395a576f5857ff80ef4acbfb).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12efcef.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated handshake loss testing to read the negotiated TLS curve directly.
  - Removed version-specific compatibility helpers, improving test consistency across supported Go versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->