### PR TITLE
ci: disable ClusterFuzz until OSS-Fuzz supports Go 1.27

### DIFF
--- a/.github/workflows/clusterfuzz-coverage.yml
+++ b/.github/workflows/clusterfuzz-coverage.yml
@@ -1,7 +1,9 @@
 name: ClusterFuzz coverage
 on:
-  schedule:
-    - cron: '12 3,11,19 * * *'
+  # Disabled because OSS-Fuzz still uses Go 1.25, while quic-go requires Go 1.27.
+  # Re-enable once OSS-Fuzz supports Go 1.27; tracked in https://github.com/google/oss-fuzz/issues/15307.
+  # schedule:
+  #   - cron: '12 3,11,19 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/clusterfuzz-lite-batch.yml
+++ b/.github/workflows/clusterfuzz-lite-batch.yml
@@ -1,7 +1,10 @@
 name: ClusterFuzzLite batch fuzzing
 on:
-  schedule:
-    - cron: '0 0/6 * * *'
+  # Disabled because OSS-Fuzz still uses Go 1.25, while quic-go requires Go 1.27.
+  # Re-enable once OSS-Fuzz supports Go 1.27; tracked in https://github.com/google/oss-fuzz/issues/15307.
+  # schedule:
+  #   - cron: '0 0/6 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/clusterfuzz-lite-pr.yml
+++ b/.github/workflows/clusterfuzz-lite-pr.yml
@@ -1,8 +1,11 @@
 name: ClusterFuzzLite PR fuzzing
 on:
-  pull_request:
-    paths:
-      - '**'
+  # Disabled because OSS-Fuzz still uses Go 1.25, while quic-go requires Go 1.27.
+  # Re-enable once OSS-Fuzz supports Go 1.27; tracked in https://github.com/google/oss-fuzz/issues/15307.
+  # pull_request:
+  #   paths:
+  #     - '**'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/clusterfuzz-lite-prune.yml
+++ b/.github/workflows/clusterfuzz-lite-prune.yml
@@ -1,7 +1,10 @@
 name: ClusterFuzzLite pruning
 on:
-  schedule:
-    - cron: '0 2 * * *'
+  # Disabled because OSS-Fuzz still uses Go 1.25, while quic-go requires Go 1.27.
+  # Re-enable once OSS-Fuzz supports Go 1.27; tracked in https://github.com/google/oss-fuzz/issues/15307.
+  # schedule:
+  #   - cron: '0 2 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 [![Documentation](https://img.shields.io/badge/docs-quic--go.net-red?style=flat)](https://quic-go.net/docs/)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/quic-go/quic-go)](https://pkg.go.dev/github.com/quic-go/quic-go)
 [![Code Coverage](https://img.shields.io/codecov/c/github/quic-go/quic-go/master.svg?style=flat-square)](https://codecov.io/gh/quic-go/quic-go/)
+<!-- Disabled because OSS-Fuzz still uses Go 1.25, while quic-go requires Go 1.27.
+Re-enable once OSS-Fuzz supports Go 1.27; tracked in https://github.com/google/oss-fuzz/issues/15307.
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/quic-go.svg)](https://issues.oss-fuzz.com/issues?q=quic-go)
+-->
 
 quic-go is an implementation of the QUIC protocol ([RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000), [RFC 9001](https://datatracker.ietf.org/doc/html/rfc9001), [RFC 9002](https://datatracker.ietf.org/doc/html/rfc9002)) in Go.
 


### PR DESCRIPTION
See https://github.com/google/oss-fuzz/issues/15307.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable automatic ClusterFuzz runs until OSS-Fuzz supports Go 1.27
> - Removes scheduled, pull_request, and cron triggers from all four ClusterFuzz workflows, leaving only manual `workflow_dispatch` triggers active
> - Comments added to each workflow explain the disablement is temporary, pending OSS-Fuzz Go 1.27 support
> - Hides the Fuzzing Status badge in [README.md](https://github.com/quic-go/quic-go/pull/5808/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) by wrapping it in an HTML comment
> - Risk: fuzzing coverage, batch fuzzing, PR fuzzing, and pruning no longer run automatically; they require manual dispatch until re-enabled
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f52247.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled scheduled ClusterFuzz and ClusterFuzzLite runs due to Go version compatibility constraints.
  * Manual execution remains available for coverage, fuzzing, pull request checks, and pruning.
  * Documented the requirements and tracking information for re-enabling automated runs.

* **Documentation**
  * Temporarily disabled the OSS-Fuzz status badge until support for the required Go version is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->