### PR TITLE
http3: support Host when :authority is omitted

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -228,15 +228,29 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 	if !validMethod(hdr.Method) {
 		return nil, fmt.Errorf("invalid :method: %q", hdr.Method)
 	}
+
+	// RFC 9114, Section 4.3.1 allows Host as an alternative to :authority.
+	// If both are present, they must contain the same value.
+	// For simplicity, an empty :authority or Host field is treated as absent.
+	host := hdr.Headers.Get("Host")
+	if hdr.Authority != "" && host != "" && hdr.Authority != host {
+		return nil, errors.New(":authority and Host header field values do not match")
+	}
+	isConnect := hdr.Method == http.MethodConnect
+	// If :authority is missing, use Host as a fallback.
+	// CONNECT requests are excluded since they must provide :authority (RFC 9114, Section 4.4).
+	if !isConnect && hdr.Authority == "" {
+		hdr.Authority = host
+	}
 	if strings.Contains(hdr.Authority, "@") && (hdr.Scheme == "http" || hdr.Scheme == "https") {
 		return nil, errors.New("userinfo is not allowed in :authority")
 	}
+
 	// concatenate cookie headers, see https://tools.ietf.org/html/rfc6265#section-5.4
 	if len(hdr.Headers["Cookie"]) > 0 {
 		hdr.Headers.Set("Cookie", strings.Join(hdr.Headers["Cookie"], "; "))
 	}
 
-	isConnect := hdr.Method == http.MethodConnect
 	// Extended CONNECT, see https://datatracker.ietf.org/doc/html/rfc8441#section-4
 	isExtendedConnected := isConnect && hdr.Protocol != ""
 	if isExtendedConnected {

--- a/http3/headers.go
+++ b/http3/headers.go
@@ -237,9 +237,9 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 		return nil, errors.New(":authority and Host header field values do not match")
 	}
 	isConnect := hdr.Method == http.MethodConnect
-	// If :authority is missing, use Host as a fallback.
+	// If :authority is missing, use Host as a fallback for HTTP(S) requests.
 	// CONNECT requests are excluded since they must provide :authority (RFC 9114, Section 4.4).
-	if !isConnect && hdr.Authority == "" {
+	if !isConnect && hdr.Authority == "" && (hdr.Scheme == "http" || hdr.Scheme == "https") {
 		hdr.Authority = host
 	}
 	if strings.Contains(hdr.Authority, "@") && (hdr.Scheme == "http" || hdr.Scheme == "https") {

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -230,6 +230,16 @@ func TestRequestHeadersValidation(t *testing.T) {
 			err: ":authority and Host header field values do not match",
 		},
 		{
+			name: "Host header field with authority-less scheme",
+			headers: []qpack.HeaderField{
+				{Name: ":scheme", Value: "urn"},
+				{Name: ":path", Value: "/"},
+				{Name: ":method", Value: http.MethodGet},
+				{Name: "host", Value: "example.com"},
+			},
+			err: ":path and :authority must not be empty",
+		},
+		{
 			name: "invalid :method",
 			headers: []qpack.HeaderField{
 				{Name: ":scheme", Value: "https"},

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -68,6 +68,20 @@ func TestRequestHeaderParsing(t *testing.T) {
 	}
 }
 
+// TestRequestHeaderParsingWithHostHeader verifies that Host is used when :authority is omitted.
+func TestRequestHeaderParsingWithHostHeader(t *testing.T) {
+	headers := []qpack.HeaderField{
+		{Name: ":scheme", Value: "https"},
+		{Name: ":path", Value: "/"},
+		{Name: ":method", Value: http.MethodGet},
+		{Name: "host", Value: "quic-go.net"},
+	}
+	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
+	require.NoError(t, err)
+	require.Equal(t, "quic-go.net", req.Host)
+	require.Equal(t, "quic-go.net", req.URL.Host)
+}
+
 func TestRequestHeadersContentLength(t *testing.T) {
 	t.Run("no content length", func(t *testing.T) {
 		headers := []qpack.HeaderField{
@@ -203,6 +217,17 @@ func TestRequestHeadersValidation(t *testing.T) {
 				{Name: ":authority", Value: "quic-go.net"},
 			},
 			err: ":method must not be empty",
+		},
+		{
+			name: "mismatching :authority and Host header field",
+			headers: []qpack.HeaderField{
+				{Name: ":scheme", Value: "https"},
+				{Name: ":path", Value: "/foo"},
+				{Name: ":authority", Value: "quic-go.net"},
+				{Name: ":method", Value: http.MethodGet},
+				{Name: "host", Value: "example.com"},
+			},
+			err: ":authority and Host header field values do not match",
 		},
 		{
 			name: "invalid :method",


### PR DESCRIPTION
Use the Host header field as the request authority when :authority is missing. Reject requests containing conflicting non-empty Host and :authority values.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to `Host` header when `:authority` is omitted in `http3` request parsing
> Updates `requestFromHeaders` in [headers.go](https://github.com/quic-go/quic-go/pull/5828/files#diff-fd2fc9252b467e3ef8b4b4a45eafc66de3fab721b4de75b705da663b3e0f3160) to use the HTTP/1.1 `Host` header as the authority for non-CONNECT `http`/`https` requests when `:authority` is empty, per RFC 9114 Section 4.3.1.
> - If both `:authority` and `Host` are present, non-empty, and differ, the parser now returns an error.
> - Adds table-driven test cases covering the `Host`-only path and the `:authority`/`Host` mismatch error.
> - Risk: requests that previously parsed with an empty `req.Host` (no `:authority`, no `Host`) are unchanged, but requests that sent both headers with different values now fail with a mismatch error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dde8183.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP/3 requests using HTTP or HTTPS now recognize the `Host` header when `:authority` is absent.
  * Requests with conflicting `Host` and `:authority` values are rejected with a validation error.
  * Host information is correctly populated from the `Host` header for applicable requests.
  * Other schemes still require the `:authority` pseudo-header.

* **Tests**
  * Added coverage for `Host` header fallback, mismatched authority validation, and unsupported scheme handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->