### PR TITLE
return an error for unsupported OOBCapablePacketConns

### DIFF
--- a/client.go
+++ b/client.go
@@ -77,9 +77,8 @@ func DialEarly(ctx context.Context, c net.PacketConn, addr net.Addr, tlsConf *tl
 
 // Dial establishes a new QUIC connection to a server using a [net.PacketConn].
 // If the PacketConn satisfies the [OOBCapablePacketConn] interface (as a [net.UDPConn] does),
-// ECN and packet info support will be enabled. In this case, [OOBCapablePacketConn.ReadMsgUDP]
-// and [OOBCapablePacketConn.WriteMsgUDP] will be used instead of [net.PacketConn.ReadFrom]
-// and [net.PacketConn.WriteTo] to read/write packets.
+// ECN and packet info support will be enabled. In this case, packets will be read in batches,
+// and [OOBCapablePacketConn.WriteMsgUDP] will be used instead of [net.PacketConn.WriteTo].
 // The [tls.Config] must define an application protocol using [tls.Config.NextProtos].
 //
 // This is a convenience function. More advanced use cases should instantiate a [Transport],

--- a/server.go
+++ b/server.go
@@ -214,9 +214,8 @@ func listenUDP(addr string) (*net.UDPConn, error) {
 
 // Listen listens for QUIC connections on a given [net.PacketConn].
 // If the PacketConn satisfies the [OOBCapablePacketConn] interface (as a [net.UDPConn] does),
-// ECN and packet info support will be enabled. In this case, [OOBCapablePacketConn.ReadMsgUDP]
-// and [OOBCapablePacketConn.WriteMsgUDP] will be used instead of [net.PacketConn.ReadFrom]
-// and [net.PacketConn.WriteTo] to read/write packets.
+// ECN and packet info support will be enabled. In this case, packets will be read in batches,
+// and [OOBCapablePacketConn.WriteMsgUDP] will be used instead of [net.PacketConn.WriteTo].
 // A single [net.PacketConn] can only be used for a single call to Listen.
 //
 // The [tls.Config] must not be nil and must contain a certificate configuration.

--- a/sys_conn.go
+++ b/sys_conn.go
@@ -41,8 +41,8 @@ type rawConn interface {
 
 // OOBCapablePacketConn is a connection that allows the reading of ECN bits from the IP header.
 // If the PacketConn passed to the [Transport] satisfies this interface, quic-go will use it.
-// In this case, [OOBCapablePacketConn.ReadMsgUDP] will be used instead of
-// [net.PacketConn.ReadFrom] to read packets.
+// In this case, packets will be read in batches, and [OOBCapablePacketConn.WriteMsgUDP]
+// will be used instead of [net.PacketConn.WriteTo] to write packets.
 type OOBCapablePacketConn interface {
 	net.PacketConn
 	SyscallConn() (syscall.RawConn, error)

--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -110,6 +110,9 @@ func newConn(c OOBCapablePacketConn, supportsDF bool) (*oobConn, error) {
 	if ibc, ok := c.(batchConn); ok {
 		bc = ibc
 	} else {
+		if _, ok := c.(net.Conn); !ok {
+			return nil, errors.New("quic: OOBCapablePacketConn must implement net.Conn or ReadBatch")
+		}
 		bc = ipv4.NewPacketConn(c)
 	}
 

--- a/sys_conn_oob_test.go
+++ b/sys_conn_oob_test.go
@@ -310,6 +310,14 @@ func TestReadsMultipleMessagesInOneBatch(t *testing.T) {
 	require.Equal(t, 2, bc.callCounter)
 }
 
+func TestNewConnWithoutNetConn(t *testing.T) {
+	udpConn := newUDPConnLocalhost(t)
+	conn := struct{ OOBCapablePacketConn }{udpConn}
+
+	_, err := newConn(conn, true)
+	require.EqualError(t, err, "quic: OOBCapablePacketConn must implement net.Conn or ReadBatch")
+}
+
 func TestSysConnSendGSO(t *testing.T) {
 	if !platformSupportsGSO {
 		t.Skip("GSO not supported on this platform")


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Return error in `newConn` for `OOBCapablePacketConn` lacking `net.Conn` or `ReadBatch`
- `newConn` in [sys_conn_oob.go](https://github.com/quic-go/quic-go/pull/5820/files#diff-18d15af7517a1da90325d39231f5dba3c53c9be1a3770e256cddddb4d90a670f) now checks that an `OOBCapablePacketConn` also implements `batchConn` (ReadBatch) or `net.Conn` before wrapping it with `ipv4.NewPacketConn`; otherwise it returns `"quic: OOBCapablePacketConn must implement net.Conn or ReadBatch"`.
- Updates doc comments in `Dial` (client.go), `Listen` (server.go), and the `OOBCapablePacketConn` interface (sys_conn.go) to reflect that packets are read in batches and `WriteMsgUDP` is used for writing.
- Adds `TestNewConnWithoutNetConn` in [sys_conn_oob_test.go](https://github.com/quic-go/quic-go/pull/5820/files#diff-31654dbde94fce3cf69a66dda467a078f4406975607cb63d68e698a17bf712ee) verifying the new error path.
- Risk: `newConn` now rejects `OOBCapablePacketConn` implementations that previously passed through unconditionally; any custom connection type not also implementing `net.Conn` or `ReadBatch` will fail at dial/listen time.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05bc697.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how packet connections handle batched reads and UDP writes when out-of-band operations are supported.
  - Updated interface documentation to accurately describe supported read and write behavior.

- **Bug Fixes**
  - Added validation and a clear error when an out-of-band packet connection lacks the required connection capabilities.

- **Tests**
  - Added coverage confirming the appropriate error is returned for unsupported packet connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->