### PR TITLE
http3: validate request :path pseudo-header values

### DIFF
--- a/http3/headers.go
+++ b/http3/headers.go
@@ -290,6 +290,10 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 	if !isExtendedConnected && hasProtocol {
 		return nil, errors.New(":protocol must be omitted")
 	}
+	// url.ParseRequestURI also accepts absolute URIs, which are invalid in :path.
+	if (!isConnect || isExtendedConnected) && !strings.HasPrefix(hdr.Path, "/") && hdr.Path != "*" {
+		return nil, fmt.Errorf("invalid :path: %q", hdr.Path)
+	}
 
 	var u *url.URL
 	var requestURI string

--- a/http3/headers.go
+++ b/http3/headers.go
@@ -290,8 +290,9 @@ func requestFromHeaders(decodeFn qpack.DecodeFunc, sizeLimit int, headerFields *
 	if !isExtendedConnected && hasProtocol {
 		return nil, errors.New(":protocol must be omitted")
 	}
-	// url.ParseRequestURI also accepts absolute URIs, which are invalid in :path.
-	if (!isConnect || isExtendedConnected) && !strings.HasPrefix(hdr.Path, "/") && hdr.Path != "*" {
+	// url.ParseRequestURI accepts absolute URIs and "*", so validate :path before parsing.
+	validPath := strings.HasPrefix(hdr.Path, "/") || (hdr.Method == http.MethodOptions && hdr.Path == "*")
+	if (!isConnect || isExtendedConnected) && !validPath {
 		return nil, fmt.Errorf("invalid :path: %q", hdr.Path)
 	}
 

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -322,7 +322,28 @@ func TestRequestHeadersValidation(t *testing.T) {
 				{Name: ":authority", Value: "quic-go.net"},
 				{Name: ":method", Value: http.MethodGet},
 			},
-			errContains: "invalid request URI",
+			err: `invalid :path: "invalid path"`,
+		},
+		{
+			name: "absolute URI in :path",
+			headers: []qpack.HeaderField{
+				{Name: ":scheme", Value: "https"},
+				{Name: ":path", Value: "https://attacker.example/foo"},
+				{Name: ":authority", Value: "quic-go.net"},
+				{Name: ":method", Value: http.MethodGet},
+			},
+			err: `invalid :path: "https://attacker.example/foo"`,
+		},
+		{
+			name: "absolute URI in :path for Extended CONNECT",
+			headers: []qpack.HeaderField{
+				{Name: ":protocol", Value: "webtransport"},
+				{Name: ":scheme", Value: "https"},
+				{Name: ":path", Value: "https://attacker.example/foo"},
+				{Name: ":authority", Value: "quic-go.net"},
+				{Name: ":method", Value: http.MethodConnect},
+			},
+			err: `invalid :path: "https://attacker.example/foo"`,
 		},
 		{
 			name: "userinfo in :authority",

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -346,6 +346,27 @@ func TestRequestHeadersValidation(t *testing.T) {
 			err: `invalid :path: "https://attacker.example/foo"`,
 		},
 		{
+			name: "asterisk-form for non-OPTIONS request",
+			headers: []qpack.HeaderField{
+				{Name: ":scheme", Value: "https"},
+				{Name: ":path", Value: "*"},
+				{Name: ":authority", Value: "quic-go.net"},
+				{Name: ":method", Value: http.MethodGet},
+			},
+			err: `invalid :path: "*"`,
+		},
+		{
+			name: "asterisk-form for Extended CONNECT",
+			headers: []qpack.HeaderField{
+				{Name: ":protocol", Value: "webtransport"},
+				{Name: ":scheme", Value: "https"},
+				{Name: ":path", Value: "*"},
+				{Name: ":authority", Value: "quic-go.net"},
+				{Name: ":method", Value: http.MethodConnect},
+			},
+			err: `invalid :path: "*"`,
+		},
+		{
 			name: "userinfo in :authority",
 			headers: []qpack.HeaderField{
 				{Name: ":scheme", Value: "https"},


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate `:path` pseudo-header values in `http3.requestFromHeaders`
> Adds explicit validation of the `:path` pseudo-header before URI parsing in [headers.go](https://github.com/quic-go/quic-go/pull/5842/files#diff-fd2fc9252b467e3ef8b4b4a45eafc66de3fab721b4de75b705da663b3e0f3160). Non-CONNECT and Extended CONNECT requests must use an origin-form path beginning with `/`; OPTIONS may use `*`. Absolute URIs, invalid relative forms, and disallowed asterisk-form paths now return an error identifying the invalid `:path` value. Tests in [headers_test.go](https://github.com/quic-go/quic-go/pull/5842/files#diff-f95985faceb231b07d7725e2546e40ee3d8eed3890235bab9980229782211c8a) add cases for absolute URIs on regular and Extended CONNECT requests, and `*` on non-OPTIONS and Extended CONNECT.
> - Risk: requests with absolute-URI `:path` values or `*` on non-OPTIONS methods are now rejected; any client relying on these forms will receive an error. Regular CONNECT requests remain exempt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c274636.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid `:path` values are now rejected for regular requests and Extended CONNECT requests.
  - Absolute URIs and paths that do not begin with `/` are rejected with clearer validation errors.
  - Asterisk-form paths are accepted only for OPTIONS requests.
  - Normal CONNECT requests continue to support their existing path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->