### PR TITLE
http3: distinguish empty pseudo-header fields from omitted ones

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -38,7 +38,8 @@ type header struct {
 	Protocol string
 	// parsed and deduplicated. -1 if no Content-Length header is sent
 	ContentLength int64
-	// all non-pseudo headers
+	// all non-pseudo headers.
+	// Some pseudo-header keys with nil values are temporarily added to track presence.
 	Headers http.Header
 }
 
@@ -53,7 +54,7 @@ var invalidHeaderFields = [...]string{
 
 func parseHeaders(decodeFn qpack.DecodeFunc, isRequest bool, sizeLimit int, headerFields *[]qpack.HeaderField) (header, error) {
 	hdr := header{Headers: make(http.Header)}
-	var readFirstRegularHeader, readContentLength bool
+	var readFirstRegularHeader, readContentLength, hasMethod, hasStatus bool
 	var contentLengthStr string
 	for {
 		h, err := decodeFn()
@@ -85,23 +86,29 @@ func parseHeaders(decodeFn qpack.DecodeFunc, isRequest bool, sizeLimit int, head
 			var isDuplicatePseudoHeader bool // pseudo headers are allowed to appear exactly once
 			switch h.Name {
 			case ":path":
-				isDuplicatePseudoHeader = hdr.Path != ""
+				_, isDuplicatePseudoHeader = hdr.Headers[h.Name]
+				hdr.Headers[h.Name] = nil
 				hdr.Path = h.Value
 			case ":method":
-				isDuplicatePseudoHeader = hdr.Method != ""
+				isDuplicatePseudoHeader = hasMethod
+				hasMethod = true
 				hdr.Method = h.Value
 			case ":authority":
-				isDuplicatePseudoHeader = hdr.Authority != ""
+				_, isDuplicatePseudoHeader = hdr.Headers[h.Name]
+				hdr.Headers[h.Name] = nil
 				hdr.Authority = h.Value
 			case ":protocol": // RFC 9220
-				isDuplicatePseudoHeader = hdr.Protocol != ""
+				_, isDuplicatePseudoHeader = hdr.Headers[h.Name]
+				hdr.Headers[h.Name] = nil
 				hdr.Protocol = h.Value
 			case ":scheme":
-				isDuplicatePseudoHeader = hdr.Scheme != ""
+				_, isDuplicatePseudoHeader = hdr.Headers[h.Name]
+				hdr.Headers[h.Name] = nil
 				// URI schemes are case-insensitive and canonically lowercase, see section 3.1 of RFC 3986
 				hdr.Scheme = strings.ToLower(h.Value)
 			case ":status":
-				isDuplicatePseudoHeader = hdr.Status != ""
+				isDuplicatePseudoHeader = hasStatus
+				hasStatus = true
 				hdr.Status = h.Value
 				isResponsePseudoHeader = true
 			default:
@@ -222,6 +229,15 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 	if err != nil {
 		return nil, err
 	}
+	_, hasPath := hdr.Headers[":path"]
+	_, hasAuthority := hdr.Headers[":authority"]
+	_, hasScheme := hdr.Headers[":scheme"]
+	_, hasProtocol := hdr.Headers[":protocol"]
+	delete(hdr.Headers, ":path")
+	delete(hdr.Headers, ":authority")
+	delete(hdr.Headers, ":scheme")
+	delete(hdr.Headers, ":protocol")
+
 	if hdr.Method == "" {
 		return nil, errors.New(":method must not be empty")
 	}
@@ -236,13 +252,13 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 	}
 	host := hdr.Headers.Get("Host")
 	// If both are present, they must contain the same value.
-	if hdr.Authority != "" && host != "" && hdr.Authority != host {
+	if hasAuthority && len(hosts) > 0 && hdr.Authority != host {
 		return nil, errors.New(":authority and Host header field values do not match")
 	}
 	isConnect := hdr.Method == http.MethodConnect
 	// If :authority is missing, use Host as a fallback for HTTP(S) requests.
 	// CONNECT requests are excluded since they must provide :authority (RFC 9114, Section 4.4).
-	if !isConnect && hdr.Authority == "" && (hdr.Scheme == "http" || hdr.Scheme == "https") {
+	if !isConnect && !hasAuthority && (hdr.Scheme == "http" || hdr.Scheme == "https") {
 		hdr.Authority = host
 	}
 	if strings.Contains(hdr.Authority, "@") && (hdr.Scheme == "http" || hdr.Scheme == "https") {
@@ -264,15 +280,15 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 			return nil, errors.New("extended CONNECT: :scheme, :path and :authority must not be empty")
 		}
 	} else if isConnect {
-		if hdr.Scheme != "" || hdr.Path != "" || hdr.Authority == "" { // normal CONNECT
-			return nil, errors.New(":scheme and :path must be empty and :authority must not be empty")
+		if hasScheme || hasPath || hdr.Authority == "" { // normal CONNECT
+			return nil, errors.New(":scheme and :path must be omitted and :authority must not be empty")
 		}
 	} else if len(hdr.Path) == 0 || len(hdr.Authority) == 0 {
 		return nil, errors.New(":path and :authority must not be empty")
 	}
 
-	if !isExtendedConnected && len(hdr.Protocol) > 0 {
-		return nil, errors.New(":protocol must be empty")
+	if !isExtendedConnected && hasProtocol {
+		return nil, errors.New(":protocol must be omitted")
 	}
 
 	var u *url.URL

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -230,6 +230,17 @@ func TestRequestHeadersValidation(t *testing.T) {
 			err: ":authority and Host header field values do not match",
 		},
 		{
+			name: "empty :authority and non-empty Host header field",
+			headers: []qpack.HeaderField{
+				{Name: ":scheme", Value: "https"},
+				{Name: ":path", Value: "/foo"},
+				{Name: ":authority", Value: ""},
+				{Name: ":method", Value: http.MethodGet},
+				{Name: "host", Value: "example.com"},
+			},
+			err: ":authority and Host header field values do not match",
+		},
+		{
 			name: "duplicate Host header field",
 			headers: []qpack.HeaderField{
 				{Name: ":scheme", Value: "https"},
@@ -264,7 +275,7 @@ func TestRequestHeadersValidation(t *testing.T) {
 		{
 			name: "duplicate :path",
 			headers: []qpack.HeaderField{
-				{Name: ":path", Value: "/foo"},
+				{Name: ":path", Value: ""},
 				{Name: ":path", Value: "/foo"},
 			},
 			err: "duplicate pseudo header: :path",
@@ -272,7 +283,7 @@ func TestRequestHeadersValidation(t *testing.T) {
 		{
 			name: "duplicate :authority",
 			headers: []qpack.HeaderField{
-				{Name: ":authority", Value: "quic-go.net"},
+				{Name: ":authority", Value: ""},
 				{Name: ":authority", Value: "quic-go.net"},
 			},
 			err: "duplicate pseudo header: :authority",
@@ -280,11 +291,12 @@ func TestRequestHeadersValidation(t *testing.T) {
 		{
 			name: "duplicate :method",
 			headers: []qpack.HeaderField{
-				{Name: ":method", Value: http.MethodGet},
+				{Name: ":method", Value: ""},
 				{Name: ":method", Value: http.MethodGet},
 			},
 			err: "duplicate pseudo header: :method",
 		},
+		// :protocol is only valid for Extended CONNECT
 		{
 			name: "invalid :protocol",
 			headers: []qpack.HeaderField{
@@ -293,7 +305,17 @@ func TestRequestHeadersValidation(t *testing.T) {
 				{Name: ":method", Value: http.MethodGet},
 				{Name: ":protocol", Value: "connect-udp"},
 			},
-			err: ":protocol must be empty",
+			err: ":protocol must be omitted",
+		},
+		{
+			name: "empty :protocol",
+			headers: []qpack.HeaderField{
+				{Name: ":path", Value: "/foo"},
+				{Name: ":authority", Value: "quic-go.net"},
+				{Name: ":method", Value: http.MethodGet},
+				{Name: ":protocol", Value: ""},
+			},
+			err: ":protocol must be omitted",
 		},
 		{
 			name: "invalid :path",
@@ -373,6 +395,8 @@ func TestRequestHeadersConnect(t *testing.T) {
 }
 
 func TestRequestHeadersConnectValidation(t *testing.T) {
+	// RFC 9114, Section 4.4: a CONNECT request must contain the :authority pseudo-header field,
+	// and must not contain the :scheme and :path pseudo-header fields.
 	for _, tc := range []struct {
 		name    string
 		headers []qpack.HeaderField
@@ -383,7 +407,7 @@ func TestRequestHeadersConnectValidation(t *testing.T) {
 			headers: []qpack.HeaderField{
 				{Name: ":method", Value: http.MethodConnect},
 			},
-			err: ":scheme and :path must be empty and :authority must not be empty",
+			err: ":scheme and :path must be omitted and :authority must not be empty",
 		},
 		{
 			name: ":scheme set",
@@ -392,7 +416,7 @@ func TestRequestHeadersConnectValidation(t *testing.T) {
 				{Name: ":authority", Value: "quic-go.net:443"},
 				{Name: ":method", Value: http.MethodConnect},
 			},
-			err: ":scheme and :path must be empty and :authority must not be empty",
+			err: ":scheme and :path must be omitted and :authority must not be empty",
 		},
 		{
 			name: ":path set",
@@ -401,7 +425,25 @@ func TestRequestHeadersConnectValidation(t *testing.T) {
 				{Name: ":authority", Value: "quic-go.net:443"},
 				{Name: ":method", Value: http.MethodConnect},
 			},
-			err: ":scheme and :path must be empty and :authority must not be empty",
+			err: ":scheme and :path must be omitted and :authority must not be empty",
+		},
+		{
+			name: "empty :path",
+			headers: []qpack.HeaderField{
+				{Name: ":path", Value: ""},
+				{Name: ":authority", Value: "quic-go.net"},
+				{Name: ":method", Value: http.MethodConnect},
+			},
+			err: ":scheme and :path must be omitted and :authority must not be empty",
+		},
+		{
+			name: "empty :scheme",
+			headers: []qpack.HeaderField{
+				{Name: ":scheme", Value: ""},
+				{Name: ":authority", Value: "quic-go.net"},
+				{Name: ":method", Value: http.MethodConnect},
+			},
+			err: ":scheme and :path must be omitted and :authority must not be empty",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -425,6 +467,7 @@ func TestRequestHeadersExtendedConnect(t *testing.T) {
 	require.Equal(t, "webtransport", req.Proto)
 	require.Equal(t, "ftp://quic-go.net/foo?val=1337", req.URL.String())
 	require.Equal(t, "1337", req.URL.Query().Get("val"))
+	require.Empty(t, req.Header)
 }
 
 func TestRequestHeadersExtendedConnectRequestValidation(t *testing.T) {
@@ -499,7 +542,7 @@ func TestResponseHeaderParsingValidation(t *testing.T) {
 		{
 			name: "duplicate :status",
 			headers: []qpack.HeaderField{
-				{Name: ":status", Value: "200"},
+				{Name: ":status", Value: ""},
 				{Name: ":status", Value: "404"},
 			},
 			err: "duplicate pseudo header: :status",
@@ -691,27 +734,28 @@ func TestQpackError(t *testing.T) {
 	})
 }
 
+var benchmarkRequestHeaders = []qpack.HeaderField{
+	{Name: ":path", Value: "/api/v1/users/12345"},
+	{Name: ":authority", Value: "quic-go.net"},
+	{Name: ":method", Value: http.MethodPost},
+	{Name: "content-type", Value: "application/json"},
+	{Name: "content-length", Value: "1024"},
+	{Name: "user-agent", Value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"},
+	{Name: "accept", Value: "application/json, text/plain, */*"},
+	{Name: "accept-encoding", Value: "gzip, deflate, br"},
+	{Name: "accept-language", Value: "en-US,en;q=0.9"},
+	{Name: "cache-control", Value: "no-cache"},
+	{Name: "cookie", Value: "session_id=abc123"},
+	{Name: "cookie", Value: "user_pref=dark_mode"},
+	{Name: "referer", Value: "https://quic-go.net/docs/http3/"},
+}
+
 func BenchmarkRequestFromHeaders(b *testing.B) {
 	b.ReportAllocs()
 
-	headers := []qpack.HeaderField{
-		{Name: ":path", Value: "/api/v1/users/12345"},
-		{Name: ":authority", Value: "quic-go.net"},
-		{Name: ":method", Value: http.MethodPost},
-		{Name: "content-type", Value: "application/json"},
-		{Name: "content-length", Value: "1024"},
-		{Name: "user-agent", Value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"},
-		{Name: "accept", Value: "application/json, text/plain, */*"},
-		{Name: "accept-encoding", Value: "gzip, deflate, br"},
-		{Name: "accept-language", Value: "en-US,en;q=0.9"},
-		{Name: "cache-control", Value: "no-cache"},
-		{Name: "cookie", Value: "session_id=abc123"},
-		{Name: "cookie", Value: "user_pref=dark_mode"},
-		{Name: "referer", Value: "https://quic-go.net/docs/http3/"},
-	}
 	var buf bytes.Buffer
 	enc := qpack.NewEncoder(&buf)
-	for _, hf := range headers {
+	for _, hf := range benchmarkRequestHeaders {
 		require.NoError(b, enc.WriteField(hf))
 	}
 
@@ -719,6 +763,16 @@ func BenchmarkRequestFromHeaders(b *testing.B) {
 	for b.Loop() {
 		decodeFn := dec.Decode(buf.Bytes())
 		if _, err := requestFromHeaders(decodeFn, math.MaxInt, nil); err != nil {
+			b.Fatalf("failed to parse request: %v", err)
+		}
+	}
+}
+
+func BenchmarkRequestFromHeaderFields(b *testing.B) {
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if _, err := requestFromHeaders(decodeFromSlice(benchmarkRequestHeaders), math.MaxInt, nil); err != nil {
 			b.Fatalf("failed to parse request: %v", err)
 		}
 	}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Distinguish empty pseudo-header fields from omitted ones in `http3` header parsing
- `parseHeaders` now tracks pseudo-header presence separately from value: `:method` and `:status` use new boolean flags, while `:path`, `:authority`, `:protocol`, and `:scheme` are temporarily inserted into `hdr.Headers` with a nil value
- `requestFromHeaders` checks key presence rather than non-empty values for validation, then removes the temporary nil entries from the header map
- Duplicate detection now rejects a second occurrence even when the first value is empty
- Risk: CONNECT requests with empty `:scheme` or `:path` now fail with 'must be omitted'; non-extended CONNECT with empty `:protocol` fails; `:authority` vs `Host` mismatch triggers when `:authority` is present (even empty) and `Host` differs — callers relying on empty-valued pseudo-headers being treated as absent will see stricter validation

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized db9673d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/3 header validation for pseudo-headers with empty values.
  * Correctly distinguishes omitted headers from headers that are present but empty.
  * Updated CONNECT and extended CONNECT validation behavior.
  * Improved handling of empty `:authority`, `:path`, `:scheme`, `:protocol`, and `:status` values.
* **Tests**
  * Expanded coverage for empty and omitted pseudo-header scenarios.
  * Added benchmark coverage for request header processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->