### PR TITLE
check for unread CRYPTO data when advancing encryption levels

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -981,12 +981,8 @@ func (c *Conn) handleHandshakeConfirmed(now monotime.Time) error {
 	// On the client side, this should have happened when sending the first Handshake packet,
 	// but this is not guaranteed if the server misbehaves.
 	// See CVE-2025-59530 for more details.
-	if err := c.dropEncryptionLevel(protocol.EncryptionInitial, now); err != nil {
-		return err
-	}
-	if err := c.dropEncryptionLevel(protocol.EncryptionHandshake, now); err != nil {
-		return err
-	}
+	c.dropEncryptionLevel(protocol.EncryptionInitial, now)
+	c.dropEncryptionLevel(protocol.EncryptionHandshake, now)
 
 	c.handshakeConfirmed = true
 	c.cryptoStreamHandler.SetHandshakeConfirmed()
@@ -1696,9 +1692,7 @@ func (c *Conn) handleUnpackedLongHeaderPacket(
 		!c.droppedInitialKeys {
 		// On the server side, Initial keys are dropped as soon as the first Handshake packet is received.
 		// See Section 4.9.1 of RFC 9001.
-		if err := c.dropEncryptionLevel(protocol.EncryptionInitial, rcvTime); err != nil {
-			return err
-		}
+		c.dropEncryptionLevel(protocol.EncryptionInitial, rcvTime)
 	}
 
 	c.lastPacketReceivedTime = rcvTime
@@ -2026,12 +2020,21 @@ func (c *Conn) handleHandshakeEvents(now monotime.Time) error {
 		case handshake.EventRestoredTransportParameters:
 			c.restoreTransportParameters(ev.TransportParameters)
 			close(c.earlyConnReadyChan)
-		case handshake.EventReceivedReadKeys:
+		case handshake.EventReceived0RTTReadKeys,
+			handshake.EventReceivedHandshakeReadKeys,
+			handshake.EventReceived1RTTReadKeys:
+			//nolint:exhaustive // only Handshake and 1-RTT require finishing the previous CRYPTO stream
+			switch ev.Kind {
+			case handshake.EventReceivedHandshakeReadKeys:
+				err = c.cryptoStreamManager.Finish(protocol.EncryptionInitial)
+			case handshake.EventReceived1RTTReadKeys:
+				err = c.cryptoStreamManager.Finish(protocol.EncryptionHandshake)
+			}
 			// queue all previously undecryptable packets
 			c.undecryptablePacketsToProcess = append(c.undecryptablePacketsToProcess, c.undecryptablePackets...)
 			c.undecryptablePackets = nil
 		case handshake.EventDiscard0RTTKeys:
-			err = c.dropEncryptionLevel(protocol.Encryption0RTT, now)
+			c.dropEncryptionLevel(protocol.Encryption0RTT, now)
 		case handshake.EventWriteInitialData:
 			_, err = c.initialStream.Write(ev.Data)
 		case handshake.EventWriteHandshakeData:
@@ -2299,7 +2302,7 @@ func (c *Conn) handleCloseError(closeErr *closeError) {
 	c.connIDGenerator.ReplaceWithClosed(connClosePacket, 3*c.rttStats.PTO(false))
 }
 
-func (c *Conn) dropEncryptionLevel(encLevel protocol.EncryptionLevel, now monotime.Time) error {
+func (c *Conn) dropEncryptionLevel(encLevel protocol.EncryptionLevel, now monotime.Time) {
 	c.sentPacketHandler.DropPackets(encLevel, now)
 	c.receivedPacketHandler.DropPackets(encLevel)
 	//nolint:exhaustive // only Initial and 0-RTT need special treatment
@@ -2311,9 +2314,7 @@ func (c *Conn) dropEncryptionLevel(encLevel protocol.EncryptionLevel, now monoti
 		c.streamsMap.ResetFor0RTT()
 		c.framer.Handle0RTTRejection()
 		c.connFlowController.Reset()
-		return nil
 	}
-	return c.cryptoStreamManager.Drop(encLevel)
 }
 
 // is called for the client, when restoring transport parameters saved for 0-RTT
@@ -2811,9 +2812,7 @@ func (c *Conn) sendPackedCoalescedPacket(packet *coalescedPacket, ecn protocol.E
 			!c.droppedInitialKeys {
 			// On the client side, Initial keys are dropped as soon as the first Handshake packet is sent.
 			// See Section 4.9.1 of RFC 9001.
-			if err := c.dropEncryptionLevel(protocol.EncryptionInitial, now); err != nil {
-				return err
-			}
+			c.dropEncryptionLevel(protocol.EncryptionInitial, now)
 		}
 	}
 	if p := packet.shortHdrPacket; p != nil {

--- a/connection_test.go
+++ b/connection_test.go
@@ -1309,6 +1309,31 @@ func TestConnectionHandshakeServer(t *testing.T) {
 	}
 }
 
+func TestConnectionFinishesCryptoStreamWhenReadKeysBecomeAvailable(t *testing.T) {
+	for _, test := range []struct {
+		event    handshake.EventKind
+		previous protocol.EncryptionLevel
+	}{
+		{handshake.EventReceivedHandshakeReadKeys, protocol.EncryptionInitial},
+		{handshake.EventReceived1RTTReadKeys, protocol.EncryptionHandshake},
+	} {
+		t.Run(test.event.String(), func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			cs := mocks.NewMockCryptoSetup(mockCtrl)
+			tc := newServerTestConnection(t, mockCtrl, nil, false, connectionOptCryptoSetup(cs))
+			require.NoError(t, tc.conn.cryptoStreamManager.HandleCryptoFrame(
+				&wire.CryptoFrame{Offset: 1, Data: []byte("foo")},
+				test.previous,
+			))
+
+			cs.EXPECT().NextEvent().Return(handshake.Event{Kind: test.event})
+			err := tc.conn.handleHandshakeEvents(monotime.Now())
+			require.ErrorIs(t, err, &qerr.TransportError{ErrorCode: qerr.ProtocolViolation})
+			require.ErrorContains(t, err, "encryption level changed, but crypto stream has more data to read")
+		})
+	}
+}
+
 func TestConnectionHandshakeClient(t *testing.T) {
 	t.Run("without preferred address", func(t *testing.T) {
 		testConnectionHandshakeClient(t, false)
@@ -1682,7 +1707,7 @@ func TestConnectionPacketBuffering(t *testing.T) {
 		hdr3.PacketNumber = 3
 		hdrs["packet3"] = &hdr3
 		tc.packer.EXPECT().PackCoalescedPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-		cs.EXPECT().NextEvent().Return(handshake.Event{Kind: handshake.EventReceivedReadKeys})
+		cs.EXPECT().NextEvent().Return(handshake.Event{Kind: handshake.EventReceived1RTTReadKeys})
 		cs.EXPECT().NextEvent().Return(handshake.Event{Kind: handshake.EventNoEvent})
 
 		gomock.InOrder(

--- a/crypto_stream_manager.go
+++ b/crypto_stream_manager.go
@@ -60,14 +60,14 @@ func (m *cryptoStreamManager) GetPostHandshakeData(maxSize protocol.ByteCount) *
 	return m.oneRTTStream.PopCryptoFrame(maxSize)
 }
 
-func (m *cryptoStreamManager) Drop(encLevel protocol.EncryptionLevel) error {
-	//nolint:exhaustive // 1-RTT keys should never get dropped.
+func (m *cryptoStreamManager) Finish(encLevel protocol.EncryptionLevel) error {
+	//nolint:exhaustive // The 1-RTT CRYPTO stream is never finished.
 	switch encLevel {
 	case protocol.EncryptionInitial:
 		return m.initialStream.Finish()
 	case protocol.EncryptionHandshake:
 		return m.handshakeStream.Finish()
 	default:
-		panic(fmt.Sprintf("dropped unexpected encryption level: %s", encLevel))
+		panic(fmt.Sprintf("finished unexpected encryption level: %s", encLevel))
 	}
 }

--- a/crypto_stream_manager_test.go
+++ b/crypto_stream_manager_test.go
@@ -48,26 +48,26 @@ func TestCryptoStreamManagerInvalidEncryptionLevel(t *testing.T) {
 	)
 }
 
-func TestCryptoStreamManagerDropEncryptionLevel(t *testing.T) {
+func TestCryptoStreamManagerFinishEncryptionLevel(t *testing.T) {
 	t.Run("Initial", func(t *testing.T) {
-		testCryptoStreamManagerDropEncryptionLevel(t, protocol.EncryptionInitial)
+		testCryptoStreamManagerFinishEncryptionLevel(t, protocol.EncryptionInitial)
 	})
 	t.Run("Handshake", func(t *testing.T) {
-		testCryptoStreamManagerDropEncryptionLevel(t, protocol.EncryptionHandshake)
+		testCryptoStreamManagerFinishEncryptionLevel(t, protocol.EncryptionHandshake)
 	})
 }
 
-func testCryptoStreamManagerDropEncryptionLevel(t *testing.T, encLevel protocol.EncryptionLevel) {
+func testCryptoStreamManagerFinishEncryptionLevel(t *testing.T, encLevel protocol.EncryptionLevel) {
 	initialStream := newInitialCryptoStream(true)
 	handshakeStream := newCryptoStream()
 	oneRTTStream := newCryptoStream()
 	csm := newCryptoStreamManager(initialStream, handshakeStream, oneRTTStream)
 
 	require.NoError(t, csm.HandleCryptoFrame(&wire.CryptoFrame{Data: []byte("foo")}, encLevel))
-	require.ErrorContains(t, csm.Drop(encLevel), "encryption level changed, but crypto stream has more data to read")
+	require.ErrorContains(t, csm.Finish(encLevel), "encryption level changed, but crypto stream has more data to read")
 
 	require.Equal(t, []byte("foo"), csm.GetCryptoData(encLevel))
-	require.NoError(t, csm.Drop(encLevel))
+	require.NoError(t, csm.Finish(encLevel))
 }
 
 func TestCryptoStreamManagerPostHandshake(t *testing.T) {

--- a/internal/handshake/crypto_setup.go
+++ b/internal/handshake/crypto_setup.go
@@ -451,9 +451,11 @@ func (h *cryptoSetup) rejected0RTT() {
 
 func (h *cryptoSetup) setReadKey(el tls.QUICEncryptionLevel, suiteID uint16, trafficSecret []byte) {
 	suite := getCipherSuite(suiteID)
+	var ev EventKind
 	//nolint:exhaustive // The TLS stack doesn't export Initial keys.
 	switch el {
 	case tls.QUICEncryptionLevelEarly:
+		ev = EventReceived0RTTReadKeys
 		if h.perspective == protocol.PerspectiveClient {
 			panic("Received 0-RTT read key for the client")
 		}
@@ -466,6 +468,7 @@ func (h *cryptoSetup) setReadKey(el tls.QUICEncryptionLevel, suiteID uint16, tra
 			h.logger.Debugf("Installed 0-RTT Read keys (using %s)", tls.CipherSuiteName(suite.ID))
 		}
 	case tls.QUICEncryptionLevelHandshake:
+		ev = EventReceivedHandshakeReadKeys
 		h.handshakeOpener = newLongHeaderOpener(
 			createAEAD(suite, trafficSecret, h.version),
 			newHeaderProtector(suite, trafficSecret, true, h.version),
@@ -474,6 +477,7 @@ func (h *cryptoSetup) setReadKey(el tls.QUICEncryptionLevel, suiteID uint16, tra
 			h.logger.Debugf("Installed Handshake Read keys (using %s)", tls.CipherSuiteName(suite.ID))
 		}
 	case tls.QUICEncryptionLevelApplication:
+		ev = EventReceived1RTTReadKeys
 		h.aead.SetReadKey(suite, trafficSecret)
 		h.has1RTTOpener = true
 		if h.logger.Debug() {
@@ -482,7 +486,7 @@ func (h *cryptoSetup) setReadKey(el tls.QUICEncryptionLevel, suiteID uint16, tra
 	default:
 		panic("unexpected read encryption level")
 	}
-	h.events = append(h.events, Event{Kind: EventReceivedReadKeys})
+	h.events = append(h.events, Event{Kind: ev})
 	if h.qlogger != nil {
 		h.qlogger.RecordEvent(qlog.KeyUpdated{
 			Trigger: qlog.KeyUpdateTLS,

--- a/internal/handshake/crypto_setup_test.go
+++ b/internal/handshake/crypto_setup_test.go
@@ -490,23 +490,19 @@ func Test0RTT(t *testing.T) {
 	require.NoError(t, serverErr)
 
 	var tp *wire.TransportParameters
-	var clientReceived0RTTKeys bool
 	for _, ev := range clientEvents {
 		switch ev.Kind {
 		case EventRestoredTransportParameters:
 			tp = ev.TransportParameters
-		case EventReceivedReadKeys:
-			clientReceived0RTTKeys = true
 		}
 	}
-	require.True(t, clientReceived0RTTKeys)
 	require.NotNil(t, tp)
 	require.Equal(t, initialMaxData, tp.InitialMaxData)
 
 	var serverReceived0RTTKeys bool
 	for _, ev := range serverEvents {
 		switch ev.Kind {
-		case EventReceivedReadKeys:
+		case EventReceived0RTTReadKeys:
 			serverReceived0RTTKeys = true
 		}
 	}
@@ -554,16 +550,12 @@ func Test0RTTRejectionOnTransportParametersChanged(t *testing.T) {
 	require.NoError(t, serverErr)
 
 	var tp *wire.TransportParameters
-	var clientReceived0RTTKeys bool
 	for _, ev := range clientEvents {
 		switch ev.Kind {
 		case EventRestoredTransportParameters:
 			tp = ev.TransportParameters
-		case EventReceivedReadKeys:
-			clientReceived0RTTKeys = true
 		}
 	}
-	require.True(t, clientReceived0RTTKeys)
 	require.NotNil(t, tp)
 	require.Equal(t, initialMaxData, tp.InitialMaxData)
 

--- a/internal/handshake/interface.go
+++ b/internal/handshake/interface.go
@@ -69,9 +69,12 @@ const (
 	EventWriteInitialData
 	// EventWriteHandshakeData contains new CRYPTO data to send at the Handshake encryption level
 	EventWriteHandshakeData
-	// EventReceivedReadKeys signals that new decryption keys are available.
-	// It doesn't say which encryption level those keys are for.
-	EventReceivedReadKeys
+	// EventReceived0RTTReadKeys signals that 0-RTT decryption keys are available.
+	EventReceived0RTTReadKeys
+	// EventReceivedHandshakeReadKeys signals that Handshake decryption keys are available.
+	EventReceivedHandshakeReadKeys
+	// EventReceived1RTTReadKeys signals that 1-RTT decryption keys are available.
+	EventReceived1RTTReadKeys
 	// EventDiscard0RTTKeys signals that the Handshake keys were discarded.
 	EventDiscard0RTTKeys
 	// EventReceivedTransportParameters contains the transport parameters sent by the peer.
@@ -91,8 +94,12 @@ func (k EventKind) String() string {
 		return "EventWriteInitialData"
 	case EventWriteHandshakeData:
 		return "EventWriteHandshakeData"
-	case EventReceivedReadKeys:
-		return "EventReceivedReadKeys"
+	case EventReceived0RTTReadKeys:
+		return "EventReceived0RTTReadKeys"
+	case EventReceivedHandshakeReadKeys:
+		return "EventReceivedHandshakeReadKeys"
+	case EventReceived1RTTReadKeys:
+		return "EventReceived1RTTReadKeys"
 	case EventDiscard0RTTKeys:
 		return "EventDiscard0RTTKeys"
 	case EventReceivedTransportParameters:


### PR DESCRIPTION
Previously, we checked for unread CRYPTO data when dropping an encryption level. This was later than necessary, since key discard can happen after TLS has already advanced to the next encryption level.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Check for unread `CRYPTO` data when advancing encryption levels
> - `handleHandshakeEvents` finishes the previous CRYPTO stream when receiving Handshake or 1-RTT read keys, returning a protocol violation if unread `CRYPTO` data remains
> - Replaces the generic `EventReceivedReadKeys` event with specific `EventReceived0RTTReadKeys`, `EventReceivedHandshakeReadKeys`, and `EventReceived1RTTReadKeys` events
> - `Conn.dropEncryptionLevel` no longer returns an error or finishes CRYPTO streams; callers update to ignore its return
> - Risk: Removes `EventReceivedReadKeys` from the `handshake.EventKind` enum in [interface.go](https://github.com/quic-go/quic-go/pull/5824/files#diff-e57d89615a2441c4fe02f9640d13e9c20d11247dbed29fd0124f9e17a08759c9), breaking consumers matching it. Renames `cryptoStreamManager.Drop` to `Finish`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66fa194.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection handling as encryption keys become available during different handshake stages.
  - Detects protocol violations when unread cryptographic data remains during an encryption-level transition.
  - Ensures cryptographic streams are properly finalized during Initial and Handshake stages.

- **Internal Improvements**
  - Handshake processing now identifies the specific encryption stage associated with newly available read keys.
  - Refined cryptographic stream finalization for more reliable connection transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->