### PR TITLE
http3: don't use gzip to decompress successful CONNECT responses

### DIFF
--- a/http3/client_test.go
+++ b/http3/client_test.go
@@ -463,13 +463,20 @@ func TestClientGzip(t *testing.T) {
 	gzippedFoobar := buf.Bytes()
 
 	t.Run("gzipped", func(t *testing.T) {
-		testClientGzip(t, gzippedFoobar, []byte("foobar"), false, true)
+		testClientGzip(t, gzippedFoobar, []byte("foobar"), false, true, http.MethodGet, http.StatusOK)
 	})
 	t.Run("not gzipped", func(t *testing.T) {
-		testClientGzip(t, []byte("foobar"), []byte("foobar"), false, false)
+		testClientGzip(t, []byte("foobar"), []byte("foobar"), false, false, http.MethodGet, http.StatusOK)
 	})
 	t.Run("disable compression", func(t *testing.T) {
-		testClientGzip(t, gzippedFoobar, gzippedFoobar, true, true)
+		testClientGzip(t, gzippedFoobar, gzippedFoobar, true, true, http.MethodGet, http.StatusOK)
+	})
+	t.Run("successful CONNECT", func(t *testing.T) {
+		rsp := testClientGzip(t, gzippedFoobar, gzippedFoobar, false, true, http.MethodConnect, http.StatusOK)
+		require.Equal(t, "gzip", rsp.Header.Get("Content-Encoding"))
+	})
+	t.Run("failed CONNECT", func(t *testing.T) {
+		testClientGzip(t, gzippedFoobar, []byte("foobar"), false, true, http.MethodConnect, http.StatusBadRequest)
 	})
 }
 
@@ -478,13 +485,15 @@ func testClientGzip(t *testing.T,
 	expectedRsp []byte,
 	transportDisableCompression bool,
 	responseAddContentEncoding bool,
-) {
+	method string,
+	status int,
+) *http.Response {
 	var rspBuf bytes.Buffer
 	rstr := NewMockDatagramStream(gomock.NewController(t))
 	rstr.EXPECT().StreamID().Return(quic.StreamID(42)).AnyTimes()
 	rstr.EXPECT().Write(gomock.Any()).Do(rspBuf.Write).AnyTimes()
 	rw := newResponseWriter(newStream(rstr, nil, nil, func(io.Reader, *headersFrame) error { return nil }, nil), nil, false, nil)
-	rw.WriteHeader(http.StatusOK)
+	rw.WriteHeader(status)
 	if responseAddContentEncoding {
 		rw.header.Add("Content-Encoding", "gzip")
 	}
@@ -500,7 +509,7 @@ func testClientGzip(t *testing.T,
 	resultChan := make(chan result)
 	go func() {
 		cc := (&Transport{DisableCompression: transportDisableCompression}).NewClientConn(clientConn)
-		rsp, err := cc.RoundTrip(httptest.NewRequest(http.MethodGet, "http://quic-go.net", nil))
+		rsp, err := cc.RoundTrip(httptest.NewRequest(method, "http://quic-go.net", nil))
 		resultChan <- result{rsp: rsp, err: err}
 	}()
 
@@ -531,10 +540,11 @@ func testClientGzip(t *testing.T,
 		t.Fatal("timeout")
 	}
 
-	require.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.Equal(t, status, rsp.StatusCode)
 	body, err := io.ReadAll(rsp.Body)
 	require.NoError(t, err)
 	require.Equal(t, expectedRsp, body)
+	return rsp
 }
 
 func TestClientRequestCancellation(t *testing.T) {

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -413,7 +413,7 @@ func (s *RequestStream) ReadResponse() (*http.Response, error) {
 	if (isInformational || isNoContent || isSuccessfulConnect) && res.ContentLength == -1 {
 		res.ContentLength = 0
 	}
-	if s.requestedGzip && res.Header.Get("Content-Encoding") == "gzip" {
+	if s.requestedGzip && !isSuccessfulConnect && res.Header.Get("Content-Encoding") == "gzip" {
 		res.Header.Del("Content-Encoding")
 		res.Header.Del("Content-Length")
 		res.ContentLength = -1


### PR DESCRIPTION
Fixes #4410. Closes #5832.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip gzip auto-decompression for successful CONNECT responses in `RequestStream.ReadResponse`
> - Previously, `http3.RequestStream.ReadResponse` transparently decompressed any gzip response when gzip was requested. This broke successful CONNECT (2xx) responses, which must pass the body through unchanged.
> - The decompression logic now checks whether the request is a CONNECT with a 2xx status and, if so, preserves the `Content-Encoding: gzip` header and leaves the body as-is.
> - Tests in [client_test.go](https://github.com/quic-go/quic-go/pull/5834/files#diff-c28b48729e43df2458d6d1dc622f8887f4aa0127ca826820b3fedde81c396355) are expanded: `testClientGzip` now takes a method and status code, with new subtests covering successful CONNECT (body stays gzip-encoded, header preserved) and failed CONNECT (transparent decompression still applies).
> - Behavioral Change: successful CONNECT responses that include `Content-Encoding: gzip` no longer have their body replaced with a gzip reader or their `Content-Encoding` header stripped; callers must handle the encoded body directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a299f29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed successful HTTP CONNECT responses so tunnel data is preserved without unintended gzip decompression.
  - Improved handling of gzip-encoded CONNECT responses while maintaining standard decompression for other responses.
  - Added coverage for successful and unsuccessful CONNECT requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->