### PR TITLE
http3: reject duplicate Host header fields

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -230,9 +230,12 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 	}
 
 	// RFC 9114, Section 4.3.1 allows Host as an alternative to :authority.
-	// If both are present, they must contain the same value.
-	// For simplicity, an empty :authority or Host field is treated as absent.
+	hosts := hdr.Headers["Host"]
+	if len(hosts) > 1 {
+		return nil, errors.New("too many Host headers")
+	}
 	host := hdr.Headers.Get("Host")
+	// If both are present, they must contain the same value.
 	if hdr.Authority != "" && host != "" && hdr.Authority != host {
 		return nil, errors.New(":authority and Host header field values do not match")
 	}

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -230,6 +230,17 @@ func TestRequestHeadersValidation(t *testing.T) {
 			err: ":authority and Host header field values do not match",
 		},
 		{
+			name: "duplicate Host header field",
+			headers: []qpack.HeaderField{
+				{Name: ":scheme", Value: "https"},
+				{Name: ":path", Value: "/foo"},
+				{Name: ":method", Value: http.MethodGet},
+				{Name: "host", Value: "quic-go.net"},
+				{Name: "host", Value: "quic-go.net"},
+			},
+			err: "too many Host headers",
+		},
+		{
 			name: "Host header field with authority-less scheme",
 			headers: []qpack.HeaderField{
 				{Name: ":scheme", Value: "urn"},


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Host` header fallback and reject duplicates in `http3.requestFromHeaders`
> - `http3.requestFromHeaders` now honors `Host` as a fallback to `:authority` for non-CONNECT http/https requests when `:authority` is absent
> - Rejects requests with duplicate `Host` headers or mismatched `Host` and `:authority` values
> - CONNECT handling and userinfo validation are unchanged
> - Risk: requests that previously silently ignored `Host` (or sent mismatched `Host`/`:authority`) now fail with an error; check the new validation paths in [headers.go](https://github.com/quic-go/quic-go/pull/5830/files#diff-fd2fc9252b467e3ef8b4b4a45eafc66de3fab721b4de75b705da663b3e0f3160)
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5932cf4. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with multiple `Host` headers are now rejected instead of silently using the first value.
  * Clear validation errors are returned for duplicate `Host` headers.
  * CONNECT requests with a non-empty scheme are now rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->