### PR TITLE
honor packet loss direction in handshake integration test

### DIFF
--- a/integrationtests/self/handshake_drop_test.go
+++ b/integrationtests/self/handshake_drop_test.go
@@ -165,11 +165,14 @@ func dropCallbackDropNthPacket(dir direction, ns ...int) func(direction, simnet.
 	}
 }
 
-func dropCallbackDropOneThird(_ direction) func(direction, simnet.Packet) bool {
+func dropCallbackDropOneThird(dir direction) func(direction, simnet.Packet) bool {
 	const maxSequentiallyDropped = 10
 	var mx sync.Mutex
 	var toClient, toServer int
 	return func(d direction, p simnet.Packet) bool {
+		if d != dir && dir != directionBoth {
+			return false
+		}
 		drop := mrand.IntN(3) == 0
 
 		mx.Lock()


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix `dropCallbackDropOneThird` to honor packet direction in handshake drop test
The packet-drop callback now uses the supplied direction argument and only applies its one-third random drop to packets matching the requested direction (or both directions when configured with `directionBoth`). Packets in the other direction are retained. The random drop selection and consecutive-drop tracking for matching packets are unchanged.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6a7824.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated handshake drop testing to apply simulated packet loss only to the requested traffic direction.
  * Preserved bidirectional packet-loss behavior when both directions are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->