### PR TITLE
http3: use :path for Extended CONNECT request targets

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -301,9 +301,7 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 		if err != nil {
 			return nil, err
 		}
-		u.Scheme = hdr.Scheme
-		u.Host = hdr.Authority
-		requestURI = hdr.Authority
+		requestURI = hdr.Path
 		protocol = hdr.Protocol
 	} else if isConnect {
 		u = &url.URL{Host: hdr.Authority}

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -466,7 +466,11 @@ func TestRequestHeadersExtendedConnect(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.MethodConnect, req.Method)
 	require.Equal(t, "webtransport", req.Proto)
-	require.Equal(t, "ftp://quic-go.net/foo?val=1337", req.URL.String())
+	require.Equal(t, "quic-go.net", req.Host)
+	require.Equal(t, "/foo?val=1337", req.RequestURI)
+	require.Equal(t, "/foo?val=1337", req.URL.String())
+	require.Empty(t, req.URL.Scheme)
+	require.Empty(t, req.URL.Host)
 	require.Equal(t, "1337", req.URL.Query().Get("val"))
 	require.Empty(t, req.Header)
 }


### PR DESCRIPTION
This stacks on #5837.

For Extended CONNECT requests, this uses :path for both RequestURI and URL while keeping :authority in Request.Host. This matches the standard library HTTP/2 request representation and prevents RequestURI and URL.Path from describing different request targets.

Regular CONNECT remains authority-form.

Tests:
- go test ./http3 -count=1
- go test ./integrationtests/self -run ^TestHTTPServerRequestParsing$ -count=1 -version=1

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `:path` for Extended CONNECT request targets in `http3.requestFromHeaders`
> For Extended CONNECT requests, `requestFromHeaders` now sets `RequestURI` and `req.URL` from `:path` instead of `:authority`. The URL `Scheme` and `Host` are no longer overwritten with `:scheme` and `:authority`; `req.Host` still gets `:authority`.
>
> Tests in [headers_test.go](https://github.com/quic-go/quic-go/pull/5838/files#diff-f95985faceb231b07d7725e2546e40ee3d8eed3890235bab9980229782211c8a) confirm `req.RequestURI` and `req.URL.String()` equal the `:path` value, with empty `Scheme` and `Host`.
>
> Behavioral Change: out-of-tree consumers expecting `RequestURI` or `req.URL` to carry `:authority` on Extended CONNECT will need to read `req.Host` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd2fb1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of extended CONNECT requests.
  * Preserved the raw request path while keeping host and request URI information separate.
  * Prevented non-HTTP schemes from being incorrectly included in the parsed request URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->