### PR TITLE
rotate and retire connection IDs when switching paths

### DIFF
--- a/conn_id_manager.go
+++ b/conn_id_manager.go
@@ -294,6 +294,41 @@ func (h *connIDManager) RetireConnIDForPath(pathID pathID) {
 	delete(h.pathProbing, pathID)
 }
 
+// SwitchToPathConnID makes the connection ID allocated for the given path the active connection ID,
+// and retires the previously active connection ID.
+// It is called when the connection switches to that path.
+func (h *connIDManager) SwitchToPathConnID(id pathID) {
+	h.assertNotClosed()
+	// if we're using zero-length connection IDs, we don't need to change the connection ID
+	if h.activeConnectionID.Len() == 0 {
+		return
+	}
+
+	entry, ok := h.pathProbing[id]
+	if !ok {
+		// The connection ID allocated for this path was retired by the peer.
+		// Switch to a new connection ID, if one is available.
+		if len(h.queue) > 0 {
+			h.updateConnectionID()
+		}
+		return
+	}
+	h.queueControlFrame(&wire.RetireConnectionIDFrame{
+		SequenceNumber: h.activeSequenceNumber,
+	})
+	h.highestRetired = max(h.highestRetired, h.activeSequenceNumber)
+	if h.activeStatelessResetToken != nil {
+		h.removeStatelessResetToken(*h.activeStatelessResetToken)
+	}
+	// The stateless reset token was already added when the connection ID was allocated for the path.
+	h.activeSequenceNumber = entry.SequenceNumber
+	h.activeConnectionID = entry.ConnectionID
+	h.activeStatelessResetToken = &entry.StatelessResetToken
+	h.packetsSinceLastChange = 0
+	h.packetsPerConnectionID = protocol.PacketsPerConnectionID/2 + uint32(h.rand.Int31n(protocol.PacketsPerConnectionID))
+	delete(h.pathProbing, id)
+}
+
 func (h *connIDManager) IsActiveStatelessResetToken(token protocol.StatelessResetToken) bool {
 	if h.activeStatelessResetToken != nil {
 		if *h.activeStatelessResetToken == token {

--- a/conn_id_manager_test.go
+++ b/conn_id_manager_test.go
@@ -333,6 +333,76 @@ func TestConnIDManagerPathMigration(t *testing.T) {
 	}, removedTokens)
 }
 
+func TestConnIDManagerSwitchToPathConnID(t *testing.T) {
+	var frameQueue []wire.Frame
+	var addedTokens, removedTokens []protocol.StatelessResetToken
+	m := newConnIDManager(
+		protocol.ParseConnectionID([]byte{1, 2, 3, 4}),
+		func(token protocol.StatelessResetToken) { addedTokens = append(addedTokens, token) },
+		func(token protocol.StatelessResetToken) { removedTokens = append(removedTokens, token) },
+		func(f wire.Frame) { frameQueue = append(frameQueue, f) },
+	)
+
+	require.NoError(t, m.Add(&wire.NewConnectionIDFrame{
+		SequenceNumber:      1,
+		ConnectionID:        protocol.ParseConnectionID([]byte{4, 3, 2, 1}),
+		StatelessResetToken: protocol.StatelessResetToken{4, 3, 2, 1, 4, 3, 2, 1},
+	}))
+	connID, ok := m.GetConnIDForPath(1)
+	require.True(t, ok)
+	require.Equal(t, protocol.ParseConnectionID([]byte{4, 3, 2, 1}), connID)
+	require.Equal(t, []protocol.StatelessResetToken{{4, 3, 2, 1, 4, 3, 2, 1}}, addedTokens)
+	addedTokens = addedTokens[:0]
+
+	// Switching to the path makes its connection ID the active one,
+	// and retires the previously active connection ID.
+	m.SwitchToPathConnID(1)
+	require.Equal(t, []wire.Frame{&wire.RetireConnectionIDFrame{SequenceNumber: 0}}, frameQueue)
+	frameQueue = nil
+	require.Equal(t, protocol.ParseConnectionID([]byte{4, 3, 2, 1}), m.Get())
+	// The stateless reset token was already added when the connection ID was allocated for the path.
+	require.Empty(t, addedTokens)
+	require.Empty(t, removedTokens)
+	require.True(t, m.IsActiveStatelessResetToken(protocol.StatelessResetToken{4, 3, 2, 1, 4, 3, 2, 1}))
+
+	// The connection ID is no longer allocated to the path.
+	_, ok = m.GetConnIDForPath(1)
+	require.False(t, ok)
+
+	// Probe another path using a new connection ID...
+	require.NoError(t, m.Add(&wire.NewConnectionIDFrame{
+		SequenceNumber:      2,
+		ConnectionID:        protocol.ParseConnectionID([]byte{5, 4, 3, 2}),
+		StatelessResetToken: protocol.StatelessResetToken{5, 4, 3, 2, 5, 4, 3, 2},
+	}))
+	connID, ok = m.GetConnIDForPath(2)
+	require.True(t, ok)
+	require.Equal(t, protocol.ParseConnectionID([]byte{5, 4, 3, 2}), connID)
+	addedTokens = addedTokens[:0]
+
+	// ... and switch to it: the previously active connection ID (seq. 1) is retired.
+	m.SwitchToPathConnID(2)
+	require.Equal(t, []wire.Frame{&wire.RetireConnectionIDFrame{SequenceNumber: 1}}, frameQueue)
+	require.Equal(t, []protocol.StatelessResetToken{{4, 3, 2, 1, 4, 3, 2, 1}}, removedTokens)
+	frameQueue = nil
+	removedTokens = removedTokens[:0]
+	require.Equal(t, protocol.ParseConnectionID([]byte{5, 4, 3, 2}), m.Get())
+
+	// Switching to a path that doesn't have a connection ID allocated
+	// (e.g. because the peer retired it) rotates to a fresh connection ID from the queue.
+	require.NoError(t, m.Add(&wire.NewConnectionIDFrame{
+		SequenceNumber:      3,
+		ConnectionID:        protocol.ParseConnectionID([]byte{6, 5, 4, 3}),
+		StatelessResetToken: protocol.StatelessResetToken{6, 5, 4, 3, 6, 5, 4, 3},
+	}))
+	addedTokens = addedTokens[:0]
+	m.SwitchToPathConnID(3)
+	require.Equal(t, []wire.Frame{&wire.RetireConnectionIDFrame{SequenceNumber: 2}}, frameQueue)
+	require.Equal(t, []protocol.StatelessResetToken{{5, 4, 3, 2, 5, 4, 3, 2}}, removedTokens)
+	require.Equal(t, []protocol.StatelessResetToken{{6, 5, 4, 3, 6, 5, 4, 3}}, addedTokens)
+	require.Equal(t, protocol.ParseConnectionID([]byte{6, 5, 4, 3}), m.Get())
+}
+
 func TestConnIDManagerZeroLengthConnectionID(t *testing.T) {
 	m := newConnIDManager(
 		protocol.ConnectionID{},

--- a/connection.go
+++ b/connection.go
@@ -704,9 +704,9 @@ runLoop:
 		if c.perspective == protocol.PerspectiveClient {
 			pm := c.pathManagerOutgoing.Load()
 			if pm != nil {
-				tr, ok := pm.ShouldSwitchPath()
+				tr, id, ok := pm.ShouldSwitchPath()
 				if ok {
-					c.switchToNewPath(tr, now)
+					c.switchToNewPath(tr, id, now)
 				}
 			}
 		}
@@ -910,7 +910,10 @@ func (c *Conn) idleTimeoutStartTime() monotime.Time {
 	return startTime
 }
 
-func (c *Conn) switchToNewPath(tr *Transport, now monotime.Time) {
+func (c *Conn) switchToNewPath(tr *Transport, id pathID, now monotime.Time) {
+	// Start using the connection ID that was used for probing this path,
+	// and retire the connection ID used on the old path.
+	c.connIDManager.SwitchToPathConnID(id)
 	initialPacketSize := protocol.ByteCount(c.config.InitialPacketSize)
 	c.sentPacketHandler.MigratedPath(now, initialPacketSize)
 	maxPacketSize := protocol.ByteCount(protocol.MaxPacketBufferSize)
@@ -1291,7 +1294,11 @@ func (c *Conn) handleShortHeaderPacket(
 	if !shouldSwitchPath || pn != c.largestRcvdAppData {
 		return true, nil
 	}
-	c.pathManager.SwitchToPath(p.remoteAddr)
+	if id := c.pathManager.SwitchToPath(p.remoteAddr); id != invalidPathID {
+		// Start using the connection ID that was used for probing this path,
+		// and retire the connection ID used on the old path.
+		c.connIDManager.SwitchToPathConnID(id)
+	}
 	c.sentPacketHandler.MigratedPath(p.rcvTime, protocol.ByteCount(c.config.InitialPacketSize))
 	maxPacketSize := protocol.ByteCount(protocol.MaxPacketBufferSize)
 	if c.peerParams.MaxUDPPayloadSize > 0 && c.peerParams.MaxUDPPayloadSize < maxPacketSize {

--- a/integrationtests/self/connection_migration_test.go
+++ b/integrationtests/self/connection_migration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -141,4 +142,94 @@ func TestConnectionMigration(t *testing.T) {
 	// some path probing might have happened
 	require.Less(t, int(packetsPath2.Load()-c2BeforeSwitch), 20)
 	require.Equal(t, tr1.Conn.LocalAddr(), conn.LocalAddr())
+}
+
+func TestConnectionMigrationRepeated(t *testing.T) {
+	const connIDLen = 8
+	const numMigrations = 6 // needs to be larger than the connection ID limit (2 with a limit of 4)
+
+	serverTr := &quic.Transport{Conn: newUDPConnLocalhost(t), ConnectionIDLength: connIDLen}
+	defer serverTr.Close()
+	ln, err := serverTr.Listen(getTLSConfig(), getQuicConfig(nil))
+	require.NoError(t, err)
+	defer ln.Close()
+
+	// Record the DCIDs of short header packets sent by the client.
+	// Since the client switches to the connection ID used for probing when it switches paths,
+	// we expect to see a new connection ID after every migration.
+	var mx sync.Mutex
+	dcids := make(map[string]struct{})
+
+	const rtt = 5 * time.Millisecond
+	proxy := quicproxy.Proxy{
+		Conn:       newUDPConnLocalhost(t),
+		ServerAddr: ln.Addr().(*net.UDPAddr),
+		DelayPacket: func(dir quicproxy.Direction, _, _ net.Addr, b []byte) time.Duration {
+			if dir == quicproxy.DirectionIncoming && len(b) > connIDLen && b[0]&0x80 == 0 {
+				mx.Lock()
+				dcids[string(b[1:1+connIDLen])] = struct{}{}
+				mx.Unlock()
+			}
+			return rtt / 2
+		},
+	}
+	require.NoError(t, proxy.Start())
+	defer proxy.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	tr := &quic.Transport{Conn: newUDPConnLocalhost(t)}
+	defer tr.Close()
+	conn, err := tr.Dial(ctx, proxy.LocalAddr(), getTLSClientConfig(), getQuicConfig(nil))
+	require.NoError(t, err)
+	defer conn.CloseWithError(0, "")
+
+	sconn, err := ln.Accept(ctx)
+	require.NoError(t, err)
+	defer sconn.CloseWithError(0, "")
+
+	sendAndReceive := func(t *testing.T) {
+		t.Helper()
+		str, err := conn.OpenUniStream()
+		require.NoError(t, err)
+		_, err = str.Write(PRDataLong[:2048])
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+
+		sstr, err := sconn.AcceptUniStream(ctx)
+		require.NoError(t, err)
+		data, err := io.ReadAll(sstr)
+		require.NoError(t, err)
+		require.Equal(t, PRDataLong[:2048], data)
+	}
+
+	sendAndReceive(t)
+
+	// Repeatedly migrate the connection to a new path.
+	// This used to fail after 2 migrations, since connection IDs were never retired:
+	// the pool of available connection IDs (4, in this implementation) was exhausted,
+	// and path probing stalled without sending any packets.
+	for i := range numMigrations {
+		newTr := &quic.Transport{Conn: newUDPConnLocalhost(t)}
+		defer newTr.Close()
+		path, err := conn.AddPath(newTr)
+		require.NoError(t, err)
+
+		probeCtx, probeCancel := context.WithTimeout(ctx, 5*time.Second)
+		require.NoErrorf(t, path.Probe(probeCtx), "probing failed on migration %d", i+1)
+		probeCancel()
+		require.NoError(t, path.Switch())
+
+		sendAndReceive(t)
+		require.Equal(t, newTr.Conn.LocalAddr(), conn.LocalAddr())
+		time.Sleep(3 * rtt) // wait for ACKs, and for the server to issue new connection IDs
+	}
+
+	// The client uses a new connection ID on every path:
+	// the handshake connection ID, and one per migration.
+	// Additional rotations (e.g. right after handshake completion) might have happened as well.
+	mx.Lock()
+	defer mx.Unlock()
+	require.GreaterOrEqual(t, len(dcids), numMigrations+1)
 }

--- a/integrationtests/self/connection_migration_test.go
+++ b/integrationtests/self/connection_migration_test.go
@@ -154,20 +154,27 @@ func TestConnectionMigrationRepeated(t *testing.T) {
 	require.NoError(t, err)
 	defer ln.Close()
 
-	// Record the DCIDs of short header packets sent by the client.
-	// Since the client switches to the connection ID used for probing when it switches paths,
-	// we expect to see a new connection ID after every migration.
+	// Record the DCIDs of short header packets sent by the client, and the source address
+	// each DCID is used from. Since the client switches to the connection ID used for probing
+	// when it switches paths, we expect to see a new connection ID after every migration,
+	// and no connection ID to ever be used from more than one source address (RFC 9000, section 9.5).
 	var mx sync.Mutex
 	dcids := make(map[string]struct{})
+	addrsByDCID := make(map[string]map[string]struct{})
 
 	const rtt = 5 * time.Millisecond
 	proxy := quicproxy.Proxy{
 		Conn:       newUDPConnLocalhost(t),
 		ServerAddr: ln.Addr().(*net.UDPAddr),
-		DelayPacket: func(dir quicproxy.Direction, _, _ net.Addr, b []byte) time.Duration {
+		DelayPacket: func(dir quicproxy.Direction, from, _ net.Addr, b []byte) time.Duration {
 			if dir == quicproxy.DirectionIncoming && len(b) > connIDLen && b[0]&0x80 == 0 {
+				dcid := string(b[1 : 1+connIDLen])
 				mx.Lock()
-				dcids[string(b[1:1+connIDLen])] = struct{}{}
+				dcids[dcid] = struct{}{}
+				if addrsByDCID[dcid] == nil {
+					addrsByDCID[dcid] = make(map[string]struct{})
+				}
+				addrsByDCID[dcid][from.String()] = struct{}{}
 				mx.Unlock()
 			}
 			return rtt / 2
@@ -232,4 +239,10 @@ func TestConnectionMigrationRepeated(t *testing.T) {
 	mx.Lock()
 	defer mx.Unlock()
 	require.GreaterOrEqual(t, len(dcids), numMigrations+1)
+	// No connection ID is ever used from more than one source address.
+	// In particular, traffic sent after a path switch doesn't continue to use the
+	// connection ID that was active on the previous path.
+	for dcid, addrs := range addrsByDCID {
+		require.Lenf(t, addrs, 1, "connection ID %x used from multiple source addresses: %v", dcid, addrs)
+	}
 }

--- a/path_manager.go
+++ b/path_manager.go
@@ -158,18 +158,23 @@ func (pm *pathManager) HandlePathResponseFrame(f *wire.PathResponseFrame) {
 	}
 }
 
-// SwitchToPath is called when the connection switches to a new path
-func (pm *pathManager) SwitchToPath(addr net.Addr) {
+// SwitchToPath is called when the connection switches to a new path.
+// It returns the ID of the path switched to,
+// or invalidPathID if no path for this address is being tracked.
+func (pm *pathManager) SwitchToPath(addr net.Addr) pathID {
+	id := invalidPathID
 	// retire all other paths
 	for _, path := range pm.paths {
 		if addrsEqual(path.addr, addr) {
 			pm.logger.Debugf("switching to path %d (%s)", path.id, addr)
+			id = path.id
 			continue
 		}
 		pm.retireConnID(path.id)
 	}
 	clear(pm.paths)
 	pm.paths = pm.paths[:0]
+	return id
 }
 
 type pathManagerAckHandler pathManager

--- a/path_manager_outgoing.go
+++ b/path_manager_outgoing.go
@@ -104,9 +104,11 @@ func (p *Path) Close() error {
 }
 
 type pathOutgoing struct {
+	id             pathID
 	pathChallenges [][8]byte // length is implicitly limited by exponential backoff
 	tr             *Transport
 	isValidated    bool
+	usesConnID     bool          // set when a connection ID is allocated for this path
 	probeSent      chan struct{} // receives when a PATH_CHALLENGE is sent
 	validated      chan struct{} // closed when the path the corresponding PATH_RESPONSE is received
 	enablePath     func()
@@ -157,6 +159,7 @@ func (pm *pathManagerOutgoing) addPath(p *Path, enablePath func()) *pathOutgoing
 	}
 
 	path := &pathOutgoing{
+		id:         p.id,
 		tr:         p.tr,
 		probeSent:  make(chan struct{}, 1),
 		validated:  make(chan struct{}),
@@ -192,7 +195,10 @@ func (pm *pathManagerOutgoing) removePathImpl(id pathID) error {
 	if !ok {
 		return nil
 	}
-	if len(p.pathChallenges) > 0 {
+	// Retire the connection ID allocated for this path.
+	// Checking the outstanding PATH_CHALLENGEs is not sufficient: they are cleared
+	// once the path is validated, but the connection ID remains allocated.
+	if p.usesConnID {
 		pm.retireConnID(id)
 	}
 	delete(pm.paths, id)
@@ -255,6 +261,7 @@ func (pm *pathManagerOutgoing) NextPathToProbe() (_ protocol.ConnectionID, _ ack
 	if !ok {
 		return protocol.ConnectionID{}, ackhandler.Frame{}, nil, false
 	}
+	p.usesConnID = true
 
 	var b [8]byte
 	_, _ = rand.Read(b[:])
@@ -291,16 +298,16 @@ func (pm *pathManagerOutgoing) HandlePathResponseFrame(f *wire.PathResponseFrame
 	}
 }
 
-func (pm *pathManagerOutgoing) ShouldSwitchPath() (*Transport, bool) {
+func (pm *pathManagerOutgoing) ShouldSwitchPath() (*Transport, pathID, bool) {
 	pm.mx.Lock()
 	defer pm.mx.Unlock()
 
 	if pm.pathToSwitchTo == nil {
-		return nil, false
+		return nil, invalidPathID, false
 	}
 	p := pm.pathToSwitchTo
 	pm.pathToSwitchTo = nil
-	return p.tr, true
+	return p.tr, p.id, true
 }
 
 type pathManagerOutgoingAckHandler pathManagerOutgoing

--- a/path_manager_outgoing_test.go
+++ b/path_manager_outgoing_test.go
@@ -68,7 +68,7 @@ func TestPathManagerOutgoingPathProbing(t *testing.T) {
 		}
 
 		require.ErrorIs(t, p.Switch(), ErrPathNotValidated)
-		_, ok = pm.ShouldSwitchPath()
+		_, _, ok = pm.ShouldSwitchPath()
 		require.False(t, ok)
 
 		// ... neither does receiving a random PATH_RESPONSE...
@@ -97,14 +97,58 @@ func TestPathManagerOutgoingPathProbing(t *testing.T) {
 		pm.HandlePathResponseFrame(&wire.PathResponseFrame{Data: pc.Data})
 
 		// now switch to the other path
-		_, ok = pm.ShouldSwitchPath()
+		_, _, ok = pm.ShouldSwitchPath()
 		require.False(t, ok)
 		require.NoError(t, p.Switch())
 		// the active path can't be closed
 		require.EqualError(t, p.Close(), "cannot close active path")
-		switchToTransport, ok := pm.ShouldSwitchPath()
+		switchToTransport, switchToPathID, ok := pm.ShouldSwitchPath()
 		require.True(t, ok)
 		require.Equal(t, tr1, switchToTransport)
+		require.Equal(t, p.id, switchToPathID)
+	})
+}
+
+func TestPathManagerOutgoingCloseValidatedPath(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		connIDs := []protocol.ConnectionID{
+			protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+		}
+		var retiredPaths []pathID
+		pm := newPathManagerOutgoing(
+			func(id pathID) (protocol.ConnectionID, bool) {
+				connID := connIDs[0]
+				connIDs = connIDs[1:]
+				return connID, true
+			},
+			func(id pathID) { retiredPaths = append(retiredPaths, id) },
+			func() {},
+		)
+
+		p := pm.NewPath(&Transport{}, time.Second, func() {})
+		errChan := make(chan error, 1)
+		go func() { errChan <- p.Probe(context.Background()) }()
+
+		// wait for the path to be queued for probing
+		synctest.Wait()
+
+		_, f, _, ok := pm.NextPathToProbe()
+		require.True(t, ok)
+		pm.HandlePathResponseFrame(&wire.PathResponseFrame{Data: f.Frame.(*wire.PathChallengeFrame).Data})
+
+		synctest.Wait()
+
+		select {
+		case err := <-errChan:
+			require.NoError(t, err)
+		default:
+			t.Fatal("expected path validation to have completed")
+		}
+
+		// Closing a validated (but not switched-to) path retires its connection ID,
+		// even though there are no outstanding PATH_CHALLENGEs anymore.
+		require.NoError(t, p.Close())
+		require.Equal(t, []pathID{p.id}, retiredPaths)
 	})
 }
 

--- a/path_manager_test.go
+++ b/path_manager_test.go
@@ -113,7 +113,9 @@ func TestPathManagerIntentionalMigration(t *testing.T) {
 	require.True(t, shouldSwitch)
 
 	// now switch to the new path
-	pm.SwitchToPath(&net.UDPAddr{IP: net.IPv4(5, 6, 7, 8), Port: 1000})
+	require.Equal(t, pathID(1), pm.SwitchToPath(&net.UDPAddr{IP: net.IPv4(5, 6, 7, 8), Port: 1000}))
+	// switching to an untracked path is a no-op
+	require.Equal(t, invalidPathID, pm.SwitchToPath(&net.UDPAddr{IP: net.IPv4(9, 9, 9, 9), Port: 1000}))
 
 	// switching to the path removes other paths
 	connID, frames, shouldSwitch = pm.HandlePacket(&net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1000}, now, nil, false)


### PR DESCRIPTION
The Path API never retires or rotates connection IDs, in three places:

1. When the client switches to a new path, it keeps sending with the DCID it used on the old path (the linkability issue reported in #5236), and the CID used for probing the path stays allocated forever.
2. `Path.Close` on a validated path doesn't retire the path's CID, because `pathChallenges` is cleared when the PATH_RESPONSE is received.
3. On the server, `pathManager.SwitchToPath` retires the CIDs of all paths except the one switched to, whose CID is neither promoted nor retired. The server also keeps its old DCID on the new path, and leaks one client-issued CID per migration.

Both endpoints therefore run out of CIDs after 2 migrations (pool of 4). The client's next probe stalls without sending a packet, and the server stops answering PATH_CHALLENGEs entirely, since it drops the PATH_RESPONSE when no CID is available for the path. RFC 9000 sec. 9.5 requires a fresh CID in both directions on a new path, and describes this exact failure mode for endpoints that exhaust CIDs.

Fix: `connIDManager.SwitchToPathConnID` promotes the path's probing CID to active and retires the previously active one, called on both the client and server switch paths. `removePathImpl` now tracks CID allocation explicitly instead of inferring it from outstanding challenges.

The new `TestConnectionMigrationRepeated` performs 6 consecutive migrations and asserts the DCID rotates on each; it fails on master at the third migration.

qlogs from both endpoints of a minimal repro, on master and on this branch, with the repro program included: [quic-go-migration-qlogs.zip](https://github.com/user-attachments/files/31485100/quic-go-migration-qlogs.zip). On master the client sends exactly one RETIRE_CONNECTION_ID over the whole connection (the post-handshake rotation) and the PATH_CHALLENGE for migration 3 is never sent. On this branch a RETIRE_CONNECTION_ID goes out on every switch and the DCID of sent 1-RTT packets changes on every migration (7 distinct DCIDs vs 3).

Fixes #5236.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rotate and retire connection IDs on path switch in `connIDManager`
> - Adds `connIDManager.SwitchToPathConnID` which activates the connection ID allocated for the target path, queues a `RetireConnectionIDFrame` for the previously active ID, and falls back to a queued connection ID when the path has none
> - Integrates this into both client-initiated path switches via `Conn.switchToNewPath` and peer-driven switches via `Conn.handleShortHeaderPacket`, using the pathID now returned by `pathManager.SwitchToPath` and `pathManagerOutgoing.ShouldSwitchPath`"`
> - Fixes `pathManagerOutgoing.removePathImpl` to retire a path's connection ID on removal even when there are no outstanding `PATH_CHALLENGE` frames, tracked via a new `usesConnID` field on `pathOutgoing`
> - Adds integration test `TestConnectionMigrationRepeated` verifying that each migration uses a new connection ID and that connection IDs are not reused across source addresses
> - Behavioral Change: `pathManagerOutgoing.ShouldSwitchPath` and `pathManager.SwitchToPath` now return an additional `pathID` value; callers in [connection.go](https://github.com/quic-go/quic-go/pull/5819/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7) are updated accordingly. Paths that previously leaked their connection ID on removal now retire it, increasing `RetireConnectionIDFrame` traffic on path close.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 75ae0cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved connection migration across multiple network paths.
  * Connection identifiers now switch correctly when changing paths, including repeated migrations.
  * Retired path-specific identifiers are cleaned up and rotated as needed.

* **Bug Fixes**
  * Corrected connection identifier handling when validated paths are closed or unavailable.
  * Preserved migration behavior when a target path cannot be identified.

* **Tests**
  * Added coverage for repeated migrations, identifier rotation, and path cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->