### PR TITLE
http3: normalize request schemes to lowercase

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -98,7 +98,8 @@ func parseHeaders(decodeFn qpack.DecodeFunc, isRequest bool, sizeLimit int, head
 				hdr.Protocol = h.Value
 			case ":scheme":
 				isDuplicatePseudoHeader = hdr.Scheme != ""
-				hdr.Scheme = h.Value
+				// URI schemes are case-insensitive and canonically lowercase, see section 3.1 of RFC 3986
+				hdr.Scheme = strings.ToLower(h.Value)
 			case ":status":
 				isDuplicatePseudoHeader = hdr.Status != ""
 				hdr.Status = h.Value

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -29,41 +29,43 @@ func decodeFromSlice(headers []qpack.HeaderField) qpack.DecodeFunc {
 }
 
 func TestRequestHeaderParsing(t *testing.T) {
-	t.Run("regular path", func(t *testing.T) {
-		testRequestHeaderParsing(t, "/foo")
-	})
-
-	// see https://github.com/quic-go/quic-go/pull/1898
-	t.Run("path starting with //", func(t *testing.T) {
-		testRequestHeaderParsing(t, "//foo")
-	})
-}
-
-func testRequestHeaderParsing(t *testing.T, path string) {
-	headers := []qpack.HeaderField{
-		{Name: ":scheme", Value: "https"},
-		{Name: ":path", Value: path},
-		{Name: ":authority", Value: "quic-go.net:443"},
-		{Name: ":method", Value: http.MethodGet},
-		{Name: "content-length", Value: "42"},
+	for _, tc := range []struct {
+		name   string
+		path   string
+		scheme string
+	}{
+		{name: "regular path", path: "/foo", scheme: "https"},
+		// see https://github.com/quic-go/quic-go/pull/1898
+		{name: "path starting with //", path: "//foo", scheme: "https"},
+		{name: "upper-case scheme", path: "/foo", scheme: "HTTPS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			headers := []qpack.HeaderField{
+				{Name: ":scheme", Value: tc.scheme},
+				{Name: ":path", Value: tc.path},
+				{Name: ":authority", Value: "quic-go.net:443"},
+				{Name: ":method", Value: http.MethodGet},
+				{Name: "content-length", Value: "42"},
+			}
+			req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+			require.NoError(t, err)
+			require.Equal(t, http.MethodGet, req.Method)
+			require.Equal(t, tc.path, req.URL.Path)
+			require.Equal(t, "quic-go.net:443", req.URL.Host)
+			require.Equal(t, "HTTP/3.0", req.Proto)
+			require.Equal(t, 3, req.ProtoMajor)
+			require.Zero(t, req.ProtoMinor)
+			require.Equal(t, int64(42), req.ContentLength)
+			require.Equal(t, 1, len(req.Header))
+			require.Equal(t, "42", req.Header.Get("Content-Length"))
+			require.Nil(t, req.Body)
+			require.Equal(t, "quic-go.net:443", req.Host)
+			require.Equal(t, tc.path, req.RequestURI)
+			require.Equal(t, "quic-go.net", req.URL.Hostname())
+			require.Equal(t, "https", req.URL.Scheme)
+			require.Equal(t, "443", req.URL.Port())
+		})
 	}
-	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
-	require.NoError(t, err)
-	require.Equal(t, http.MethodGet, req.Method)
-	require.Equal(t, path, req.URL.Path)
-	require.Equal(t, "quic-go.net:443", req.URL.Host)
-	require.Equal(t, "HTTP/3.0", req.Proto)
-	require.Equal(t, 3, req.ProtoMajor)
-	require.Zero(t, req.ProtoMinor)
-	require.Equal(t, int64(42), req.ContentLength)
-	require.Equal(t, 1, len(req.Header))
-	require.Equal(t, "42", req.Header.Get("Content-Length"))
-	require.Nil(t, req.Body)
-	require.Equal(t, "quic-go.net:443", req.Host)
-	require.Equal(t, path, req.RequestURI)
-	require.Equal(t, "quic-go.net", req.URL.Hostname())
-	require.Equal(t, "https", req.URL.Scheme)
-	require.Equal(t, "443", req.URL.Port())
 }
 
 func TestRequestHeadersContentLength(t *testing.T) {


### PR DESCRIPTION
URI schemes are case-insensitive and canonically lowercase, see section 3.1 of RFC 3986.

See https://github.com/quic-go/quic-go/pull/5825#discussion_r3887007218.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize request `:scheme` to lowercase in `http3.parseHeaders`
> Lowercases the parsed `Scheme` field from the `:scheme` pseudo-header using `strings.ToLower`, matching RFC 3986's case-insensitivity rule. The returned header always has a lowercase scheme regardless of incoming case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 023c4b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - HTTP/3 request scheme values are now normalized to lowercase during header parsing, ensuring consistent handling of values such as `HTTPS`.

- **Tests**
  - Expanded request header parsing coverage to verify lowercase normalization for uppercase scheme values and existing path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->