### PR TITLE
add an integration test for stream priorities

### DIFF
--- a/integrationtests/self/http3_stream_priority_test.go
+++ b/integrationtests/self/http3_stream_priority_test.go
@@ -1,0 +1,92 @@
+package self_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"testing/synctest"
+
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTP3StreamPriority(t *testing.T) {
+	for _, test := range streamPriorityTests {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				client, server := newStreamPriorityTestConnections(t)
+
+				paths := [...]string{"/0", "/1", "/2", "/3"}
+				started := make(chan struct{}, len(paths))
+				startWrites := make(chan struct{}, len(paths))
+				t.Cleanup(func() { close(startWrites) })
+				serverWriteErrs := make(chan error, len(paths))
+				mux := http.NewServeMux()
+				for i, path := range paths {
+					mux.HandleFunc("GET "+path, func(w http.ResponseWriter, _ *http.Request) {
+						started <- struct{}{}
+						<-startWrites
+						_, err := w.Write(PRData[:test.sizes[i]])
+						serverWriteErrs <- err
+					})
+				}
+				h3Server := &http3.Server{Handler: mux}
+				go h3Server.ServeQUICConn(server)
+
+				cc := (&http3.Transport{}).NewClientConn(client)
+				t.Cleanup(func() { cc.CloseWithError(0, "") })
+				var streams [4]*http3.RequestStream
+				for i := range streams {
+					str, err := cc.OpenRequestStream(t.Context())
+					require.NoError(t, err)
+					req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com"+paths[i], nil)
+					require.NoError(t, err)
+					priority := fmt.Sprintf("u=%d", test.urgencies[i])
+					if test.incremental {
+						priority += ", i"
+					}
+					req.Header.Set("Priority", priority)
+					require.NoError(t, str.SendRequestHeader(req))
+					require.NoError(t, str.Close())
+					streams[i] = str
+				}
+				for range streams {
+					<-started
+				}
+
+				type readResult struct {
+					i   int
+					n   int64
+					err error
+				}
+				completed := make(chan readResult, len(streams))
+				for i, str := range streams {
+					go func() {
+						resp, err := str.ReadResponse()
+						var n int64
+						if err == nil {
+							n, err = io.Copy(io.Discard, resp.Body)
+							resp.Body.Close()
+						}
+						completed <- readResult{i: i, n: n, err: err}
+					}()
+				}
+				for range streams {
+					startWrites <- struct{}{}
+				}
+
+				for _, i := range test.order {
+					result := <-completed
+					require.NoError(t, result.err)
+					require.Equal(t, i, result.i)
+					require.EqualValues(t, test.sizes[i], result.n)
+				}
+				for range streams {
+					require.NoError(t, <-serverWriteErrs)
+				}
+			})
+		})
+	}
+}

