### PR TITLE
http3: use :path for Extended CONNECT request targets

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -306,9 +306,7 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 		if err != nil {
 			return nil, err
 		}
-		u.Scheme = hdr.Scheme
-		u.Host = hdr.Authority
-		requestURI = hdr.Authority
+		requestURI = hdr.Path
 		protocol = hdr.Protocol
 	} else if isConnect {
 		u = &url.URL{Host: hdr.Authority}

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -508,7 +508,11 @@ func TestRequestHeadersExtendedConnect(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.MethodConnect, req.Method)
 	require.Equal(t, "webtransport", req.Proto)
-	require.Equal(t, "ftp://quic-go.net/foo?val=1337", req.URL.String())
+	require.Equal(t, "quic-go.net", req.Host)
+	require.Equal(t, "/foo?val=1337", req.RequestURI)
+	require.Equal(t, "/foo?val=1337", req.URL.String())
+	require.Empty(t, req.URL.Scheme)
+	require.Empty(t, req.URL.Host)
 	require.Equal(t, "1337", req.URL.Query().Get("val"))
 	require.Empty(t, req.Header)
 }

--- a/integrationtests/self/http_request_parsing_test.go
+++ b/integrationtests/self/http_request_parsing_test.go
@@ -63,6 +63,7 @@ func TestHTTPServerRequestParsing(t *testing.T) {
 
 	// Cover origin, asterisk and authority request-target forms, URL parsing
 	// edge cases, host authorities, body lengths and trailers.
+	// TODO: Add an extended CONNECT case once https://go.dev/issue/53208 is resolved.
 	tests := []struct {
 		name          string
 		method        string


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix extended CONNECT to use `:path` for request target in `http3.requestFromHeaders`
> Extended CONNECT requests now expose the `:path` pseudo-header as `RequestURI` and `URL.Path`, keep `:authority` in `Request.Host`, and leave `URL.Scheme` and `URL.Host` empty. Previously the parser copied scheme and authority into the URL fields. Updated [TestRequestHeadersExtendedConnect](https://github.com/quic-go/quic-go/pull/5841/files#diff-f95985faceb231b07d7725e2546e40ee3d8eed3890235bab9980229782211c8a) to match. Risk: any consumer relying on `URL.Scheme` or `URL.Host` being populated for extended CONNECT will now see empty values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77b67f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected extended CONNECT request parsing so the URL and request URI contain only the request path and query.
  * Request authority is now exposed through the separate host field rather than being included in the URL.
  * Added validation to reject invalid request paths for applicable HTTP requests.
  * Extended CONNECT requests now provide consistent URL, request URI, host, scheme, and authority values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->