### PR TITLE
http3: reject regular CONNECT requests with :scheme

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -247,8 +247,8 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 			return nil, errors.New("extended CONNECT: :scheme, :path and :authority must not be empty")
 		}
 	} else if isConnect {
-		if hdr.Path != "" || hdr.Authority == "" { // normal CONNECT
-			return nil, errors.New(":path must be empty and :authority must not be empty")
+		if hdr.Scheme != "" || hdr.Path != "" || hdr.Authority == "" { // normal CONNECT
+			return nil, errors.New(":scheme and :path must be empty and :authority must not be empty")
 		}
 	} else if len(hdr.Path) == 0 || len(hdr.Authority) == 0 {
 		return nil, errors.New(":path and :authority must not be empty")

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -316,14 +316,14 @@ func TestHeadersConcatenation(t *testing.T) {
 
 func TestRequestHeadersConnect(t *testing.T) {
 	headers := []qpack.HeaderField{
-		{Name: ":authority", Value: "quic-go.net"},
+		{Name: ":authority", Value: "quic-go.net:443"},
 		{Name: ":method", Value: http.MethodConnect},
 	}
 	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, http.MethodConnect, req.Method)
 	require.Equal(t, "HTTP/3.0", req.Proto)
-	require.Equal(t, "quic-go.net", req.RequestURI)
+	require.Equal(t, "quic-go.net:443", req.RequestURI)
 }
 
 func TestRequestHeadersConnectValidation(t *testing.T) {
@@ -337,15 +337,25 @@ func TestRequestHeadersConnectValidation(t *testing.T) {
 			headers: []qpack.HeaderField{
 				{Name: ":method", Value: http.MethodConnect},
 			},
-			err: ":path must be empty and :authority must not be empty",
+			err: ":scheme and :path must be empty and :authority must not be empty",
+		},
+		{
+			name: ":scheme set",
+			headers: []qpack.HeaderField{
+				{Name: ":scheme", Value: "https"},
+				{Name: ":authority", Value: "quic-go.net:443"},
+				{Name: ":method", Value: http.MethodConnect},
+			},
+			err: ":scheme and :path must be empty and :authority must not be empty",
 		},
 		{
 			name: ":path set",
 			headers: []qpack.HeaderField{
 				{Name: ":path", Value: "/foo"},
+				{Name: ":authority", Value: "quic-go.net:443"},
 				{Name: ":method", Value: http.MethodConnect},
 			},
-			err: ":path must be empty and :authority must not be empty",
+			err: ":scheme and :path must be empty and :authority must not be empty",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
RFC 9114 requires regular CONNECT requests to omit `:scheme` and `:path` and include `:authority`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject regular HTTP/3 CONNECT requests with non-empty `:scheme`
> Updates `requestFromHeaders` in [headers.go](https://github.com/quic-go/quic-go/pull/5829/files#diff-fd2fc9252b467e3ef8b4b4a45eafc66de3fab721b4de75b705da663b3e0f3160) to reject normal CONNECT requests when `:scheme` is set, `:path` is set, or `:authority` is empty. The error message now reads `:scheme and :path must be empty and :authority must not be empty`. Tests in [headers_test.go](https://github.com/quic-go/quic-go/pull/5829/files#diff-f95985faceb231b07d7725e2546e40ee3d8eed3890235bab9980229782211c8a) are updated to cover the new `:scheme` rejection and adjusted expected messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37b00ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for HTTP CONNECT requests by rejecting requests with a non-empty scheme.
  * CONNECT requests now correctly preserve the authority, including port information, in the request URI.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->