--- a/integrationtests/self/stream_priority_test.go
+++ b/integrationtests/self/stream_priority_test.go
@@ -1,0 +1,155 @@
+package self_test
+
+import (
+	"io"
+	"net"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/testutils/simnet"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newStreamPriorityTestConnections(t *testing.T) (client, server *quic.Conn) {
+	t.Helper()
+
+	const (
+		rtt               = 10 * time.Millisecond
+		bandwidthBytesSec = 1 << 20
+	)
+	n := &simnet.Simnet{Router: &simnet.PerfectRouter{}}
+	linkSettings := func() simnet.NodeBiDiLinkSettings {
+		var nextTransmission time.Time
+		return simnet.NodeBiDiLinkSettings{
+			LatencyFunc: func(p simnet.Packet) time.Duration {
+				now := time.Now()
+				if nextTransmission.Before(now) {
+					nextTransmission = now
+				}
+				nextTransmission = nextTransmission.Add(time.Duration(len(p.Data)) * time.Second / bandwidthBytesSec)
+				return nextTransmission.Add(rtt / 2).Sub(now)
+			},
+		}
+	}
+	clientPacketConn := n.NewEndpoint(&net.UDPAddr{IP: net.ParseIP("1.0.0.1"), Port: 9001}, linkSettings())
+	serverPacketConn := n.NewEndpoint(&net.UDPAddr{IP: net.ParseIP("1.0.0.2"), Port: 9002}, linkSettings())
+	require.NoError(t, n.Start())
+	t.Cleanup(func() {
+		require.NoError(t, clientPacketConn.Close())
+		require.NoError(t, serverPacketConn.Close())
+		require.NoError(t, n.Close())
+	})
+
+	serverConfig := getQuicConfig(&quic.Config{
+		InitialStreamReceiveWindow:     uint64(len(PRData)),
+		InitialConnectionReceiveWindow: uint64(len(PRData)),
+		DisablePathMTUDiscovery:        true,
+	})
+	listener, err := quic.Listen(
+		serverPacketConn,
+		getTLSConfig(),
+		serverConfig,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	client, err = quic.Dial(
+		t.Context(),
+		clientPacketConn,
+		serverPacketConn.LocalAddr(),
+		getTLSClientConfig(),
+		getQuicConfig(&quic.Config{DisablePathMTUDiscovery: true}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.CloseWithError(0, "") })
+	server, err = listener.Accept(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { server.CloseWithError(0, "") })
+	return client, server
+}
+
+type streamPriorityTestCase struct {
+	name        string
+	incremental bool
+	urgencies   [4]int8
+	sizes       [4]int
+	order       [4]int
+}
+
+var streamPriorityTests = [...]streamPriorityTestCase{
+	{
+		name:        "incremental streams use urgency and round robin",
+		incremental: true,
+		urgencies:   [4]int8{0, 0, 1, 1},
+		sizes:       [4]int{len(PRData) / 2, len(PRData) / 4, len(PRData) / 8, len(PRData) / 16},
+		// Round robin makes the smaller stream at each urgency finish first,
+		// while both urgency 0 streams finish before either urgency 1 stream.
+		order: [4]int{1, 0, 3, 2},
+	},
+	{
+		name:        "non-incremental streams use stream ID",
+		incremental: false,
+		urgencies:   [4]int8{3, 3, 3, 3},
+		sizes:       [4]int{len(PRData) / 2, len(PRData) / 4, len(PRData) / 8, len(PRData) / 16},
+		order:       [4]int{0, 1, 2, 3},
+	},
+}
+
+func TestStreamPriority(t *testing.T) {
+	for _, test := range streamPriorityTests {
+		t.Run(test.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				client, server := newStreamPriorityTestConnections(t)
+
+				var streams [4]*quic.SendStream
+				for i := range streams {
+					str, err := client.OpenUniStreamSync(t.Context())
+					require.NoError(t, err)
+					str.SetPriority(test.urgencies[i], test.incremental)
+					_, err = str.Write([]byte{0}) // make the stream visible to the peer
+					require.NoError(t, err)
+					streams[i] = str
+				}
+
+				type readResult struct {
+					id  quic.StreamID
+					n   int64
+					err error
+				}
+				completed := make(chan readResult, len(streams))
+				for range streams {
+					str, err := server.AcceptUniStream(t.Context())
+					require.NoError(t, err)
+					go func() {
+						n, err := io.Copy(io.Discard, str)
+						completed <- readResult{id: str.StreamID(), n: n, err: err}
+					}()
+				}
+
+				writeErrs := make(chan error, len(streams))
+				for i, str := range streams {
+					go func() {
+						_, err := str.Write(PRData[:test.sizes[i]])
+						if err == nil {
+							err = str.Close()
+						}
+						writeErrs <- err
+					}()
+				}
+
+				for _, i := range test.order {
+					result := <-completed
+					require.NoError(t, result.err)
+					require.Equal(t, streams[i].StreamID(), result.id)
+					require.EqualValues(t, test.sizes[i]+1, result.n)
+				}
+				for range streams {
+					require.NoError(t, <-writeErrs)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add integration tests for QUIC and HTTP/3 stream priorities
> - Adds `TestStreamPriority`, which opens four QUIC unidirectional streams with per-stream `SetPriority(urgency, incremental)` calls and asserts server read completion order under incremental and non-incremental modes
> - Adds `TestHTTP3StreamPriority`, which serves four HTTP/3 request-stream handlers and verifies response completion order based on the HTTP Priority request header
> - Introduces `newStreamPriorityTestConnections`, a `simnet`-based helper that builds a shaped QUIC client/server pair sized to the test data
> - Defines `streamPriorityTests` data covering round-robin within equal urgency, higher-urgency-first, and stream-ID-order scenarios
> - Both tests use `synctest.Test` for deterministic execution
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14280ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for stream priority scheduling.
  * Verifies that incremental streams are delivered by urgency and non-incremental streams by stream ID.
  * Added HTTP/3 coverage for configured urgency and incremental priority.
  * Confirms response completion order, transferred data, and server write behavior.
  * Tests behavior under simulated network latency and bandwidth constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->