### PR TITLE
http3: handle empty DNS resolution results

### DIFF
--- a/http3/transport.go
+++ b/http3/transport.go
@@ -106,6 +106,7 @@ type Transport struct {
 	initErr  error
 
 	newClientConn func(*quic.Conn) clientConn
+	lookupIPAddr  func(context.Context, string) ([]net.IPAddr, error)
 
 	clients   map[string]*roundTripperWithCount
 	transport *quic.Transport
@@ -408,10 +409,16 @@ func (t *Transport) resolveUDPAddr(ctx context.Context, network, addr string) (*
 	if err != nil {
 		return nil, err
 	}
-	resolver := net.DefaultResolver
-	ipAddrs, err := resolver.LookupIPAddr(ctx, host)
+	lookupIPAddr := t.lookupIPAddr
+	if lookupIPAddr == nil {
+		lookupIPAddr = net.DefaultResolver.LookupIPAddr
+	}
+	ipAddrs, err := lookupIPAddr(ctx, host)
 	if err != nil {
 		return nil, err
+	}
+	if len(ipAddrs) == 0 {
+		return nil, &net.AddrError{Err: "no suitable address found", Addr: host}
 	}
 	addrs := addrList(ipAddrs)
 	ip := addrs.forResolve(network, addr)

--- a/http3/transport_test.go
+++ b/http3/transport_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -172,6 +173,20 @@ func TestTransportDialHostname(t *testing.T) {
 			t.Fatal("timeout")
 		}
 	})
+}
+
+func TestTransportEmptyDNSResult(t *testing.T) {
+	tr := &Transport{
+		lookupIPAddr: func(context.Context, string) ([]net.IPAddr, error) { return nil, nil },
+	}
+	t.Cleanup(func() { require.NoError(t, tr.Close()) })
+
+	req := httptest.NewRequest(http.MethodGet, "https://empty.example", nil)
+	_, err := tr.RoundTrip(req)
+	var addrErr *net.AddrError
+	require.ErrorAs(t, err, &addrErr)
+	require.Equal(t, "no suitable address found", addrErr.Err)
+	require.Equal(t, "empty.example", addrErr.Addr)
 }
 
 func TestTransportDatagrams(t *testing.T) {


### PR DESCRIPTION
## Summary

The HTTP/3 client crashes with an index-out-of-range panic when a hostname lookup returns an empty address list without an error. The dial goroutine panics before recording `dialErr`, which can cause a second nil pointer dereference in a waiting request goroutine.

## Stack Trace

Observed with v0.61.0:

```text
panic: runtime error: index out of range [0] with length 0

github.com/quic-go/quic-go/http3.addrList.first(...)
        github.com/quic-go/quic-go@v0.61.0/http3/ip_addr.go:47
github.com/quic-go/quic-go/http3.addrList.forResolve(...)
        github.com/quic-go/quic-go@v0.61.0/http3/ip_addr.go:36
github.com/quic-go/quic-go/http3.(*Transport).resolveUDPAddr(...)
        github.com/quic-go/quic-go@v0.61.0/http3/transport.go:415

panic: runtime error: invalid memory address or nil pointer dereference

github.com/quic-go/quic-go/http3.(*Transport).doRoundTripOpt(...)
        github.com/quic-go/quic-go@v0.61.0/http3/transport.go:235
```

## Fix

Check for an empty address list before selecting an address and return a `net.AddrError` matching the standard library's `no suitable address found` behavior. The regression test exercises the complete asynchronous `RoundTrip` path.

## Workaround

Providing a custom `Transport.Dial` implementation that rejects empty DNS results avoids the crash

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable `lookupIPAddr` to `http3.Transport` and error on empty DNS results
> - Adds `Transport.lookupIPAddr` to allow injecting a custom IP lookup function; falls back to `net.DefaultResolver.LookupIPAddr` when unset.
> - `Transport.resolveUDPAddr` now returns a `*net.AddrError` (`Err: "no suitable address found"`) when DNS resolution yields zero addresses, instead of proceeding.
> - Risk: callers that previously received a connect-time error on empty DNS results now get a `*net.AddrError` earlier in `resolveUDPAddr`; verify any error-type checks around `http3.Transport.RoundTrip`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d42b48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->