### PR TITLE
http3: validate request method syntax

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -221,6 +221,12 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 	if err != nil {
 		return nil, err
 	}
+	if hdr.Method == "" {
+		return nil, errors.New(":method must not be empty")
+	}
+	if !validMethod(hdr.Method) {
+		return nil, fmt.Errorf("invalid :method: %q", hdr.Method)
+	}
 	if strings.Contains(hdr.Authority, "@") && (hdr.Scheme == "http" || hdr.Scheme == "https") {
 		return nil, errors.New("userinfo is not allowed in :authority")
 	}
@@ -243,8 +249,8 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 		if hdr.Path != "" || hdr.Authority == "" { // normal CONNECT
 			return nil, errors.New(":path must be empty and :authority must not be empty")
 		}
-	} else if len(hdr.Path) == 0 || len(hdr.Authority) == 0 || len(hdr.Method) == 0 {
-		return nil, errors.New(":path, :authority and :method must not be empty")
+	} else if len(hdr.Path) == 0 || len(hdr.Authority) == 0 {
+		return nil, errors.New(":path and :authority must not be empty")
 	}
 
 	if !isExtendedConnected && len(hdr.Protocol) > 0 {

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -184,7 +184,7 @@ func TestRequestHeadersValidation(t *testing.T) {
 				{Name: ":authority", Value: "quic-go.net"},
 				{Name: ":method", Value: http.MethodGet},
 			},
-			err: ":path, :authority and :method must not be empty",
+			err: ":path and :authority must not be empty",
 		},
 		{
 			name: "missing :authority",
@@ -192,7 +192,7 @@ func TestRequestHeadersValidation(t *testing.T) {
 				{Name: ":path", Value: "/foo"},
 				{Name: ":method", Value: http.MethodGet},
 			},
-			err: ":path, :authority and :method must not be empty",
+			err: ":path and :authority must not be empty",
 		},
 		{
 			name: "missing :method",
@@ -200,7 +200,18 @@ func TestRequestHeadersValidation(t *testing.T) {
 				{Name: ":path", Value: "/foo"},
 				{Name: ":authority", Value: "quic-go.net"},
 			},
-			err: ":path, :authority and :method must not be empty",
+			err: ":method must not be empty",
+		},
+		{
+			name: "invalid :method",
+			headers: []qpack.HeaderField{
+				{Name: ":scheme", Value: "https"},
+				{Name: ":path", Value: "/foo"},
+				{Name: ":authority", Value: "quic-go.net"},
+				// a method must be a token, and tokens cannot contain spaces
+				{Name: ":method", Value: "GET POST"},
+			},
+			err: `invalid :method: "GET POST"`,
 		},
 		{
 			name: "duplicate :path",


### PR DESCRIPTION
Verify that incoming request methods are valid HTTP tokens. Unknown methods remain valid and are passed to the application.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate request `:method` syntax in `http3.requestFromHeaders`
> - Adds explicit checks in [headers.go](https://github.com/quic-go/quic-go/pull/5827/files#diff-fd2fc9252b467e3ef8b4b4a45eafc66de3fab721b4de75b705da663b3e0f3160) for an empty `:method` and invalid method tokens via `validMethod`.
> - Updates the combined missing-field error to only mention `:path` and `:authority`.
> - Risk: Changes error messages for malformed requests; tests in [headers_test.go](https://github.com/quic-go/quic-go/pull/5827/files#diff-f95985faceb231b07d7725e2546e40ee3d8eed3890235bab9980229782211c8a) are updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 776e1d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/3 request validation for the `:method` header.
  * Requests with missing, empty, or invalid method values are now rejected consistently.
  * Clarified validation handling for missing `:path` or `:authority` headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->