### PR TITLE
http3: parse requests like net/http

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -296,17 +296,17 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 
 	protocol := "HTTP/3.0"
 
-	if isConnect {
-		u = &url.URL{}
-		if isExtendedConnected {
-			u, err = url.ParseRequestURI(hdr.Path)
-			if err != nil {
-				return nil, err
-			}
-			protocol = hdr.Protocol
-		} else {
-			u.Path = hdr.Path
+	if isExtendedConnected {
+		u, err = url.ParseRequestURI(hdr.Path)
+		if err != nil {
+			return nil, err
 		}
+		u.Scheme = hdr.Scheme
+		u.Host = hdr.Authority
+		requestURI = hdr.Authority
+		protocol = hdr.Protocol
+	} else if isConnect {
+		u = &url.URL{Host: hdr.Authority}
 		requestURI = hdr.Authority
 	} else {
 		u, err = url.ParseRequestURI(hdr.Path)
@@ -315,8 +315,6 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 		}
 		requestURI = hdr.Path
 	}
-	u.Scheme = hdr.Scheme
-	u.Host = hdr.Authority
 
 	req := &http.Request{
 		Method:        hdr.Method,

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -51,7 +51,7 @@ func TestRequestHeaderParsing(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, http.MethodGet, req.Method)
 			require.Equal(t, tc.path, req.URL.Path)
-			require.Equal(t, "quic-go.net:443", req.URL.Host)
+			require.Empty(t, req.URL.Host)
 			require.Equal(t, "HTTP/3.0", req.Proto)
 			require.Equal(t, 3, req.ProtoMajor)
 			require.Zero(t, req.ProtoMinor)
@@ -61,9 +61,7 @@ func TestRequestHeaderParsing(t *testing.T) {
 			require.Nil(t, req.Body)
 			require.Equal(t, "quic-go.net:443", req.Host)
 			require.Equal(t, tc.path, req.RequestURI)
-			require.Equal(t, "quic-go.net", req.URL.Hostname())
-			require.Equal(t, "https", req.URL.Scheme)
-			require.Equal(t, "443", req.URL.Port())
+			require.Empty(t, req.URL.Scheme)
 		})
 	}
 }
