### PR TITLE
http3: verify that server didn't accept 0-RTT with incompatible SETTINGS

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -76,6 +76,11 @@ type ClientConn struct {
 	qlogger qlogwriter.Recorder
 	logger  *slog.Logger
 
+	// zeroRTTSettings tracks the server's SETTINGS across session resumption.
+	// It is nil if the connection can't use 0-RTT, i.e. if no session cache is configured,
+	// or if the application manages the QUIC connection itself.
+	zeroRTTSettings *zeroRTTSettings
+
 	requestWriter *requestWriter
 }
 
@@ -87,6 +92,7 @@ func newClientConn(
 	additionalSettings map[uint64]uint64,
 	maxResponseHeaderBytes int,
 	disableCompression bool,
+	zeroRTTSettings *zeroRTTSettings,
 	logger *slog.Logger,
 ) *ClientConn {
 	var qlogger qlogwriter.Recorder
@@ -98,6 +104,7 @@ func newClientConn(
 		additionalSettings: additionalSettings,
 		disableCompression: disableCompression,
 		maxStreamID:        invalidStreamID,
+		zeroRTTSettings:    zeroRTTSettings,
 		logger:             logger,
 		qlogger:            qlogger,
 		decoder:            qpack.NewDecoder(),
@@ -199,6 +206,9 @@ func (c *ClientConn) handleUnidirectionalStream(str *quic.ReceiveStream) {
 }
 
 func (c *ClientConn) handleControlStream(str *quic.ReceiveStream, fp *frameParser) {
+	if !c.checkSettingsAfter0RTT(c.rawConn.rcvdSettings) {
+		return
+	}
 	for {
 		f, err := fp.ParseNext(c.qlogger)
 		if err != nil {
@@ -244,6 +254,37 @@ func (c *ClientConn) handleControlStream(str *quic.ReceiveStream, fp *frameParse
 			return
 		}
 	}
+}
+
+// checkSettingsAfter0RTT saves the server's SETTINGS, so that they can be stored alongside the
+// session ticket, and verifies them against the settings that were restored from a session ticket.
+//
+// If the server accepted 0-RTT, but then sent SETTINGS that are incompatible with the ones the
+// client used for its 0-RTT data, the connection is closed with H3_SETTINGS_ERROR,
+// as required by RFC 9114, section 7.2.4.2. It returns false if the connection was closed.
+func (c *ClientConn) checkSettingsAfter0RTT(current *settingsFrame) bool {
+	if c.zeroRTTSettings == nil {
+		return true
+	}
+	c.zeroRTTSettings.setCurrent(current)
+	restored := c.zeroRTTSettings.getRestored()
+	// Nothing to check: this connection didn't resume a session, or no settings were stored.
+	if restored == nil {
+		return true
+	}
+	if settingsCompatibleAfter0RTT(restored, current) {
+		return true
+	}
+	// Only if the server actually accepted our 0-RTT data can it have violated the old settings.
+	// This is checked last: ConnectionState blocks until the handshake is complete.
+	if !c.conn.ConnectionState().Used0RTT {
+		return true
+	}
+	c.conn.CloseWithError(
+		quic.ApplicationErrorCode(ErrCodeSettingsError),
+		"server accepted 0-RTT, but sent incompatible SETTINGS",
+	)
+	return false
 }
 
 func (c *ClientConn) onStreamsEmpty() {

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -42,7 +42,10 @@ type rawConn struct {
 
 	onStreamsEmpty func()
 
-	settings         *Settings
+	settings *Settings
+	// rcvdSettings is the SETTINGS frame the peer sent, as received on the control stream.
+	// Unlike settings, it also carries the values that are not part of the public Settings API.
+	rcvdSettings     *settingsFrame
 	receivedSettings chan struct{}
 
 	qlogger   qlogwriter.Recorder
@@ -238,6 +241,7 @@ func (c *rawConn) handleControlStream(str *quic.ReceiveStream) {
 		EnableExtendedConnect: sf.ExtendedConnect,
 		Other:                 sf.Other,
 	}
+	c.rcvdSettings = sf
 	close(c.receivedSettings)
 	if sf.Datagram {
 		// If datagram support was enabled on our side as well as on the server side,

--- a/http3/settings_0rtt.go
+++ b/http3/settings_0rtt.go
@@ -2,6 +2,8 @@ package http3
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 
 	"github.com/quic-go/quic-go/quicvarint"
 )
@@ -24,17 +26,29 @@ func settingsDataFromSessionTicket(extras [][]byte) ([]byte, bool) {
 	return nil, false
 }
 
-func settingsCompatibleFor0RTT(data []byte, current *settings) bool {
+// parseSettingsFromSessionTicket parses a SETTINGS frame that was stored in a session ticket
+// by settingsForSessionTicket.
+func parseSettingsFromSessionTicket(data []byte) (*settings, error) {
 	r := bytes.NewReader(data)
 	frameType, err := quicvarint.Read(r)
-	if err != nil || frameType != 0x4 {
-		return false
+	if err != nil {
+		return nil, err
+	}
+	if frameType != 0x4 {
+		return nil, fmt.Errorf("unexpected frame type: %d", frameType)
 	}
 	length, err := quicvarint.Read(r)
-	if err != nil || uint64(r.Len()) != length {
-		return false
+	if err != nil {
+		return nil, err
 	}
-	old, err := parseSettingsFrame(&countingByteReader{Reader: r}, length, 0, nil)
+	if uint64(r.Len()) != length {
+		return nil, errors.New("SETTINGS frame length doesn't match")
+	}
+	return parseSettingsFrame(&countingByteReader{Reader: r}, length, 0, nil)
+}
+
+func settingsCompatibleFor0RTT(data []byte, current *settings) bool {
+	old, err := parseSettingsFromSessionTicket(data)
 	if err != nil {
 		return false
 	}
@@ -44,6 +58,36 @@ func settingsCompatibleFor0RTT(data []byte, current *settings) bool {
 	}
 
 	if current.MaxFieldSectionSize >= 0 && (old.MaxFieldSectionSize < 0 || old.MaxFieldSectionSize > current.MaxFieldSectionSize) {
+		return false
+	}
+	if old.Datagram && !current.Datagram {
+		return false
+	}
+	if old.ExtendedConnect && !current.ExtendedConnect {
+		return false
+	}
+	return true
+}
+
+// settingsCompatibleAfter0RTT says whether the SETTINGS frame that the server sent on a
+// resumed connection is compatible with the settings the client assumed when it sent 0-RTT data.
+//
+// RFC 9114, section 7.2.4.2 requires that a server accepting 0-RTT neither reduces a limit nor
+// omits a setting that the client understands and that was previously sent with a non-default
+// value. Either is a connection error of type H3_SETTINGS_ERROR.
+//
+// Settings that we don't recognize are deliberately not considered: the omission rule only
+// applies to settings that the client understands, and for the remaining ones there's no way
+// to tell whether a changed value is more restrictive.
+func settingsCompatibleAfter0RTT(old, current *settings) bool {
+	// A missing SETTINGS_MAX_FIELD_SECTION_SIZE means unlimited, so sending a value where there
+	// previously was none reduces the limit just as much as sending a smaller value does.
+	if current.MaxFieldSectionSize >= 0 &&
+		(old.MaxFieldSectionSize < 0 || current.MaxFieldSectionSize < old.MaxFieldSectionSize) {
+		return false
+	}
+	// The value is gone, even though it was previously sent with a non-default value.
+	if old.MaxFieldSectionSize >= 0 && current.MaxFieldSectionSize < 0 {
 		return false
 	}
 	if old.Datagram && !current.Datagram {

--- a/http3/settings_0rtt_client.go
+++ b/http3/settings_0rtt_client.go
@@ -1,0 +1,115 @@
+package http3
+
+import (
+	"crypto/tls"
+	"sync"
+)
+
+// zeroRTTSettings carries the server's SETTINGS across a session resumption.
+//
+// RFC 9114, section 7.2.4.2: when a 0-RTT QUIC connection is being used, the initial value of
+// each server setting is the value used in the previous session. Clients therefore store the
+// settings the server sent, and check the SETTINGS frame of the resumed connection against them.
+type zeroRTTSettings struct {
+	mx sync.Mutex
+	// restored are the settings recovered from the session ticket.
+	// It is nil if no settings were stored alongside the ticket.
+	restored *settings
+	// current are the settings the server sent on this connection.
+	// It is nil until the SETTINGS frame is received.
+	current *settings
+}
+
+func (s *zeroRTTSettings) setCurrent(sf *settings) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+	s.current = sf
+}
+
+func (s *zeroRTTSettings) getCurrent() *settings {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+	return s.current
+}
+
+func (s *zeroRTTSettings) setRestored(sf *settings) {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+	s.restored = sf
+}
+
+func (s *zeroRTTSettings) getRestored() *settings {
+	s.mx.Lock()
+	defer s.mx.Unlock()
+	return s.restored
+}
+
+// clientSessionCache wraps a tls.ClientSessionCache, storing the server's HTTP/3 SETTINGS
+// alongside the session ticket, and restoring them when the session is resumed.
+//
+// The settings are only ever kept in the client's own session cache. They are not sent to the
+// server, and they are not part of the (opaque) session ticket itself.
+type clientSessionCache struct {
+	tls.ClientSessionCache
+
+	settings *zeroRTTSettings
+}
+
+var _ tls.ClientSessionCache = &clientSessionCache{}
+
+func (c *clientSessionCache) Put(key string, cs *tls.ClientSessionState) {
+	if cs == nil {
+		c.ClientSessionCache.Put(key, nil)
+		return
+	}
+	// The session ticket can be received before the server's SETTINGS frame.
+	// RFC 9114, section 7.2.4.2 explicitly allows not storing any settings in that case.
+	// The next connection then won't have any settings to rely on, and won't use 0-RTT.
+	current := c.settings.getCurrent()
+	if current == nil {
+		c.ClientSessionCache.Put(key, cs)
+		return
+	}
+	ticket, state, err := cs.ResumptionState()
+	if err != nil || state == nil {
+		c.ClientSessionCache.Put(key, cs)
+		return
+	}
+	state.Extra = append(state.Extra, settingsForSessionTicket(current))
+	newCS, err := tls.NewResumptionState(ticket, state)
+	if err != nil {
+		c.ClientSessionCache.Put(key, cs)
+		return
+	}
+	c.ClientSessionCache.Put(key, newCS)
+}
+
+func (c *clientSessionCache) Get(key string) (*tls.ClientSessionState, bool) {
+	cs, ok := c.ClientSessionCache.Get(key)
+	if !ok || cs == nil {
+		return cs, ok
+	}
+	ticket, state, err := cs.ResumptionState()
+	if err != nil || state == nil {
+		return cs, true
+	}
+	if data, ok := settingsDataFromSessionTicket(state.Extra); ok {
+		if sf, err := parseSettingsFromSessionTicket(data); err == nil {
+			c.settings.setRestored(sf)
+			return cs, true
+		}
+	}
+	// There's no settings baseline stored alongside this ticket, so checkSettingsAfter0RTT has
+	// nothing to check the server's SETTINGS against once the connection is established. Strip
+	// the ticket of its ability to be used for 0-RTT, rather than silently accepting whatever
+	// SETTINGS the server sends.
+	if !state.EarlyData {
+		return cs, true
+	}
+	state.EarlyData = false
+	newCS, err := tls.NewResumptionState(ticket, state)
+	if err != nil {
+		return nil, false
+	}
+	return newCS, true
+}

--- a/http3/settings_0rtt_client_test.go
+++ b/http3/settings_0rtt_client_test.go
@@ -1,0 +1,233 @@
+package http3
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingsCompatibleAfter0RTT(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		old        *settings
+		current    *settings
+		compatible bool
+	}{
+		{
+			name:       "unchanged",
+			old:        &settings{MaxFieldSectionSize: 100},
+			current:    &settings{MaxFieldSectionSize: 100},
+			compatible: true,
+		},
+		{
+			name:       "max field section size increased",
+			old:        &settings{MaxFieldSectionSize: 100},
+			current:    &settings{MaxFieldSectionSize: 101},
+			compatible: true,
+		},
+		{
+			name:    "max field section size reduced",
+			old:     &settings{MaxFieldSectionSize: 100},
+			current: &settings{MaxFieldSectionSize: 99},
+		},
+		{
+			// The default is unlimited, so dropping the value raises the limit,
+			// but RFC 9114, section 7.2.4.2 doesn't allow omitting it either.
+			name:    "max field section size omitted",
+			old:     &settings{MaxFieldSectionSize: 100},
+			current: &settings{MaxFieldSectionSize: -1},
+		},
+		{
+			// Going from unlimited to a limit is a reduction as well.
+			name:    "max field section size added",
+			old:     &settings{MaxFieldSectionSize: -1},
+			current: &settings{MaxFieldSectionSize: 100},
+		},
+		{
+			name:       "no max field section size on either side",
+			old:        &settings{MaxFieldSectionSize: -1},
+			current:    &settings{MaxFieldSectionSize: -1},
+			compatible: true,
+		},
+		{
+			name:    "datagrams disabled",
+			old:     &settings{MaxFieldSectionSize: -1, Datagram: true},
+			current: &settings{MaxFieldSectionSize: -1},
+		},
+		{
+			name:       "datagrams enabled",
+			old:        &settings{MaxFieldSectionSize: -1},
+			current:    &settings{MaxFieldSectionSize: -1, Datagram: true},
+			compatible: true,
+		},
+		{
+			name:    "extended connect disabled",
+			old:     &settings{MaxFieldSectionSize: -1, ExtendedConnect: true},
+			current: &settings{MaxFieldSectionSize: -1},
+		},
+		{
+			name:       "extended connect enabled",
+			old:        &settings{MaxFieldSectionSize: -1},
+			current:    &settings{MaxFieldSectionSize: -1, ExtendedConnect: true},
+			compatible: true,
+		},
+		{
+			// The omission rule only covers settings that the client understands.
+			name:       "unknown setting dropped",
+			old:        &settings{MaxFieldSectionSize: -1, Other: map[uint64]uint64{13: 37}},
+			current:    &settings{MaxFieldSectionSize: -1},
+			compatible: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.compatible, settingsCompatibleAfter0RTT(tc.old, tc.current))
+		})
+	}
+}
+
+// newClientSessionState creates a tls.ClientSessionState carrying the given extra data,
+// mimicking what crypto/tls hands to the session cache after a handshake.
+func newClientSessionState(t *testing.T, extra [][]byte) *tls.ClientSessionState {
+	t.Helper()
+	return newClientSessionStateWithEarlyData(t, extra, false)
+}
+
+// newClientSessionStateWithEarlyData is like newClientSessionState, but also controls whether
+// the ticket may be used for 0-RTT, mimicking a ticket that the server issued with early data
+// enabled.
+func newClientSessionStateWithEarlyData(t *testing.T, extra [][]byte, earlyData bool) *tls.ClientSessionState {
+	t.Helper()
+
+	cs, err := tls.NewResumptionState([]byte("ticket"), &tls.SessionState{Extra: extra, EarlyData: earlyData})
+	require.NoError(t, err)
+	return cs
+}
+
+func earlyDataFromClientSessionState(t *testing.T, cs *tls.ClientSessionState) bool {
+	t.Helper()
+
+	_, state, err := cs.ResumptionState()
+	require.NoError(t, err)
+	return state.EarlyData
+}
+
+func extraFromClientSessionState(t *testing.T, cs *tls.ClientSessionState) [][]byte {
+	t.Helper()
+
+	_, state, err := cs.ResumptionState()
+	require.NoError(t, err)
+	return state.Extra
+}
+
+// stubClientSessionCache records what was stored, and hands back what it was seeded with.
+type stubClientSessionCache struct {
+	put  *tls.ClientSessionState
+	get  *tls.ClientSessionState
+	miss bool
+}
+
+var _ tls.ClientSessionCache = &stubClientSessionCache{}
+
+func (c *stubClientSessionCache) Put(_ string, cs *tls.ClientSessionState) { c.put = cs }
+
+func (c *stubClientSessionCache) Get(string) (*tls.ClientSessionState, bool) {
+	if c.miss {
+		return nil, false
+	}
+	return c.get, true
+}
+
+func TestClientSessionCacheStoresSettings(t *testing.T) {
+	current := &settings{MaxFieldSectionSize: 1337, Datagram: true}
+	stub := &stubClientSessionCache{}
+	zeroRTT := &zeroRTTSettings{}
+	zeroRTT.setCurrent(current)
+	cache := &clientSessionCache{ClientSessionCache: stub, settings: zeroRTT}
+
+	// quic-go appends its own entry before the session reaches the cache
+	cache.Put("key", newClientSessionStateWithEarlyData(t, [][]byte{[]byte("quic-go's entry")}, true))
+	require.NotNil(t, stub.put)
+
+	extra := extraFromClientSessionState(t, stub.put)
+	require.Len(t, extra, 2)
+	require.Equal(t, []byte("quic-go's entry"), extra[0])
+
+	// restoring the settings from that same session yields what we put in, and 0-RTT
+	// stays available since there's a baseline to check the server's SETTINGS against
+	restoreCache := &clientSessionCache{
+		ClientSessionCache: &stubClientSessionCache{get: stub.put},
+		settings:           &zeroRTTSettings{},
+	}
+	cs, ok := restoreCache.Get("key")
+	require.True(t, ok)
+	require.NotNil(t, cs)
+	require.Equal(t, current, restoreCache.settings.getRestored())
+	require.True(t, earlyDataFromClientSessionState(t, cs))
+}
+
+func TestClientSessionCacheWithoutSettings(t *testing.T) {
+	t.Run("settings not received yet", func(t *testing.T) {
+		stub := &stubClientSessionCache{}
+		cache := &clientSessionCache{ClientSessionCache: stub, settings: &zeroRTTSettings{}}
+
+		// The session ticket can arrive before the server's SETTINGS frame.
+		// The session is then stored unmodified, and 0-RTT is not used on the next connection.
+		cache.Put("key", newClientSessionState(t, [][]byte{[]byte("quic-go's entry")}))
+		require.NotNil(t, stub.put)
+		require.Equal(t, [][]byte{[]byte("quic-go's entry")}, extraFromClientSessionState(t, stub.put))
+	})
+
+	t.Run("no settings stored", func(t *testing.T) {
+		cache := &clientSessionCache{
+			ClientSessionCache: &stubClientSessionCache{
+				get: newClientSessionStateWithEarlyData(t, [][]byte{[]byte("quic-go's entry")}, true),
+			},
+			settings: &zeroRTTSettings{},
+		}
+		cs, ok := cache.Get("key")
+		require.True(t, ok)
+		require.Nil(t, cache.settings.getRestored())
+		// There's nothing to check the server's SETTINGS against, so this ticket must not be
+		// used for 0-RTT, even though the server allowed it.
+		require.False(t, earlyDataFromClientSessionState(t, cs))
+	})
+
+	t.Run("malformed settings", func(t *testing.T) {
+		cache := &clientSessionCache{
+			ClientSessionCache: &stubClientSessionCache{
+				get: newClientSessionStateWithEarlyData(t, [][]byte{
+					append([]byte(serverSettingsSessionTicketPrefix), 0xff),
+				}, true),
+			},
+			settings: &zeroRTTSettings{},
+		}
+		cs, ok := cache.Get("key")
+		require.True(t, ok)
+		require.Nil(t, cache.settings.getRestored())
+		require.False(t, earlyDataFromClientSessionState(t, cs))
+	})
+
+	t.Run("no settings stored, ticket not eligible for 0-RTT anyway", func(t *testing.T) {
+		cache := &clientSessionCache{
+			ClientSessionCache: &stubClientSessionCache{
+				get: newClientSessionState(t, [][]byte{[]byte("quic-go's entry")}),
+			},
+			settings: &zeroRTTSettings{},
+		}
+		cs, ok := cache.Get("key")
+		require.True(t, ok)
+		require.Nil(t, cache.settings.getRestored())
+		require.False(t, earlyDataFromClientSessionState(t, cs))
+	})
+
+	t.Run("cache miss", func(t *testing.T) {
+		cache := &clientSessionCache{
+			ClientSessionCache: &stubClientSessionCache{miss: true},
+			settings:           &zeroRTTSettings{},
+		}
+		_, ok := cache.Get("key")
+		require.False(t, ok)
+		require.Nil(t, cache.settings.getRestored())
+	})
+}

--- a/http3/transport.go
+++ b/http3/transport.go
@@ -105,7 +105,7 @@ type Transport struct {
 	initOnce sync.Once
 	initErr  error
 
-	newClientConn func(*quic.Conn) clientConn
+	newClientConn func(*quic.Conn, *zeroRTTSettings) clientConn
 
 	clients   map[string]*roundTripperWithCount
 	transport *quic.Transport
@@ -128,13 +128,14 @@ var (
 
 func (t *Transport) init() error {
 	if t.newClientConn == nil {
-		t.newClientConn = func(conn *quic.Conn) clientConn {
+		t.newClientConn = func(conn *quic.Conn, zeroRTTSettings *zeroRTTSettings) clientConn {
 			return newClientConn(
 				conn,
 				t.EnableDatagrams,
 				t.AdditionalSettings,
 				t.MaxResponseHeaderBytes,
 				t.DisableCompression,
+				zeroRTTSettings,
 				t.Logger,
 			)
 		}
@@ -360,6 +361,18 @@ func (t *Transport) dial(ctx context.Context, hostname string) (*quic.Conn, clie
 	// Replace existing ALPNs by H3
 	tlsConf.NextProtos = []string{NextProtoH3}
 
+	// Store the server's SETTINGS alongside the session ticket, so that they are available
+	// as the initial values when this session is resumed using 0-RTT.
+	// Without a session cache, sessions are never resumed, and there's nothing to track.
+	var zeroRTT *zeroRTTSettings
+	if tlsConf.ClientSessionCache != nil {
+		zeroRTT = &zeroRTTSettings{}
+		tlsConf.ClientSessionCache = &clientSessionCache{
+			ClientSessionCache: tlsConf.ClientSessionCache,
+			settings:           zeroRTT,
+		}
+	}
+
 	dial := t.Dial
 	if dial == nil {
 		dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
@@ -385,7 +398,7 @@ func (t *Transport) dial(ctx context.Context, hostname string) (*quic.Conn, clie
 	if err != nil {
 		return nil, nil, err
 	}
-	clientConn := t.newClientConn(conn)
+	clientConn := t.newClientConn(conn, zeroRTT)
 	go func() {
 		for {
 			str, err := conn.AcceptUniStream(context.Background())
@@ -439,6 +452,9 @@ func (t *Transport) NewClientConn(conn *quic.Conn) *ClientConn {
 		t.AdditionalSettings,
 		t.MaxResponseHeaderBytes,
 		t.DisableCompression,
+		// The application dialed this connection itself, so the Transport didn't get to
+		// wrap the session cache, and has no settings from a previous session to check against.
+		nil,
 		t.Logger,
 	)
 	go func() {
@@ -465,6 +481,7 @@ func (t *Transport) NewRawClientConn(conn *quic.Conn) *RawClientConn {
 			t.AdditionalSettings,
 			t.MaxResponseHeaderBytes,
 			t.DisableCompression,
+			nil,
 			t.Logger,
 		),
 	}

--- a/http3/transport_test.go
+++ b/http3/transport_test.go
@@ -225,7 +225,7 @@ func TestTransportConnectionReuse(t *testing.T) {
 			dialCount++
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn { return cl },
+		newClientConn: func(*quic.Conn, *zeroRTTSettings) clientConn { return cl },
 	}
 
 	req1 := httptest.NewRequest(http.MethodGet, "https://quic-go.net/file1.html", nil)
@@ -322,7 +322,7 @@ func testTransportConnectionRedial(t *testing.T, req *http.Request, roundtripErr
 			dialCount++
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn { return cl },
+		newClientConn: func(*quic.Conn, *zeroRTTSettings) clientConn { return cl },
 	}
 
 	var body string
@@ -358,7 +358,7 @@ func TestTransportRequestContextCancellation(t *testing.T) {
 			dialCount++
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn { return cl },
+		newClientConn: func(*quic.Conn, *zeroRTTSettings) clientConn { return cl },
 	}
 
 	// the first request succeeds
@@ -405,7 +405,7 @@ func TestTransportConnetionRedialHandshakeError(t *testing.T) {
 			}
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn { return cl },
+		newClientConn: func(*quic.Conn, *zeroRTTSettings) clientConn { return cl },
 	}
 
 	req1 := httptest.NewRequest(http.MethodGet, "https://quic-go.net/file1.html", nil)
@@ -428,7 +428,7 @@ func TestTransportCloseEstablishedConnections(t *testing.T) {
 		Dial: func(context.Context, string, *tls.Config, *quic.Config) (*quic.Conn, error) {
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn {
+		newClientConn: func(*quic.Conn, *zeroRTTSettings) clientConn {
 			cl := NewMockClientConn(mockCtrl)
 			cl.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{}, nil)
 			return cl
@@ -499,7 +499,7 @@ func TestTransportCloseIdleConnections(t *testing.T) {
 				return nil, errors.New("unexpected hostname")
 			}
 		},
-		newClientConn: func(*quic.Conn) clientConn {
+		newClientConn: func(*quic.Conn, *zeroRTTSettings) clientConn {
 			cl := NewMockClientConn(mockCtrl)
 			cl.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(r *http.Request) (*http.Response, error) {
 				roundTripCalled <- struct{}{}
@@ -556,7 +556,7 @@ func TestTransportClose(t *testing.T) {
 		Dial: func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn {
+		newClientConn: func(*quic.Conn, *zeroRTTSettings) clientConn {
 			cl := NewMockClientConn(mockCtrl)
 			cl.EXPECT().RoundTrip(gomock.Any()).Return(nil, nil)
 			return cl

--- a/integrationtests/self/http_0rtt_test.go
+++ b/integrationtests/self/http_0rtt_test.go
@@ -1,12 +1,14 @@
 package self_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -82,6 +84,112 @@ func TestHTTP0RTT(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "true", string(data))
 	require.NotZero(t, num0RTTPackets.Load())
+}
+
+// TestHTTP0RTTIncompatibleServerSettings tests the client side of RFC 9114, section 7.2.4.2:
+// if a server accepts 0-RTT, but then sends a SETTINGS frame that is incompatible with the
+// settings the client used for its 0-RTT data, the client closes the connection
+// with H3_SETTINGS_ERROR.
+func TestHTTP0RTTIncompatibleServerSettings(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/0rtt", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, strconv.FormatBool(!r.TLS.HandshakeComplete))
+	})
+
+	// Set up the listener manually, using the exported ConfigureTLSConfig. That way the server
+	// doesn't store its settings in the session ticket, and therefore doesn't reject 0-RTT when
+	// its own settings change - which is exactly the misbehavior the client needs to catch.
+	serverTLSConf := getTLSConfig()
+	startServer := func(t *testing.T, maxHeaderBytes int) int {
+		t.Helper()
+
+		ln, err := quic.ListenEarly(
+			newUDPConnLocalhost(t),
+			http3.ConfigureTLSConfig(serverTLSConf),
+			getQuicConfig(&quic.Config{Allow0RTT: true}),
+		)
+		require.NoError(t, err)
+		server := &http3.Server{Handler: mux, MaxHeaderBytes: maxHeaderBytes}
+		go server.ServeListener(ln)
+		t.Cleanup(func() { server.Close() })
+		return ln.Addr().(*net.UDPAddr).Port
+	}
+
+	puts := make(chan string, 1)
+	clientTLSConf := getTLSClientConfigWithoutServerName()
+	clientTLSConf.ClientSessionCache = newClientSessionCache(tls.NewLRUClientSessionCache(1), nil, puts)
+	// doRequest returns the QUIC connection that the request was sent on,
+	// so that the test can tell how the connection was closed.
+	doRequest := func(port int) (*quic.Conn, string, error) {
+		var mx sync.Mutex
+		var conn *quic.Conn
+		tr := &http3.Transport{
+			TLSClientConfig:    clientTLSConf,
+			QUICConfig:         getQuicConfig(&quic.Config{MaxIdleTimeout: 10 * time.Second}),
+			DisableCompression: true,
+			Dial: func(ctx context.Context, addr string, tlsConf *tls.Config, quicConf *quic.Config) (*quic.Conn, error) {
+				udpAddr, err := net.ResolveUDPAddr("udp", addr)
+				if err != nil {
+					return nil, err
+				}
+				c, err := quic.DialEarly(ctx, newUDPConnLocalhost(t), udpAddr, tlsConf, quicConf)
+				if err != nil {
+					return nil, err
+				}
+				mx.Lock()
+				conn = c
+				mx.Unlock()
+				return c, nil
+			},
+		}
+		t.Cleanup(func() { tr.Close() })
+
+		req, err := http.NewRequest(http3.MethodGet0RTT, fmt.Sprintf("https://localhost:%d/0rtt", port), nil)
+		require.NoError(t, err)
+		rsp, err := tr.RoundTrip(req)
+		mx.Lock()
+		defer mx.Unlock()
+		if err != nil {
+			return conn, "", err
+		}
+		defer rsp.Body.Close()
+		body, err := io.ReadAll(rsp.Body)
+		return conn, string(body), err
+	}
+
+	_, body, err := doRequest(startServer(t, 1024))
+	require.NoError(t, err)
+	require.Equal(t, "false", body)
+	select {
+	case <-puts:
+	case <-time.After(time.Second):
+		t.Fatal("did not receive session ticket")
+	}
+
+	// This server accepts the 0-RTT data, but then announces a smaller maximum field section size.
+	proxy := quicproxy.Proxy{
+		Conn:       newUDPConnLocalhost(t),
+		ServerAddr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: startServer(t, 1023)},
+		DelayPacket: func(quicproxy.Direction, net.Addr, net.Addr, []byte) time.Duration {
+			return scaleDuration(25 * time.Millisecond)
+		},
+	}
+	require.NoError(t, proxy.Start())
+	defer proxy.Close()
+
+	// The SETTINGS frame is processed asynchronously, so the 0-RTT request itself may still
+	// succeed. What matters is that the connection is torn down with H3_SETTINGS_ERROR.
+	conn, _, _ := doRequest(proxy.LocalAddr().(*net.UDPAddr).Port)
+	require.NotNil(t, conn)
+	select {
+	case <-conn.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("connection was not closed")
+	}
+	var appErr *quic.ApplicationError
+	require.ErrorAs(t, context.Cause(conn.Context()), &appErr)
+	require.False(t, appErr.Remote)
+	require.Equal(t, quic.ApplicationErrorCode(http3.ErrCodeSettingsError), appErr.ErrorCode)
 }
 
 func TestHTTP0RTTWithChangedServerSettings(t *testing.T) {


### PR DESCRIPTION
Fixes #5772.

RFC 9114, section 7.2.4.2 says that the initial value of each server setting on a 0-RTT connection is the value used in the previous session. The client now stores the server's SETTINGS alongside the session ticket, by wrapping tls.Config.ClientSessionCache, and restores them when the session is resumed.

If the server accepts 0-RTT but then sends a SETTINGS frame that reduces SETTINGS_MAX_FIELD_SECTION_SIZE, disables datagrams or Extended CONNECT, or omits a setting that was previously sent with a non-default value, the connection is closed with H3_SETTINGS_ERROR.

The session ticket can be received before the server's SETTINGS frame arrives. In that case nothing is stored, which the same section explicitly allows.

This is the client-side counterpart to #5771.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate server `SETTINGS` after 0-RTT in `http3.ClientConn`
> - On resumed connections that used 0-RTT, the client now compares the server's live `SETTINGS` against the baseline stored in the session ticket and closes the QUIC connection with `H3_SETTINGS_ERROR` if they are incompatible.
> - `http3.Transport.dial` wraps any configured `tls.ClientSessionCache` in a `clientSessionCache` that appends HTTP/3 `SETTINGS` to session tickets on `Put` and restores them on `Get`.
> - Tickets that indicate early data but lack a valid stored `SETTINGS` baseline have early data disabled before being returned from `Get`.
> - Compatibility is decided by `http3.settingsCompatibleAfter0RTT`, which treats omitted or reduced understood settings as incompatible.
> - Behavioral Change: connections created via `http3.Transport.NewClientConn` and `http3.Transport.NewRawClientConn` pass `nil` for `zeroRTTSettings`, so externally managed QUIC connections do not perform 0-RTT settings validation or tracking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5cc3e27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HTTP/3 0-RTT session resumption by preserving and restoring server settings.
  * Validates resumed connections against previously accepted settings.

* **Bug Fixes**
  * Prevents unsafe 0-RTT operation when settings are missing, malformed, or incompatible.
  * Closes connections with an HTTP/3 settings error when resumed settings conflict.
  * Falls back cleanly when settings cannot be restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->