### PR TITLE
send blocked frames for zero flow control limits

### DIFF
--- a/flow_controller_connection.go
+++ b/flow_controller_connection.go
@@ -30,6 +30,7 @@ func newConnectionFlowController(
 	logger utils.Logger,
 ) *connectionFlowController {
 	return &connectionFlowController{
+		lastBlockedAt: protocol.InvalidByteCount,
 		receiveFlowController: receiveFlowController{
 			rttStats:             rttStats,
 			receiveWindow:        receiveWindow,
@@ -122,12 +123,13 @@ func (c *connectionFlowController) SendWindowSize() protocol.ByteCount {
 
 // IsNewlyBlocked says if it is newly blocked by connection flow control.
 // For every offset, it only returns true once.
+// hasData distinguishes a zero send window from an idle connection.
 // If it is blocked, the offset is returned.
-func (c *connectionFlowController) IsNewlyBlocked() (bool, protocol.ByteCount) {
+func (c *connectionFlowController) IsNewlyBlocked(hasData bool) (bool, protocol.ByteCount) {
 	c.sendMutex.Lock()
 	defer c.sendMutex.Unlock()
 
-	if c.bytesSent < c.sendWindow || c.sendWindow == c.lastBlockedAt {
+	if c.bytesSent < c.sendWindow || c.sendWindow == c.lastBlockedAt || (c.sendWindow == 0 && !hasData) {
 		return false, 0
 	}
 	c.lastBlockedAt = c.sendWindow
@@ -173,6 +175,6 @@ func (c *connectionFlowController) Reset() {
 	defer c.sendMutex.Unlock()
 
 	c.bytesSent = 0
-	c.lastBlockedAt = 0
+	c.lastBlockedAt = protocol.InvalidByteCount
 	c.sendWindow = 0
 }

--- a/flow_controller_connection_test.go
+++ b/flow_controller_connection_test.go
@@ -69,3 +69,17 @@ func TestConnectionFlowControllerReset(t *testing.T) {
 	fc.Reset()
 	require.Zero(t, fc.SendWindowSize())
 }
+
+func TestConnectionFlowControllerBlockedAtZero(t *testing.T) {
+	fc := newConnectionFlowController(0, 0, nil, utils.NewRTTStats(), utils.DefaultLogger)
+
+	blocked, _ := fc.IsNewlyBlocked(false)
+	require.False(t, blocked)
+
+	blocked, offset := fc.IsNewlyBlocked(true)
+	require.True(t, blocked)
+	require.Zero(t, offset)
+
+	blocked, _ = fc.IsNewlyBlocked(true)
+	require.False(t, blocked)
+}

--- a/flow_controller_stream.go
+++ b/flow_controller_stream.go
@@ -34,9 +34,10 @@ func newStreamFlowController(
 	logger utils.Logger,
 ) *streamFlowController {
 	return &streamFlowController{
-		streamID:   streamID,
-		connection: cfc,
-		sendWindow: initialSendWindow,
+		streamID:      streamID,
+		connection:    cfc,
+		sendWindow:    initialSendWindow,
+		lastBlockedAt: protocol.InvalidByteCount,
 		receiveFlowController: receiveFlowController{
 			rttStats:             rttStats,
 			receiveWindow:        receiveWindow,

--- a/flow_controller_stream_test.go
+++ b/flow_controller_stream_test.go
@@ -176,6 +176,33 @@ func TestStreamSendWindow(t *testing.T) {
 	require.False(t, fc.IsNewlyBlocked()) // we're blocked, but not on stream flow control
 }
 
+func TestStreamFlowControllerBlockedAtZero(t *testing.T) {
+	connFC := newConnectionFlowController(
+		protocol.MaxByteCount,
+		protocol.MaxByteCount,
+		nil,
+		utils.NewRTTStats(),
+		utils.DefaultLogger,
+	)
+	require.True(t, connFC.UpdateSendWindow(protocol.MaxByteCount))
+	fc := newStreamFlowController(
+		42,
+		connFC,
+		protocol.MaxByteCount,
+		protocol.MaxByteCount,
+		0,
+		utils.NewRTTStats(),
+		utils.DefaultLogger,
+	)
+
+	blocked, offset := fc.isNewlyBlocked()
+	require.True(t, blocked)
+	require.Zero(t, offset)
+
+	blocked, _ = fc.isNewlyBlocked()
+	require.False(t, blocked)
+}
+
 func TestStreamFlowControllerTryAddBytesSent(t *testing.T) {
 	connFC := newConnectionFlowController(
 		protocol.MaxByteCount,

--- a/framer.go
+++ b/framer.go
@@ -136,6 +136,7 @@ func (f *framer) Append(
 
 	var lastFrame ackhandler.StreamFrame
 	var streamFrameLen protocol.ByteCount
+	var hasDataWithoutStreamFrame bool
 	f.mutex.Lock()
 	// retransmit all lost STREAM data before sending new STREAM data
 retransmissions:
@@ -182,7 +183,8 @@ retransmissions:
 			if protocol.MinStreamFrameSize > maxLen {
 				break
 			}
-			sf, blocked := f.getNextStreamFrame(maxLen, int8(urgency), v)
+			sf, blocked, hasData := f.getNextStreamFrame(maxLen, int8(urgency), v)
+			hasDataWithoutStreamFrame = hasDataWithoutStreamFrame || hasData
 			if sf.Frame != nil {
 				streamFrames = append(streamFrames, sf)
 				maxLen -= sf.Frame.Length(v)
@@ -205,8 +207,8 @@ retransmissions:
 		}
 	}
 
-	// The only way to become blocked on connection-level flow control is by sending STREAM frames.
-	if isBlocked, offset := f.connFlowController.IsNewlyBlocked(); isBlocked {
+	// A zero connection limit can block pending data before a STREAM frame is sent.
+	if isBlocked, offset := f.connFlowController.IsNewlyBlocked(hasDataWithoutStreamFrame); isBlocked {
 		blocked := &wire.DataBlockedFrame{MaximumData: offset}
 		l := blocked.Length(v)
 		// In case it doesn't fit, queue it for the next packet.
@@ -370,7 +372,7 @@ func (f *framer) getNextStreamFrame(
 	maxLen protocol.ByteCount,
 	urgency int8,
 	v protocol.Version,
-) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
+) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasDataWithoutStreamFrame bool) {
 	if f.nonIncrementalStreams[urgency].Empty() || (!f.lastSendWasIncremental[urgency] && !f.incrementalStreams[urgency].Empty()) {
 		return f.getNextIncrementalStreamFrame(maxLen, urgency, v)
 	}
@@ -381,19 +383,19 @@ func (f *framer) getNextIncrementalStreamFrame(
 	maxLen protocol.ByteCount,
 	urgency int8,
 	v protocol.Version,
-) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
+) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasDataWithoutStreamFrame bool) {
 	queue := &f.incrementalStreams[urgency]
 	if queue.Empty() {
-		return ackhandler.StreamFrame{}, nil
+		return ackhandler.StreamFrame{}, nil, false
 	}
 	entry := queue.PopFront()
 	str, ok := f.activeStreams[entry.id]
 	if !ok {
-		return ackhandler.StreamFrame{}, nil
+		return ackhandler.StreamFrame{}, nil, false
 	}
 	_, _, generation := str.priority()
 	if generation != entry.generation {
-		return ackhandler.StreamFrame{}, nil
+		return ackhandler.StreamFrame{}, nil, false
 	}
 
 	frame, blocked, hasMoreData := f.popStreamFrame(entry.id, str, maxLen, v)
@@ -401,28 +403,28 @@ func (f *framer) getNextIncrementalStreamFrame(
 		queue.PushBack(entry)
 	}
 	f.lastSendWasIncremental[urgency] = true
-	return frame, blocked
+	return frame, blocked, frame.Frame == nil && (blocked != nil || hasMoreData)
 }
 
 func (f *framer) getNextNonIncrementalStreamFrame(
 	maxLen protocol.ByteCount,
 	urgency int8,
 	v protocol.Version,
-) (ackhandler.StreamFrame, *wire.StreamDataBlockedFrame) {
+) (_ ackhandler.StreamFrame, _ *wire.StreamDataBlockedFrame, hasDataWithoutStreamFrame bool) {
 	queue := &f.nonIncrementalStreams[urgency]
 	if queue.Empty() {
-		return ackhandler.StreamFrame{}, nil
+		return ackhandler.StreamFrame{}, nil, false
 	}
 	id, queuedGeneration := queue.Peek()
 	str, ok := f.activeStreams[id]
 	if !ok {
 		queue.Pop()
-		return ackhandler.StreamFrame{}, nil
+		return ackhandler.StreamFrame{}, nil, false
 	}
 	_, _, generation := str.priority()
 	if generation != queuedGeneration {
 		queue.Pop()
-		return ackhandler.StreamFrame{}, nil
+		return ackhandler.StreamFrame{}, nil, false
 	}
 
 	frame, blocked, hasMoreData := f.popStreamFrame(id, str, maxLen, v)
@@ -430,7 +432,7 @@ func (f *framer) getNextNonIncrementalStreamFrame(
 		queue.Pop()
 	}
 	f.lastSendWasIncremental[urgency] = false
-	return frame, blocked
+	return frame, blocked, frame.Frame == nil && (blocked != nil || hasMoreData)
 }
 
 func (f *framer) popStreamFrame(

--- a/framer_test.go
+++ b/framer_test.go
@@ -162,6 +162,20 @@ func TestFramerDataBlocked(t *testing.T) {
 	})
 }
 
+func TestFramerDataBlockedAtZero(t *testing.T) {
+	const streamID = 5
+
+	str := NewMockStreamFrameGetter(gomock.NewController(t))
+	str.EXPECT().priority().Return(defaultUrgency, true, uint32(0)).AnyTimes()
+	str.EXPECT().popStreamFrame(gomock.Any(), gomock.Any()).Return(ackhandler.StreamFrame{}, nil, true)
+	framer := newFramer(newConnectionFlowController(0, 0, nil, nil, nil))
+	framer.AddActiveStream(streamID, str)
+
+	frames, streamFrames, _ := framer.Append(nil, nil, 1000, monotime.Now(), protocol.Version1)
+	require.Empty(t, streamFrames)
+	require.Equal(t, []ackhandler.Frame{{Frame: &wire.DataBlockedFrame{MaximumData: 0}}}, frames)
+}
+
 // If the stream becomes blocked on connection flow control, we attempt to pack the
 // DATA_BLOCKED frame into the same packet.
 // However, there's the pathological case, where the STREAM frame and the DATA_BLOCKED frame

--- a/send_stream.go
+++ b/send_stream.go
@@ -425,6 +425,9 @@ func (s *SendStream) popNewStreamFrameForPacket(maxBytes protocol.ByteCount, v p
 		maxDataLen = min(maxDataLen, f.MaxDataLen(maxBytes, v), protocol.ByteCount(len(s.dataForWriting)))
 	}
 	if maxDataLen == 0 {
+		if isBlocked, offset := s.flowController.isNewlyBlocked(); isBlocked {
+			return nil, &wire.StreamDataBlockedFrame{StreamID: s.streamID, MaximumStreamData: offset}, false
+		}
 		return nil, nil, true
 	}
 	if limitedWrite {

--- a/send_stream_test.go
+++ b/send_stream_test.go
@@ -856,6 +856,22 @@ func TestSendStreamFlowControlBlocked(t *testing.T) {
 	require.False(t, hasMore)
 }
 
+func TestSendStreamFlowControlBlockedAtZero(t *testing.T) {
+	const streamID protocol.StreamID = 42
+	mockCtrl := gomock.NewController(t)
+	mockSender := NewMockStreamSender(mockCtrl)
+	str := newSendStream(context.Background(), streamID, mockSender, newTestStreamFlowController(streamID), false)
+
+	mockSender.EXPECT().onHasStreamData(streamID, str)
+	_, err := str.Write([]byte("foobar"))
+	require.NoError(t, err)
+
+	frame, blocked, hasMoreData := str.popStreamFrame(protocol.MaxByteCount, protocol.Version1)
+	require.Nil(t, frame.Frame)
+	require.False(t, hasMoreData)
+	require.Equal(t, &wire.StreamDataBlockedFrame{StreamID: streamID, MaximumStreamData: 0}, blocked)
+}
+
 func TestSendStreamCloseForShutdown(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		const streamID protocol.StreamID = 1337


### PR DESCRIPTION
## Problem

When a peer advertises a connection-level or stream-level flow control limit of zero, pending application data doesn't produce a `DATA_BLOCKED` or `STREAM_DATA_BLOCKED` frame. [RFC 9000 section 4.1](https://www.rfc-editor.org/rfc/rfc9000.html#section-4.1) recommends sending these frames when data is waiting behind a flow control limit.

## Root cause

`lastBlockedAt` used zero both as its initial value and as a valid blocked offset, so the first notification at offset zero looked like a duplicate. In addition, `SendStream` returned as soon as its available send window was zero, before checking stream-level blocked state. At the connection level, the framer didn't preserve that data was pending when no STREAM frame could be produced.

## Fix

Use `protocol.InvalidByteCount` for the unseen blocked offset, check stream-level blocking on the zero-credit path, and carry pending-data state through the framer. The connection controller uses that state only for a zero send window, which prevents idle connections from emitting unsolicited blocked frames.

## Tests

- `go test ./... -count=1`
- `go test -race . -run 'Test(ConnectionFlowControllerBlockedAtZero|StreamFlowControllerBlockedAtZero|FramerDataBlockedAtZero|SendStreamFlowControlBlockedAtZero)' -count=1`
- `GOTOOLCHAIN=go1.25.0 go test . -count=1`
- `GOTOOLCHAIN=go1.26.0 go test . -count=1`
- `go vet ./...`
- `golangci-lint run --timeout=3m --new-from-rev=HEAD`

## Compatibility

Nonzero flow control limits retain the existing behavior, repeated blocked notifications at the same offset remain suppressed, and idle zero-window connections remain silent. No public API changes.

Fixes #4174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected flow-control blocking detection when connection or stream limits are zero.
  * Ensured blocked notifications are emitted even when no data frame can be sent.
  * Prevented duplicate blocked notifications for unchanged flow-control windows.
  * Added accurate `DATA_BLOCKED` and `STREAM_DATA_BLOCKED` signaling with a zero limit.

* **Tests**
  * Added coverage for zero-window behavior at connection, stream, and framing levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send `DATA_BLOCKED` and `STREAM_DATA_BLOCKED` frames at zero flow control limits
> - Flow controllers now distinguish a zero send window with no pending data (not blocked) from one with pending data (blocked). `IsNewlyBlocked` takes a new `hasData` parameter; constructors and `Reset` initialize `lastBlockedAt` to `protocol.InvalidByteCount` to avoid spurious re-block reports at offset 0.
> - Framer tracks pending data via `hasDataWithoutStreamFrame` across `getNextStreamFrame` helpers and emits a `DATA_BLOCKED` frame when the connection flow control limit is zero and data is pending, even if no STREAM frame was produced.
> - `SendStream.popNewStreamFrameForPacket` emits a `STREAM_DATA_BLOCKED` frame when the stream is newly blocked at its current limit with no payload to send.
> - Risk: `IsNewlyBlocked` signature changed to require a `hasData` argument; all in-tree callers in [framer.go](https://github.com/quic-go/quic-go/pull/5812/files#diff-a97a2544cb1bf86661368aeb59921e0629ab259d2728c61715e856a7ab5c1f6f) and [send_stream.go](https://github.com/quic-go/quic-go/pull/5812/files#diff-0683df4767cffeaa4b1127b3e6027900d06dac7973a80454782e810871af742e) are updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2e0ef78. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->