### PR TITLE
http3: reject userinfo subcomponent in URIs

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -221,6 +221,9 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 	if err != nil {
 		return nil, err
 	}
+	if strings.Contains(hdr.Authority, "@") && (hdr.Scheme == "http" || hdr.Scheme == "https") {
+		return nil, errors.New("userinfo is not allowed in :authority")
+	}
 	// concatenate cookie headers, see https://tools.ietf.org/html/rfc6265#section-5.4
 	if len(hdr.Headers["Cookie"]) > 0 {
 		hdr.Headers.Set("Cookie", strings.Join(hdr.Headers["Cookie"], "; "))

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -245,6 +245,16 @@ func TestRequestHeadersValidation(t *testing.T) {
 			},
 			errContains: "invalid request URI",
 		},
+		{
+			name: "userinfo in :authority",
+			headers: []qpack.HeaderField{
+				{Name: ":scheme", Value: "https"},
+				{Name: ":path", Value: "/foo"},
+				{Name: ":authority", Value: "user@quic-go.net"},
+				{Name: ":method", Value: http.MethodGet},
+			},
+			err: "userinfo is not allowed in :authority",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := requestFromHeaders(decodeFromSlice(tc.headers), math.MaxInt, nil)


### PR DESCRIPTION
RFC 9114, section 4.3.1:
> The authority MUST NOT include the deprecated userinfo subcomponent for URIs of scheme "http" or "https".

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject userinfo subcomponent in URIs for `http3.requestFromHeaders`
> Adds a validation step in the HTTP/3 request parser that rejects requests when the `:authority` header contains a userinfo component (an `@` character) and `:scheme` is `http` or `https`. The parser now returns the error "userinfo is not allowed in :authority" before further processing. A test case is added in [headers_test.go](https://github.com/quic-go/quic-go/pull/5825/files#diff-f95985faceb231b07d7725e2546e40ee3d8eed3890235bab9980229782211c8a) covering this scenario.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f9fd359. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests using HTTP or HTTPS with user information in the `:authority` header are now rejected.
  * Improved validation prevents malformed authority values from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->