### PR TITLE
prevent path closure from racing connection shutdown

### DIFF
--- a/conn_id_manager.go
+++ b/conn_id_manager.go
@@ -3,6 +3,7 @@ package quic
 import (
 	"fmt"
 	"slices"
+	"sync"
 
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/qerr"
@@ -20,6 +21,7 @@ type connIDManager struct {
 	queue []newConnID
 
 	highestProbingID uint64
+	pathMx           sync.Mutex
 	pathProbing      map[pathID]newConnID // initialized lazily
 
 	handshakeComplete         bool
@@ -62,6 +64,9 @@ func (h *connIDManager) AddFromPreferredAddress(connID protocol.ConnectionID, re
 }
 
 func (h *connIDManager) Add(f *wire.NewConnectionIDFrame) error {
+	h.pathMx.Lock()
+	defer h.pathMx.Unlock()
+
 	if err := h.add(f); err != nil {
 		return err
 	}
@@ -186,15 +191,17 @@ func (h *connIDManager) updateConnectionID() {
 }
 
 func (h *connIDManager) Close() {
+	h.pathMx.Lock()
+	defer h.pathMx.Unlock()
+
 	h.closed = true
 	if h.activeStatelessResetToken != nil {
 		h.removeStatelessResetToken(*h.activeStatelessResetToken)
 	}
-	if h.pathProbing != nil {
-		for _, entry := range h.pathProbing {
-			h.removeStatelessResetToken(entry.StatelessResetToken)
-		}
+	for _, entry := range h.pathProbing {
+		h.removeStatelessResetToken(entry.StatelessResetToken)
 	}
+	clear(h.pathProbing)
 }
 
 // is called when the server performs a Retry
@@ -252,6 +259,9 @@ func (h *connIDManager) SetHandshakeComplete() {
 // When called with the same pathID, it will return the same connection ID,
 // unless the peer requested that this connection ID be retired.
 func (h *connIDManager) GetConnIDForPath(id pathID) (protocol.ConnectionID, bool) {
+	h.pathMx.Lock()
+	defer h.pathMx.Unlock()
+
 	h.assertNotClosed()
 	// if we're using zero-length connection IDs, we don't need to change the connection ID
 	if h.activeConnectionID.Len() == 0 {
@@ -277,11 +287,8 @@ func (h *connIDManager) GetConnIDForPath(id pathID) (protocol.ConnectionID, bool
 }
 
 func (h *connIDManager) RetireConnIDForPath(pathID pathID) {
-	h.assertNotClosed()
-	// if we're using zero-length connection IDs, we don't need to change the connection ID
-	if h.activeConnectionID.Len() == 0 {
-		return
-	}
+	h.pathMx.Lock()
+	defer h.pathMx.Unlock()
 
 	entry, ok := h.pathProbing[pathID]
 	if !ok {
@@ -295,6 +302,9 @@ func (h *connIDManager) RetireConnIDForPath(pathID pathID) {
 }
 
 func (h *connIDManager) IsActiveStatelessResetToken(token protocol.StatelessResetToken) bool {
+	h.pathMx.Lock()
+	defer h.pathMx.Unlock()
+
 	if h.activeStatelessResetToken != nil {
 		if *h.activeStatelessResetToken == token {
 			return true

--- a/conn_id_manager_test.go
+++ b/conn_id_manager_test.go
@@ -326,11 +326,14 @@ func TestConnIDManagerPathMigration(t *testing.T) {
 	removedTokens = removedTokens[:0]
 	require.False(t, m.IsActiveStatelessResetToken(protocol.StatelessResetToken{16, 15, 14, 13}))
 
+	frameQueue = nil
 	m.Close()
 	require.Equal(t, []protocol.StatelessResetToken{
 		{6, 5, 4, 3, 6, 5, 4, 3}, // currently active connection ID
 		{5, 4, 3, 2, 5, 4, 3, 2}, // path 2
 	}, removedTokens)
+	m.RetireConnIDForPath(2)
+	require.Empty(t, frameQueue)
 }
 
 func TestConnIDManagerZeroLengthConnectionID(t *testing.T) {


### PR DESCRIPTION
Path.Close may retire a connection ID from an application Goroutine while the connection is shutting down. If shutdown wins, RetireConnIDForPath hits assertNotClosed and panics.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard path state in `connIDManager` with `pathMx` mutex to prevent races with `Close`
> - Adds a `pathMx sync.Mutex` to `connIDManager` and wraps `Add`, `Close`, `GetConnIDForPath`, `RetireConnIDForPath`, and `IsActiveStatelessResetToken` with locking to serialize path-state access.
> - `Close` now unconditionally removes all `pathProbing` stateless reset tokens and clears the map, replacing the previous nil-guarded removal.
> - `RetireConnIDForPath` drops the `assertNotClosed()` guard and the early return for zero-length active connection IDs; after `Close` clears `pathProbing`, calling it is a no-op.
> - Behavioral Change: `RetireConnIDForPath` no longer asserts the manager is open; callers that relied on the panic or early return on a closed manager will see different behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 199baa5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection ID management during concurrent operations.
  * Ensured connection paths and reset tokens are properly cleared when connections close.
  * Made retiring connection IDs after shutdown safe and without side effects.
* **Tests**
  * Added coverage confirming no frames are queued when retiring connection IDs after shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->