@@ -79,7 +77,7 @@ func TestRequestHeaderParsingWithHostHeader(t *testing.T) {
 	req, err := requestFromHeaders(decodeFromSlice(headers), math.MaxInt, nil)
 	require.NoError(t, err)
 	require.Equal(t, "quic-go.net", req.Host)
-	require.Equal(t, "quic-go.net", req.URL.Host)
+	require.Empty(t, req.URL.Host)
 }
 
 func TestRequestHeadersContentLength(t *testing.T) {
@@ -392,6 +390,9 @@ func TestRequestHeadersConnect(t *testing.T) {
 	require.Equal(t, http.MethodConnect, req.Method)
 	require.Equal(t, "HTTP/3.0", req.Proto)
 	require.Equal(t, "quic-go.net:443", req.RequestURI)
+	require.Equal(t, "quic-go.net:443", req.URL.Host)
+	require.Empty(t, req.URL.Scheme)
+	require.Empty(t, req.URL.Path)
 }
 
 func TestRequestHeadersConnectValidation(t *testing.T) {

--- a/integrationtests/self/http_request_parsing_test.go
+++ b/integrationtests/self/http_request_parsing_test.go
@@ -1,0 +1,246 @@
+package self_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHTTPServerRequestParsing compares how the standard library's HTTP/2 server
+// and quic-go's HTTP/3 server parse different requests. It aims for equivalent
+// behavior wherever the protocols allow it.
+func TestHTTPServerRequestParsing(t *testing.T) {
+	requests := make(chan *http.Request, 1)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		requests <- r
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	h2Server := httptest.NewUnstartedServer(handler)
+	h2Server.EnableHTTP2 = true
+	h2Server.Config.DisableGeneralOptionsHandler = true
+	h2Server.StartTLS()
+	defer h2Server.Close()
+	h2Client := h2Server.Client()
+	h2Transport := h2Client.Transport.(*http.Transport)
+	h2Transport.DisableCompression = true
+	h2Transport.ForceAttemptHTTP2 = true
+
+	h3PacketConn := newUDPConnLocalhost(t)
+	h3Server := &http3.Server{Handler: handler, TLSConfig: getTLSConfig()}
+	h3ServerErr := make(chan error, 1)
+	go func() { h3ServerErr <- h3Server.Serve(h3PacketConn) }()
+	t.Cleanup(func() {
+		require.NoError(t, h3Server.Close())
+		require.ErrorIs(t, <-h3ServerErr, http.ErrServerClosed)
+	})
+	h3TLSConfig := getTLSClientConfig()
+	h3TLSConfig.NextProtos = []string{http3.NextProtoH3}
+	h3Conn, err := quic.Dial(
+		t.Context(),
+		newUDPConnLocalhost(t),
+		h3PacketConn.LocalAddr(),
+		h3TLSConfig,
+		getQuicConfig(nil),
+	)
+	require.NoError(t, err)
+	defer h3Conn.CloseWithError(0, "")
+	h3Client := &http.Client{Transport: (&http3.Transport{DisableCompression: true}).NewClientConn(h3Conn)}
+
+	// Cover origin, asterisk and authority request-target forms, URL parsing
+	// edge cases, host authorities, body lengths and trailers.
+	tests := []struct {
+		name          string
+		method        string
+		authority     string
+		path          string
+		body          string
+		contentLength int64
+		trailer       http.Header
+	}{
+		{
+			name:      "origin form",
+			method:    http.MethodGet,
+			authority: "quic-go.net",
+			path:      "/foo?bar=baz",
+		},
+		{
+			name:      "HEAD request",
+			method:    http.MethodHead,
+			authority: "quic-go.net",
+			path:      "/head?foo=bar",
+		},
+		{
+			name:      "origin-form OPTIONS",
+			method:    http.MethodOptions,
+			authority: "quic-go.net",
+			path:      "/options",
+		},
+		{
+			name:          "POST request with trailers",
+			method:        http.MethodPost,
+			authority:     "quic-go.net",
+			path:          "/post?foo=bar",
+			body:          "request body",
+			contentLength: -1,
+			trailer:       http.Header{"X-Test-Trailer": {"trailer value"}},
+		},
+		{
+			name:          "POST request with known length",
+			method:        http.MethodPost,
+			authority:     "quic-go.net",
+			path:          "/post-known-length",
+			body:          "known-length body",
+			contentLength: int64(len("known-length body")),
+		},
+		{
+			name:      "origin form with escaped path",
+			method:    http.MethodGet,
+			authority: "quic-go.net",
+			path:      "/foo%2Fbar?baz=qux",
+		},
+		{
+			name:      "origin form with path starting with double slash",
+			method:    http.MethodGet,
+			authority: "quic-go.net",
+			path:      "//foo",
+		},
+		{
+			name:      "origin form with force query",
+			method:    http.MethodGet,
+			authority: "quic-go.net",
+			path:      "/foo?",
+		},
+		{
+			name:      "origin form with encoded query",
+			method:    http.MethodGet,
+			authority: "quic-go.net",
+			path:      "/search?q=a%2Fb%20c",
+		},
+		{
+			name:      "origin form with explicit authority port",
+			method:    http.MethodGet,
+			authority: "quic-go.net:443",
+			path:      "/port",
+		},
+		{
+			name:      "asterisk form",
+			method:    http.MethodOptions,
+			authority: "quic-go.net",
+			path:      "*",
+		},
+		{
+			name:      "authority form",
+			method:    http.MethodConnect,
+			authority: "quic-go.net:443",
+		},
+		{
+			name:      "origin form with IPv6 authority",
+			method:    http.MethodGet,
+			authority: "[2001:db8::1]:443",
+			path:      "/ipv6",
+		},
+		{
+			name:      "authority form with IPv6 authority",
+			method:    http.MethodConnect,
+			authority: "[2001:db8::1]:443",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			requestURL := &url.URL{Scheme: "https", Host: h2Server.Listener.Addr().String()}
+			if tc.path != "" {
+				parsedURL, err := url.ParseRequestURI(tc.path)
+				require.NoError(t, err)
+				parsedURL.Scheme = requestURL.Scheme
+				parsedURL.Host = requestURL.Host
+				requestURL = parsedURL
+			}
+			request := &http.Request{
+				Method: tc.method,
+				URL:    requestURL,
+				Host:   tc.authority,
+				Header: http.Header{
+					"User-Agent":    nil,
+					"X-Test-Header": {"foo", "bar"},
+				},
+				Trailer: tc.trailer,
+			}
+			if tc.body != "" {
+				request.Body = io.NopCloser(strings.NewReader(tc.body))
+				request.ContentLength = tc.contentLength
+			}
+
+			resp, err := h2Client.Do(request.Clone(t.Context()))
+			require.NoError(t, err)
+			h2Request := <-requests
+			require.NoError(t, resp.Body.Close())
+			require.Equal(t, 2, resp.ProtoMajor)
+			require.Equal(t, http.StatusTeapot, resp.StatusCode)
+
+			if tc.body != "" {
+				request.Body = io.NopCloser(strings.NewReader(tc.body))
+			}
+			resp, err = h3Client.Do(request.Clone(t.Context()))
+			require.NoError(t, err)
+			h3Request := <-requests
+			require.NoError(t, resp.Body.Close())
+			require.Equal(t, 3, resp.ProtoMajor)
+			require.Equal(t, http.StatusTeapot, resp.StatusCode)
+
+			t.Logf("HTTP/2 request: %+v", h2Request)
+			t.Logf("HTTP/3 request: %+v", h3Request)
+			assert.Equal(t, "HTTP/2.0", h2Request.Proto)
+			assert.Equal(t, 2, h2Request.ProtoMajor)
+			assert.Zero(t, h2Request.ProtoMinor)
+			assert.Equal(t, "HTTP/3.0", h3Request.Proto)
+			assert.Equal(t, 3, h3Request.ProtoMajor)
+			assert.Zero(t, h3Request.ProtoMinor)
+
+			// Body, TLS and RemoteAddr are backed by different transports.
+			assert.Equal(t, h2Request.Method, h3Request.Method)
+			assert.Equal(t, h2Request.Host, h3Request.Host)
+			assert.Equal(t, h2Request.RequestURI, h3Request.RequestURI)
+			assert.Equal(t, h2Request.URL, h3Request.URL)
+			assert.Equal(t, h2Request.Header, h3Request.Header)
+			assert.Equal(t, h2Request.TransferEncoding, h3Request.TransferEncoding)
+			assert.Equal(t, h2Request.Close, h3Request.Close)
+			assert.Equal(t, h2Request.Trailer, h3Request.Trailer)
+			if tc.trailer != nil {
+				assert.Equal(t, tc.trailer, h2Request.Trailer)
+				assert.Equal(t, tc.trailer, h3Request.Trailer)
+			}
+			if tc.contentLength > 0 {
+				contentLength := strconv.FormatInt(tc.contentLength, 10)
+				assert.Equal(t, contentLength, h2Request.Header.Get("Content-Length"))
+				assert.Equal(t, contentLength, h3Request.Header.Get("Content-Length"))
+			}
+			if _, hasContentLength := h2Request.Header["Content-Length"]; hasContentLength {
+				assert.Equal(t, h2Request.ContentLength, h3Request.ContentLength)
+			} else if tc.body != "" {
+				assert.Equal(t, int64(-1), h2Request.ContentLength)
+				assert.Equal(t, int64(-1), h3Request.ContentLength)
+			} else {
+				// HTTP/2 has an END_STREAM flag on the HEADERS frame. HTTP/3 only
+				// learns that no body follows when the request stream reaches EOF.
+				assert.Zero(t, h2Request.ContentLength)
+				assert.Equal(t, int64(-1), h3Request.ContentLength)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR effectively reverts changes we made earlier this year, in particular #5554. @qiulaidongfeng @pjebs

While I don't think that these changes were wrong, there are arguably multiple ways we can fill out an `http.Request`, with no one way being more or less correct than the other. We should therefore strive to replicate what the standard library does as much as possible.

This PR adds an integration test that compares request parsing between HTTP/2 and HTTP/3.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align `http3.requestFromHeaders` request parsing with `net/http`
> - Reworks HTTP/3 request-target construction so ordinary requests use a path-only URL (no `URL.Scheme` or `URL.Host`), standard CONNECT uses an authority-only URL with authority as `RequestURI`, and extended CONNECT sets `RequestURI` to the authority while `URL` gets `:scheme` and `:authority`
> - Updates unit tests in [headers_test.go](https://github.com/quic-go/quic-go/pull/5839/files#diff-f95985faceb231b07d7725e2546e40ee3d8eed3890235bab9980229782211c8a) to expect the new URL field shapes for regular, Host-header-fallback, and CONNECT cases
> - Adds integration test in [http_request_parsing_test.go](https://github.com/quic-go/quic-go/pull/5839/files#diff-9c55dc614035f67d104bbbc94423119e333a0b77092cf884f8b77577f2eda4b5) that runs an HTTP/2 TLS server and HTTP/3 server with the same handler and compares parsed requests across origin-form, CONNECT, OPTIONS asterisk-form, trailers, escaped paths, and IPv6 authority cases
> - Behavioral Change: `http3.requestFromHeaders` no longer populates `URL.Scheme` or `URL.Host` for ordinary (non-CONNECT) requests; callers relying on those fields on `url.URL` must use `request.Host` and `request.TLS` instead
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4463698. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP/3 request parsing for regular and extended CONNECT requests.
  - CONNECT requests now preserve authority correctly, while extended CONNECT requests properly interpret path, scheme, authority, and protocol details.
  - Standard requests no longer populate URL scheme and host fields from transport pseudo-headers, improving compatibility with HTTP/2 behavior.

- **Tests**
  - Added integration coverage comparing HTTP/2 and HTTP/3 parsing across common request types, including bodies, trailers, escaped paths, query strings, IPv6 addresses, and CONNECT requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->