### PR TITLE
http3: verify server SETTINGS after 0-RTT

### DIFF
--- a/http3/client.go
+++ b/http3/client.go
@@ -51,7 +51,8 @@ type ClientConn struct {
 	conn    *quic.Conn
 	rawConn *rawConn
 
-	decoder *qpack.Decoder
+	decoder      *qpack.Decoder
+	sessionCache *clientSessionCache
 
 	// Additional HTTP/3 settings.
 	// It is invalid to specify any settings defined by RFC 9114 (HTTP/3) and RFC 9297 (HTTP Datagrams).
@@ -88,6 +89,7 @@ func newClientConn(
 	maxResponseHeaderBytes int,
 	disableCompression bool,
 	logger *slog.Logger,
+	sessionCache *clientSessionCache,
 ) *ClientConn {
 	var qlogger qlogwriter.Recorder
 	if qlogTrace := conn.QlogTrace(); qlogTrace != nil && qlogTrace.SupportsSchemas(qlog.EventSchema) {
@@ -101,6 +103,7 @@ func newClientConn(
 		logger:             logger,
 		qlogger:            qlogger,
 		decoder:            qpack.NewDecoder(),
+		sessionCache:       sessionCache,
 	}
 	c.goAwayCtx, c.goAwayCancel = context.WithCancel(context.Background())
 	if maxResponseHeaderBytes <= 0 {
@@ -198,7 +201,13 @@ func (c *ClientConn) handleUnidirectionalStream(str *quic.ReceiveStream) {
 	c.rawConn.handleUnidirectionalStream(str, false)
 }
 
-func (c *ClientConn) handleControlStream(str *quic.ReceiveStream, fp *frameParser) {
+func (c *ClientConn) handleControlStream(str *quic.ReceiveStream, fp *frameParser, settings *settingsFrame) {
+	if c.sessionCache != nil {
+		if err := c.sessionCache.HandleSettings(settings, c.conn.ConnectionState().Used0RTT); err != nil {
+			c.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeSettingsError), err.Error())
+			return
+		}
+	}
 	for {
 		f, err := fp.ParseNext(c.qlogger)
 		if err != nil {

--- a/http3/client_0rtt.go
+++ b/http3/client_0rtt.go
@@ -87,8 +87,9 @@ func (c *clientSessionCache) HandleSettings(current *settings, used0RTT bool) er
 
 	if used0RTT && c.restored != nil {
 		old := c.restored
-		if old.MaxFieldSectionSize < 0 && current.MaxFieldSectionSize >= 0 ||
-			old.MaxFieldSectionSize > current.MaxFieldSectionSize ||
+		// the default value for SETTINGS_MAX_FIELD_SECTION_SIZE is unlimited
+		if (current.MaxFieldSectionSize >= 0 &&
+			(old.MaxFieldSectionSize < 0 || old.MaxFieldSectionSize > current.MaxFieldSectionSize)) ||
 			old.Datagram && !current.Datagram ||
 			old.ExtendedConnect && !current.ExtendedConnect {
 			return errors.New("server sent incompatible settings after accepting 0-RTT")

--- a/http3/client_0rtt.go
+++ b/http3/client_0rtt.go
@@ -1,0 +1,116 @@
+package http3
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"sync"
+
+	"github.com/quic-go/quic-go/quicvarint"
+)
+
+type clientSessionCache struct {
+	cache tls.ClientSessionCache
+
+	mutex sync.Mutex
+
+	settingsExtra []byte
+	restored      *settings
+}
+
+var _ tls.ClientSessionCache = &clientSessionCache{}
+
+func newClientSessionCache(cache tls.ClientSessionCache) *clientSessionCache {
+	return &clientSessionCache{cache: cache}
+}
+
+func (c *clientSessionCache) Get(key string) (*tls.ClientSessionState, bool) {
+	c.mutex.Lock()
+	c.restored = nil
+	c.mutex.Unlock()
+
+	session, ok := c.cache.Get(key)
+	if !ok || session == nil {
+		return session, ok
+	}
+	ticket, state, err := session.ResumptionState()
+	if err != nil {
+		return nil, false
+	}
+	if !state.EarlyData {
+		return session, true
+	}
+
+	if data, ok := settingsDataFromSessionTicket(state.Extra); ok {
+		if restored, ok := c.restoreSettings(data); ok {
+			c.mutex.Lock()
+			c.restored = restored
+			c.mutex.Unlock()
+			return session, true
+		}
+	}
+	state.EarlyData = false
+	session, err = tls.NewResumptionState(ticket, state)
+	if err != nil {
+		return nil, false
+	}
+	return session, true
+}
+
+func (c *clientSessionCache) Put(key string, session *tls.ClientSessionState) {
+	if session == nil {
+		c.cache.Put(key, nil)
+		return
+	}
+
+	c.mutex.Lock()
+	extra := c.settingsExtra
+	c.mutex.Unlock()
+	if extra == nil {
+		return
+	}
+
+	ticket, state, err := session.ResumptionState()
+	if err != nil {
+		return
+	}
+	state.Extra = append(state.Extra, extra)
+	session, err = tls.NewResumptionState(ticket, state)
+	if err == nil {
+		c.cache.Put(key, session)
+	}
+}
+
+func (c *clientSessionCache) HandleSettings(current *settings, used0RTT bool) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if used0RTT && c.restored != nil {
+		old := c.restored
+		if old.MaxFieldSectionSize < 0 && current.MaxFieldSectionSize >= 0 ||
+			old.MaxFieldSectionSize > current.MaxFieldSectionSize ||
+			old.Datagram && !current.Datagram ||
+			old.ExtendedConnect && !current.ExtendedConnect {
+			return errors.New("server sent incompatible settings after accepting 0-RTT")
+		}
+	}
+	c.settingsExtra = settingsForSessionTicket(current)
+	return nil
+}
+
+func (*clientSessionCache) restoreSettings(data []byte) (*settings, bool) {
+	r := bytes.NewReader(data)
+	frameType, err := quicvarint.Read(r)
+	if err != nil || frameType != 0x4 {
+		return nil, false
+	}
+	length, err := quicvarint.Read(r)
+	if err != nil || uint64(r.Len()) != length {
+		return nil, false
+	}
+	settings, err := parseSettingsFrame(&countingByteReader{Reader: r}, length, 0, nil)
+	if err != nil || len(settings.Other) > 0 {
+		return nil, false
+	}
+	return settings, true
+}

--- a/http3/client_0rtt_test.go
+++ b/http3/client_0rtt_test.go
@@ -30,33 +30,53 @@ func TestClientSessionCacheStoresAndRestoresSettings(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, state.EarlyData)
 	require.NoError(t, restoring.HandleSettings(want, true))
+	// Omitting MAX_FIELD_SECTION_SIZE restores its unlimited default and is compatible.
+	require.NoError(t, restoring.HandleSettings(&settings{MaxFieldSectionSize: -1, Datagram: true, ExtendedConnect: true}, true))
 }
 
 func TestClientSessionCacheRejectsIncompatibleSettings(t *testing.T) {
-	stored := &settings{MaxFieldSectionSize: 100, Datagram: true, ExtendedConnect: true}
 	underlying := tls.NewLRUClientSessionCache(1)
-	session, err := tls.NewResumptionState([]byte("ticket"), &tls.SessionState{
-		EarlyData: true,
-		Extra:     [][]byte{settingsForSessionTicket(stored)},
-	})
-	require.NoError(t, err)
-	underlying.Put("key", session)
 	cache := newClientSessionCache(underlying)
-	_, ok := cache.Get("key")
-	require.True(t, ok)
 
 	const wantErr = "server sent incompatible settings after accepting 0-RTT"
+	limited := &settings{MaxFieldSectionSize: 100, Datagram: true, ExtendedConnect: true}
+	unlimited := &settings{MaxFieldSectionSize: -1, Datagram: true, ExtendedConnect: true}
+
 	for _, tc := range []struct {
-		name     string
-		settings *settings
+		name            string
+		stored, current *settings
 	}{
-		{name: "lower maximum field section size", settings: &settings{MaxFieldSectionSize: 99, Datagram: true, ExtendedConnect: true}},
-		{name: "restore unlimited to limited", settings: &settings{MaxFieldSectionSize: -1, Datagram: true, ExtendedConnect: true}},
-		{name: "disable datagrams", settings: &settings{MaxFieldSectionSize: 100, ExtendedConnect: true}},
-		{name: "disable extended connect", settings: &settings{MaxFieldSectionSize: 100, Datagram: true}},
+		{
+			name:    "lower maximum field section size",
+			stored:  limited,
+			current: &settings{MaxFieldSectionSize: 99, Datagram: true, ExtendedConnect: true},
+		},
+		{
+			name:    "restore unlimited to limited",
+			stored:  unlimited,
+			current: limited,
+		},
+		{
+			name:    "disable datagrams",
+			stored:  limited,
+			current: &settings{MaxFieldSectionSize: 100, ExtendedConnect: true},
+		},
+		{
+			name:    "disable extended connect",
+			stored:  limited,
+			current: &settings{MaxFieldSectionSize: 100, Datagram: true},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.EqualError(t, cache.HandleSettings(tc.settings, true), wantErr)
+			session, err := tls.NewResumptionState([]byte("ticket"), &tls.SessionState{
+				EarlyData: true,
+				Extra:     [][]byte{settingsForSessionTicket(tc.stored)},
+			})
+			require.NoError(t, err)
+			underlying.Put("key", session)
+			_, ok := cache.Get("key")
+			require.True(t, ok)
+			require.EqualError(t, cache.HandleSettings(tc.current, true), wantErr)
 		})
 	}
 }

--- a/http3/client_0rtt_test.go
+++ b/http3/client_0rtt_test.go
@@ -1,0 +1,88 @@
+package http3
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientSessionCacheStoresAndRestoresSettings(t *testing.T) {
+	underlying := tls.NewLRUClientSessionCache(1)
+	cache := newClientSessionCache(underlying)
+	session, err := tls.NewResumptionState([]byte("ticket"), &tls.SessionState{EarlyData: true})
+	require.NoError(t, err)
+
+	cache.Put("key", session)
+	_, ok := underlying.Get("key")
+	require.False(t, ok)
+
+	want := &settings{MaxFieldSectionSize: 100, Datagram: true, ExtendedConnect: true}
+	require.NoError(t, cache.HandleSettings(want, false))
+	_, ok = underlying.Get("key")
+	require.False(t, ok)
+
+	cache.Put("key", session)
+	restoring := newClientSessionCache(underlying)
+	session, ok = restoring.Get("key")
+	require.True(t, ok)
+	_, state, err := session.ResumptionState()
+	require.NoError(t, err)
+	require.True(t, state.EarlyData)
+	require.NoError(t, restoring.HandleSettings(want, true))
+}
+
+func TestClientSessionCacheRejectsIncompatibleSettings(t *testing.T) {
+	stored := &settings{MaxFieldSectionSize: 100, Datagram: true, ExtendedConnect: true}
+	underlying := tls.NewLRUClientSessionCache(1)
+	session, err := tls.NewResumptionState([]byte("ticket"), &tls.SessionState{
+		EarlyData: true,
+		Extra:     [][]byte{settingsForSessionTicket(stored)},
+	})
+	require.NoError(t, err)
+	underlying.Put("key", session)
+	cache := newClientSessionCache(underlying)
+	_, ok := cache.Get("key")
+	require.True(t, ok)
+
+	const wantErr = "server sent incompatible settings after accepting 0-RTT"
+	for _, tc := range []struct {
+		name     string
+		settings *settings
+	}{
+		{name: "lower maximum field section size", settings: &settings{MaxFieldSectionSize: 99, Datagram: true, ExtendedConnect: true}},
+		{name: "restore unlimited to limited", settings: &settings{MaxFieldSectionSize: -1, Datagram: true, ExtendedConnect: true}},
+		{name: "disable datagrams", settings: &settings{MaxFieldSectionSize: 100, ExtendedConnect: true}},
+		{name: "disable extended connect", settings: &settings{MaxFieldSectionSize: 100, Datagram: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.EqualError(t, cache.HandleSettings(tc.settings, true), wantErr)
+		})
+	}
+}
+
+func TestClientSessionCacheDisables0RTTWithoutRestorableSettings(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		extra [][]byte
+	}{
+		{name: "missing"},
+		{name: "malformed", extra: [][]byte{append([]byte(settingsSessionTicketPrefix), 0xff)}},
+		{name: "unknown", extra: [][]byte{settingsForSessionTicket(&settings{Other: map[uint64]uint64{13: 37}})}},
+	} {
+		underlying := tls.NewLRUClientSessionCache(1)
+		session, err := tls.NewResumptionState(
+			[]byte("ticket"),
+			&tls.SessionState{EarlyData: true, Extra: tc.extra},
+		)
+		require.NoError(t, err, tc.name)
+		underlying.Put("key", session)
+
+		cache := newClientSessionCache(underlying)
+		session, ok := cache.Get("key")
+		require.True(t, ok, tc.name)
+		_, state, err := session.ResumptionState()
+		require.NoError(t, err, tc.name)
+		require.False(t, state.EarlyData, tc.name)
+	}
+}

--- a/http3/conn.go
+++ b/http3/conn.go
@@ -38,7 +38,7 @@ type rawConn struct {
 	rcvdControlStr      atomic.Bool
 	rcvdQPACKEncoderStr atomic.Bool
 	rcvdQPACKDecoderStr atomic.Bool
-	controlStrHandler   func(*quic.ReceiveStream, *frameParser) // is called *after* the SETTINGS frame was parsed
+	controlStrHandler   func(*quic.ReceiveStream, *frameParser, *settingsFrame) // is called *after* the SETTINGS frame was parsed
 
 	onStreamsEmpty func()
 
@@ -53,7 +53,7 @@ func newRawConn(
 	quicConn *quic.Conn,
 	enableDatagrams bool,
 	onStreamsEmpty func(),
-	controlStrHandler func(*quic.ReceiveStream, *frameParser),
+	controlStrHandler func(*quic.ReceiveStream, *frameParser, *settingsFrame),
 	qlogger qlogwriter.Recorder,
 	logger *slog.Logger,
 ) *rawConn {
@@ -254,8 +254,7 @@ func (c *rawConn) handleControlStream(str *quic.ReceiveStream) {
 			}
 		})
 	}
-
-	c.controlStrHandler(str, fp)
+	c.controlStrHandler(str, fp, sf)
 }
 
 func (c *rawConn) sendDatagram(streamID quic.StreamID, b []byte) error {

--- a/http3/conn_test.go
+++ b/http3/conn_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func nopControlStrHandler(*quic.ReceiveStream, *frameParser) {}
+func nopControlStrHandler(*quic.ReceiveStream, *frameParser, *settingsFrame) {}
 
 func TestConnReceiveSettings(t *testing.T) {
 	var eventRecorder events.Recorder
@@ -245,7 +245,7 @@ func TestConnControlStreamHandler(t *testing.T) {
 	localConn, peerConn := newConnPair(t)
 
 	handlerCalled := make(chan struct{})
-	conn := newRawConn(localConn, false, nil, func(*quic.ReceiveStream, *frameParser) { close(handlerCalled) }, nil, nil)
+	conn := newRawConn(localConn, false, nil, func(*quic.ReceiveStream, *frameParser, *settingsFrame) { close(handlerCalled) }, nil, nil)
 
 	b := quicvarint.Append(nil, streamTypeControlStream)
 	b = (&settingsFrame{}).Append(b)

--- a/http3/server_conn.go
+++ b/http3/server_conn.go
@@ -266,7 +266,7 @@ func (c *RawServerConn) handleRequestStream(str *stateTrackingStream) {
 	str.Close()
 }
 
-func (c *RawServerConn) handleControlStream(_ *quic.ReceiveStream, fp *frameParser) {
+func (c *RawServerConn) handleControlStream(_ *quic.ReceiveStream, fp *frameParser, _ *settingsFrame) {
 	for {
 		f, err := fp.ParseNext(c.qlogger)
 		if err != nil {

--- a/http3/settings_0rtt.go
+++ b/http3/settings_0rtt.go
@@ -6,16 +6,16 @@ import (
 	"github.com/quic-go/quic-go/quicvarint"
 )
 
-const serverSettingsSessionTicketPrefix = "quic-go h3 settings v1"
+const settingsSessionTicketPrefix = "quic-go h3 settings v1"
 
 type settings = settingsFrame
 
 func settingsForSessionTicket(current *settings) []byte {
-	return current.Append([]byte(serverSettingsSessionTicketPrefix))
+	return current.Append([]byte(settingsSessionTicketPrefix))
 }
 
 func settingsDataFromSessionTicket(extras [][]byte) ([]byte, bool) {
-	prefix := []byte(serverSettingsSessionTicketPrefix)
+	prefix := []byte(settingsSessionTicketPrefix)
 	for _, extra := range extras {
 		if data, ok := bytes.CutPrefix(extra, prefix); ok {
 			return data, true

--- a/http3/settings_0rtt_test.go
+++ b/http3/settings_0rtt_test.go
@@ -30,7 +30,7 @@ func TestSettingsCompatibleFor0RTT(t *testing.T) {
 		{
 			name:    "malformed settings",
 			current: &settings{},
-			extra:   [][]byte{append([]byte(serverSettingsSessionTicketPrefix), 0xff)},
+			extra:   [][]byte{append([]byte(settingsSessionTicketPrefix), 0xff)},
 		},
 		{
 			name:    "max field section size reduced",

--- a/http3/transport.go
+++ b/http3/transport.go
@@ -105,7 +105,7 @@ type Transport struct {
 	initOnce sync.Once
 	initErr  error
 
-	newClientConn func(*quic.Conn) clientConn
+	newClientConn func(*quic.Conn, *clientSessionCache) clientConn
 
 	clients   map[string]*roundTripperWithCount
 	transport *quic.Transport
@@ -128,7 +128,7 @@ var (
 
 func (t *Transport) init() error {
 	if t.newClientConn == nil {
-		t.newClientConn = func(conn *quic.Conn) clientConn {
+		t.newClientConn = func(conn *quic.Conn, sessionCache *clientSessionCache) clientConn {
 			return newClientConn(
 				conn,
 				t.EnableDatagrams,
@@ -136,6 +136,7 @@ func (t *Transport) init() error {
 				t.MaxResponseHeaderBytes,
 				t.DisableCompression,
 				t.Logger,
+				sessionCache,
 			)
 		}
 	}
@@ -359,6 +360,11 @@ func (t *Transport) dial(ctx context.Context, hostname string) (*quic.Conn, clie
 	}
 	// Replace existing ALPNs by H3
 	tlsConf.NextProtos = []string{NextProtoH3}
+	var sessionCache *clientSessionCache
+	if tlsConf.ClientSessionCache != nil {
+		sessionCache = newClientSessionCache(tlsConf.ClientSessionCache)
+		tlsConf.ClientSessionCache = sessionCache
+	}
 
 	dial := t.Dial
 	if dial == nil {
@@ -385,7 +391,7 @@ func (t *Transport) dial(ctx context.Context, hostname string) (*quic.Conn, clie
 	if err != nil {
 		return nil, nil, err
 	}
-	clientConn := t.newClientConn(conn)
+	clientConn := t.newClientConn(conn, sessionCache)
 	go func() {
 		for {
 			str, err := conn.AcceptUniStream(context.Background())
@@ -440,6 +446,7 @@ func (t *Transport) NewClientConn(conn *quic.Conn) *ClientConn {
 		t.MaxResponseHeaderBytes,
 		t.DisableCompression,
 		t.Logger,
+		nil,
 	)
 	go func() {
 		for {
@@ -466,6 +473,7 @@ func (t *Transport) NewRawClientConn(conn *quic.Conn) *RawClientConn {
 			t.MaxResponseHeaderBytes,
 			t.DisableCompression,
 			t.Logger,
+			nil,
 		),
 	}
 }

--- a/http3/transport_test.go
+++ b/http3/transport_test.go
@@ -225,7 +225,7 @@ func TestTransportConnectionReuse(t *testing.T) {
 			dialCount++
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn { return cl },
+		newClientConn: func(*quic.Conn, *clientSessionCache) clientConn { return cl },
 	}
 
 	req1 := httptest.NewRequest(http.MethodGet, "https://quic-go.net/file1.html", nil)
@@ -322,7 +322,7 @@ func testTransportConnectionRedial(t *testing.T, req *http.Request, roundtripErr
 			dialCount++
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn { return cl },
+		newClientConn: func(*quic.Conn, *clientSessionCache) clientConn { return cl },
 	}
 
 	var body string
@@ -358,7 +358,7 @@ func TestTransportRequestContextCancellation(t *testing.T) {
 			dialCount++
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn { return cl },
+		newClientConn: func(*quic.Conn, *clientSessionCache) clientConn { return cl },
 	}
 
 	// the first request succeeds
@@ -405,7 +405,7 @@ func TestTransportConnetionRedialHandshakeError(t *testing.T) {
 			}
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn { return cl },
+		newClientConn: func(*quic.Conn, *clientSessionCache) clientConn { return cl },
 	}
 
 	req1 := httptest.NewRequest(http.MethodGet, "https://quic-go.net/file1.html", nil)
@@ -428,7 +428,7 @@ func TestTransportCloseEstablishedConnections(t *testing.T) {
 		Dial: func(context.Context, string, *tls.Config, *quic.Config) (*quic.Conn, error) {
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn {
+		newClientConn: func(*quic.Conn, *clientSessionCache) clientConn {
 			cl := NewMockClientConn(mockCtrl)
 			cl.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{}, nil)
 			return cl
@@ -499,7 +499,7 @@ func TestTransportCloseIdleConnections(t *testing.T) {
 				return nil, errors.New("unexpected hostname")
 			}
 		},
-		newClientConn: func(*quic.Conn) clientConn {
+		newClientConn: func(*quic.Conn, *clientSessionCache) clientConn {
 			cl := NewMockClientConn(mockCtrl)
 			cl.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(func(r *http.Request) (*http.Response, error) {
 				roundTripCalled <- struct{}{}
@@ -556,7 +556,7 @@ func TestTransportClose(t *testing.T) {
 		Dial: func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
 			return conn, nil
 		},
-		newClientConn: func(*quic.Conn) clientConn {
+		newClientConn: func(*quic.Conn, *clientSessionCache) clientConn {
 			cl := NewMockClientConn(mockCtrl)
 			cl.EXPECT().RoundTrip(gomock.Any()).Return(nil, nil)
 			return cl

--- a/integrationtests/self/http_0rtt_test.go
+++ b/integrationtests/self/http_0rtt_test.go
@@ -1,6 +1,7 @@
 package self_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -155,4 +156,74 @@ func TestHTTP0RTTWithChangedServerSettings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHTTP0RTTRejectsIncompatibleServerSettings(t *testing.T) {
+	const originalMaxHeaderBytes = 1024
+
+	// Establish a session and cache the server's original SETTINGS.
+	serverTLSConf := getTLSConfig()
+	port := startHTTPServer(t, http.NewServeMux(), func(s *http3.Server) {
+		s.TLSConfig = serverTLSConf
+		s.MaxHeaderBytes = originalMaxHeaderBytes
+	})
+
+	puts := make(chan string, 1)
+	clientTLSConf := getTLSClientConfigWithoutServerName()
+	clientTLSConf.ClientSessionCache = newClientSessionCache(tls.NewLRUClientSessionCache(1), nil, puts)
+	client := newHTTP3Client(t, func(tr *http3.Transport) { tr.TLSClientConfig = clientTLSConf })
+	rsp, err := client.Get(fmt.Sprintf("https://localhost:%d/", port))
+	require.NoError(t, err)
+	require.NoError(t, rsp.Body.Close())
+	select {
+	case <-puts:
+	case <-time.After(time.Second):
+		t.Fatal("did not receive session ticket")
+	}
+
+	// Deliberately bypass the HTTP/3 server's 0-RTT SETTINGS compatibility check.
+	ln, err := quic.ListenEarly(
+		newUDPConnLocalhost(t),
+		http3.ConfigureTLSConfig(serverTLSConf),
+		getQuicConfig(&quic.Config{Allow0RTT: true, EnableDatagrams: true}),
+	)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	resultChan := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept(t.Context())
+		if err != nil {
+			resultChan <- err
+			return
+		}
+		defer conn.CloseWithError(0, "")
+		// Send reduced SETTINGS after accepting 0-RTT, simulating a misbehaving HTTP/3 server.
+		if _, err := (&http3.Server{MaxHeaderBytes: originalMaxHeaderBytes - 1}).NewRawServerConn(conn); err != nil {
+			resultChan <- err
+			return
+		}
+		<-conn.Context().Done()
+		resultChan <- context.Cause(conn.Context())
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	client = newHTTP3Client(t, func(tr *http3.Transport) { tr.TLSClientConfig = clientTLSConf })
+	req, err := http.NewRequestWithContext(ctx, http3.MethodGet0RTT, fmt.Sprintf("https://localhost:%d/", ln.Addr().(*net.UDPAddr).Port), nil)
+	require.NoError(t, err)
+	_, err = client.Do(req)
+	require.Error(t, err)
+
+	var serverErr error
+	select {
+	case serverErr = <-resultChan:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for connection close")
+	}
+	require.ErrorIs(t, serverErr, &quic.ApplicationError{
+		Remote:    true,
+		ErrorCode: quic.ApplicationErrorCode(http3.ErrCodeSettingsError),
+	})
+	require.ErrorContains(t, serverErr, "server sent incompatible settings after accepting 0-RTT")
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Verify server `SETTINGS` after 0-RTT in HTTP/3 client
> - Adds `clientSessionCache` in [client_0rtt.go](https://github.com/quic-go/quic-go/pull/5822/files#diff-90c40f820edd09f8a16ba565e53633213fc3cf25c47b02cfaf59fe230b29854d), a wrapper around `tls.ClientSessionCache` that persists HTTP/3 SETTINGS in the TLS session ticket and restores them on resume
> - On 0-RTT resume, the client validates the server's `SETTINGS` frame against the cached values via `HandleSettings`; on mismatch it closes the QUIC connection with `ErrCodeSettingsError`
> - Disables 0-RTT when settings cannot be restored (missing, malformed, or containing unknown values)
> - Plumbs the parsed `*settingsFrame` through `rawConn.handleControlStream` and the `controlStrHandler` callback so the client receives the server settings
> - Risk: `Transport.dial` replaces the user-supplied `tls.Config.ClientSessionCache` with the wrapper; callers that inspect or rely on the original cache object directly will see a different type
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa08498.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP/3 0-RTT session caching to preserve compatible server settings across connections.
  * Automatically disables 0-RTT when cached settings are missing, invalid, or incompatible.
  * Detects incompatible server settings and closes the connection with an appropriate settings error.

* **Tests**
  * Added coverage for session restoration, compatibility validation, invalid session data, and rejection of incompatible server settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->