### PR TITLE
http3: Do not decode content on CONNECT responses

### DIFF
--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -471,6 +471,9 @@ func TestClientGzip(t *testing.T) {
 	t.Run("disable compression", func(t *testing.T) {
 		testClientGzip(t, gzippedFoobar, gzippedFoobar, true, true)
 	})
+	t.Run("CONNECT", func(t *testing.T) {
+		testClientGzip(t, gzippedFoobar, gzippedFoobar, false, true, http.MethodConnect)
+	})
 }
 
 func testClientGzip(t *testing.T,
@@ -478,6 +481,7 @@ func testClientGzip(t *testing.T,
 	expectedRsp []byte,
 	transportDisableCompression bool,
 	responseAddContentEncoding bool,
+	requestMethod ...string,
 ) {
 	var rspBuf bytes.Buffer
 	rstr := NewMockDatagramStream(gomock.NewController(t))
@@ -498,9 +502,15 @@ func testClientGzip(t *testing.T,
 		err error
 	}
 	resultChan := make(chan result)
+	method := http.MethodGet
+	if len(requestMethod) > 0 {
+		method = requestMethod[0]
+	}
 	go func() {
 		cc := (&Transport{DisableCompression: transportDisableCompression}).NewClientConn(clientConn)
-		rsp, err := cc.RoundTrip(httptest.NewRequest(http.MethodGet, "http://quic-go.net", nil))
+		req, err := http.NewRequest(method, "https://quic-go.net", nil)
+		require.NoError(t, err)
+		rsp, err := cc.RoundTrip(req)
 		resultChan <- result{rsp: rsp, err: err}
 	}()
 
@@ -532,6 +542,9 @@ func testClientGzip(t *testing.T,
 	}
 
 	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	if method == http.MethodConnect {
+		require.Equal(t, "gzip", rsp.Header.Get("Content-Encoding"))
+	}
 	body, err := io.ReadAll(rsp.Body)
 	require.NoError(t, err)
 	require.Equal(t, expectedRsp, body)

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -413,7 +413,7 @@ func (s *RequestStream) ReadResponse() (*http.Response, error) {
 	if (isInformational || isNoContent || isSuccessfulConnect) && res.ContentLength == -1 {
 		res.ContentLength = 0
 	}
-	if s.requestedGzip && res.Header.Get("Content-Encoding") == "gzip" {
+	if s.requestedGzip && !s.isConnect && res.Header.Get("Content-Encoding") == "gzip" {
 		res.Header.Del("Content-Encoding")
 		res.Header.Del("Content-Length")
 		res.ContentLength = -1


### PR DESCRIPTION
## Summary

CONNECT responses carry capsules, not content. When a server includes `Content-Encoding: gzip`, the client must not transparently decode the response body because content encoding does not apply to CONNECT or Extended CONNECT.

This keeps the response header and body unchanged for CONNECT requests while preserving automatic gzip decoding for regular responses.

Fixes #4410

## Test Plan

- `go test ./...`
- `go vet ./...`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip transparent gzip decompression for CONNECT responses in `RequestStream.ReadResponse`
> CONNECT responses are no longer transparently decompressed even when gzip was requested. `ReadResponse` now checks `!s.isConnect` before wrapping the body with a gzip reader and stripping `Content-Encoding`/`Content-Length` headers. Tests in [client_test.go](https://github.com/quic-go/quic-go/pull/5832/files#diff-c28b48729e43df2458d6d1dc622f8887f4aa0127ca826820b3fedde81c396355) add a CONNECT subtest to `testClientGzip` confirming the gzipped body is returned unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01cb042.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of gzip-encoded responses to HTTP CONNECT requests.
  * CONNECT responses now preserve the `Content-Encoding: gzip` header and are not automatically decompressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->