### PR TITLE
Recover from EMSGSIZE during the handshake

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -159,10 +159,12 @@ type Conn struct {
 	tokenStoreKey         string                    // only set for the client
 	tokenGenerator        *handshake.TokenGenerator // only set for the server
 
-	unpacker      unpacker
-	frameParser   wire.FrameParser
-	packer        packer
-	mtuDiscoverer *mtuFinder // initialized when the transport parameters are received
+	unpacker          unpacker
+	frameParser       wire.FrameParser
+	packer            packer
+	mtuDiscoverer     *mtuFinder         // initialized when the transport parameters are received
+	initialPacketSize protocol.ByteCount // reduced on EMSGSIZE during the handshake
+	sendMsgSizeErr    chan struct{}
 
 	maxPayloadSizeEstimate atomic.Uint32
 
@@ -509,10 +511,12 @@ var newClientConnection = func(
 }
 
 func (c *Conn) preSetup() {
+	c.initialPacketSize = protocol.ByteCount(c.config.InitialPacketSize)
+	c.sendMsgSizeErr = make(chan struct{}, 1)
 	c.largestRcvdAppData = protocol.InvalidPacketNumber
 	c.initialStream = newInitialCryptoStream(c.perspective == protocol.PerspectiveClient)
 	c.handshakeStream = newCryptoStream()
-	c.sendQueue = newSendQueue(c.conn)
+	c.sendQueue = newSendQueue(c.conn, c.sendMsgSizeErr)
 	c.retransmissionQueue = newRetransmissionQueue()
 	c.frameParser = *wire.NewFrameParser(
 		c.config.EnableDatagrams,
@@ -658,6 +662,8 @@ runLoop:
 				break runLoop
 			case <-c.timer.C:
 			case <-c.sendingScheduled:
+			case <-c.sendMsgSizeErr:
+				c.handleSendMsgSizeError()
 			case <-sendQueueAvailable:
 			case <-c.notifyReceivedPacket:
 				wasProcessed, err := c.handlePackets()
@@ -920,7 +926,7 @@ func (c *Conn) switchToNewPath(tr *Transport, now monotime.Time) {
 	c.mtuDiscoverer.Reset(now, initialPacketSize, maxPacketSize)
 	c.conn = newSendConn(tr.conn, c.conn.RemoteAddr(), packetInfo{}, utils.DefaultLogger) // TODO: find a better way
 	c.sendQueue.Close()
-	c.sendQueue = newSendQueue(c.conn)
+	c.sendQueue = newSendQueue(c.conn, nil)
 	go func() {
 		if err := c.sendQueue.Run(); err != nil {
 			c.destroyImpl(err)
@@ -2442,7 +2448,7 @@ func (c *Conn) applyTransportParameters() {
 	}
 	c.mtuDiscoverer = newMTUDiscoverer(
 		c.rttStats,
-		protocol.ByteCount(c.config.InitialPacketSize),
+		c.initialPacketSize,
 		maxPacketSize,
 		c.qlogger,
 	)
@@ -2862,13 +2868,30 @@ func (c *Conn) sendConnectionClose(e error) ([]byte, error) {
 	return packet.buffer.Data, c.conn.Write(packet.buffer.Data, 0, ecn)
 }
 
+// handleSendMsgSizeError runs on the connection goroutine. Before handshake
+// confirmation, loss recovery alone would keep retransmitting at the rejected size.
+func (c *Conn) handleSendMsgSizeError() {
+	if c.handshakeConfirmed || c.initialPacketSize <= protocol.MinInitialPacketSize {
+		return
+	}
+	c.initialPacketSize = protocol.MinInitialPacketSize
+	if c.mtuDiscoverer != nil {
+		// Transport parameters can arrive before the first oversized server flight.
+		// No MTU probes have been sent yet, so only the starting size changes.
+		c.mtuDiscoverer = newMTUDiscoverer(c.rttStats, c.initialPacketSize, c.mtuDiscoverer.max(), c.qlogger)
+	}
+	c.maxPayloadSizeEstimate.Store(uint32(estimateMaxPayloadSize(c.initialPacketSize)))
+	c.sentPacketHandler.SetMaxDatagramSize(c.initialPacketSize)
+}
+
 func (c *Conn) maxPacketSize() protocol.ByteCount {
 	if c.mtuDiscoverer == nil {
-		// Use the configured packet size on the client side.
+		// Use the configured packet size on the client side, unless a local write
+		// error required a smaller size during the handshake.
 		// If the server sends a max_udp_payload_size that's smaller than this size, we can ignore this:
 		// Apparently the server still processed the (fully padded) Initial packet anyway.
 		if c.perspective == protocol.PerspectiveClient {
-			return protocol.ByteCount(c.config.InitialPacketSize)
+			return c.initialPacketSize
 		}
 		// On the server side, there's no downside to using 1200 bytes until we received the client's transport
 		// parameters:

--- a/connection_mtu_test.go
+++ b/connection_mtu_test.go
@@ -1,0 +1,82 @@
+package quic
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go/internal/monotime"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/wire"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionHandshakePacketSizeFallback(t *testing.T) {
+	for _, perspective := range []protocol.Perspective{protocol.PerspectiveClient, protocol.PerspectiveServer} {
+		for _, receivedParams := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/received parameters: %t", perspective, receivedParams), func(t *testing.T) {
+				config := &Config{InitialPacketSize: 1337}
+				var tc *testConnection
+				if perspective == protocol.PerspectiveClient {
+					tc = newClientTestConnection(t, nil, config, false)
+				} else {
+					tc = newServerTestConnection(t, nil, config, false)
+				}
+				c := tc.conn
+				c.rttStats.UpdateRTT(10*time.Millisecond, 0)
+				c.peerParams = &wire.TransportParameters{MaxUDPPayloadSize: 1400, ActiveConnectionIDLimit: 2}
+				if receivedParams {
+					c.applyTransportParameters()
+					require.Equal(t, protocol.ByteCount(1337), c.maxPacketSize())
+				} else {
+					require.Nil(t, c.mtuDiscoverer)
+				}
+				c.handleSendMsgSizeError()
+				require.Equal(t, protocol.ByteCount(protocol.MinInitialPacketSize), c.maxPacketSize())
+				require.Equal(t, uint32(estimateMaxPayloadSize(protocol.MinInitialPacketSize)), c.maxPayloadSizeEstimate.Load())
+				require.Equal(t, uint16(1337), c.config.InitialPacketSize)
+				if !receivedParams {
+					c.applyTransportParameters()
+				}
+				require.Equal(t, protocol.ByteCount(protocol.MinInitialPacketSize), c.mtuDiscoverer.CurrentSize())
+				require.Equal(t, protocol.ByteCount(1400), c.mtuDiscoverer.max())
+				require.False(t, c.mtuDiscoverer.ShouldSendProbe(monotime.Now().Add(time.Hour)))
+
+				// Repeated notifications at the minimum don't reset discovery or shrink further.
+				finder := c.mtuDiscoverer
+				c.handleSendMsgSizeError()
+				require.Same(t, finder, c.mtuDiscoverer)
+				require.Equal(t, protocol.ByteCount(protocol.MinInitialPacketSize), c.maxPacketSize())
+
+				// Confirmation preserves the fallback, then normal probing can grow it.
+				c.handshakeConfirmed = true
+				now := monotime.Now()
+				finder.Start(now)
+				require.Equal(t, protocol.ByteCount(protocol.MinInitialPacketSize), c.maxPacketSize())
+				require.True(t, finder.ShouldSendProbe(now.Add(time.Second)))
+				probe, size := finder.GetPing(now.Add(time.Second))
+				c.handleSendMsgSizeError()
+				require.Same(t, finder, c.mtuDiscoverer)
+				probe.Handler.OnAcked(probe.Frame)
+				require.Equal(t, size, c.maxPacketSize())
+				require.Greater(t, size, protocol.ByteCount(protocol.MinInitialPacketSize))
+			})
+		}
+	}
+}
+
+func TestConnectionSendMessageTooLargeAfterHandshake(t *testing.T) {
+	tc := newClientTestConnection(t, nil, &Config{InitialPacketSize: 1337}, false, connectionOptHandshakeConfirmed())
+	c := tc.conn
+	c.peerParams = &wire.TransportParameters{MaxUDPPayloadSize: 1450, ActiveConnectionIDLimit: 2}
+	c.applyTransportParameters()
+	finder := c.mtuDiscoverer
+	finder.Start(monotime.Now())
+	probe, size := finder.GetPing(monotime.Now().Add(time.Second))
+	c.handleSendMsgSizeError()
+	require.Same(t, finder, c.mtuDiscoverer)
+	require.Equal(t, protocol.ByteCount(1337), c.maxPacketSize())
+	probe.Handler.OnAcked(probe.Frame)
+	require.Equal(t, size, c.maxPacketSize())
+}

--- a/integrationtests/self/handshake_mtu_test.go
+++ b/integrationtests/self/handshake_mtu_test.go
@@ -1,0 +1,126 @@
+package self_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/wire"
+	"github.com/quic-go/quic-go/testutils/simnet"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mtuLimitedPacketConn struct {
+	net.PacketConn
+	limit    int
+	rejected atomic.Int32
+}
+
+func (c *mtuLimitedPacketConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+	if len(b) > c.limit {
+		c.rejected.Add(1)
+		return 0, sendMessageTooLargeError(addr)
+	}
+	return c.PacketConn.WriteTo(b, addr)
+}
+
+func TestHandshakeWithSendMessageTooLarge(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		t.Skip("send message size errors are not recognized on this platform")
+	}
+	for _, dir := range []direction{directionToServer, directionToClient, directionBoth} {
+		for _, clientSpeaksFirst := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/client speaks first: %t", dir, clientSpeaksFirst), func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					n := &simnet.Simnet{Router: &simnet.PerfectRouter{}}
+					settings := simnet.NodeBiDiLinkSettings{Latency: 10 * time.Millisecond}
+					client := &mtuLimitedPacketConn{PacketConn: n.NewEndpoint(&net.UDPAddr{IP: net.IPv4(1, 0, 0, 1), Port: 9001}, settings), limit: protocol.MaxPacketBufferSize}
+					server := &mtuLimitedPacketConn{PacketConn: n.NewEndpoint(&net.UDPAddr{IP: net.IPv4(1, 0, 0, 2), Port: 9002}, settings), limit: protocol.MaxPacketBufferSize}
+					defer client.Close()
+					defer server.Close()
+					if dir == directionToServer || dir == directionBoth {
+						client.limit = protocol.MinInitialPacketSize
+					}
+					if dir == directionToClient || dir == directionBoth {
+						server.limit = protocol.MinInitialPacketSize
+					}
+					require.NoError(t, n.Start())
+					defer n.Close()
+					tr := &quic.Transport{Conn: server}
+					defer tr.Close()
+					ln, err := tr.Listen(getTLSConfig(), getQuicConfig(&quic.Config{DisablePathMTUDiscovery: true}))
+					require.NoError(t, err)
+					defer ln.Close()
+					fn := dropTestProtocolClientSpeaksFirst
+					if !clientSpeaksFirst {
+						fn = dropTestProtocolServerSpeaksFirst
+					}
+					fn(t, ln, client, getTLSClientConfig(), 5*time.Second, GeneratePRData(10000))
+					if client.limit == protocol.MinInitialPacketSize {
+						require.Positive(t, client.rejected.Load())
+					}
+					if server.limit == protocol.MinInitialPacketSize {
+						require.Positive(t, server.rejected.Load())
+					}
+				})
+			})
+		}
+	}
+}
+
+func sendMessageTooLargeError(addr net.Addr) error {
+	err := syscall.EMSGSIZE
+	if runtime.GOOS == "windows" {
+		err = syscall.Errno(10040) // WSAEMSGSIZE
+	}
+	return &net.OpError{Op: "write", Net: "udp", Addr: addr, Err: &os.SyscallError{Syscall: "sendmsg", Err: err}}
+}
+
+// Preserve the UDP socket capabilities so the integration test exercises both
+// WriteMsgUDP errors during the handshake and real MTU probing afterwards.
+type handshakeMTULimitedUDPConn struct {
+	*net.UDPConn
+	rejected atomic.Int32
+}
+
+func (c *handshakeMTULimitedUDPConn) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (int, int, error) {
+	if len(b) > protocol.MinInitialPacketSize && wire.IsLongHeaderPacket(b[0]) {
+		c.rejected.Add(1)
+		return 0, 0, sendMessageTooLargeError(addr)
+	}
+	return c.UDPConn.WriteMsgUDP(b, oob, addr)
+}
+
+func TestHandshakeSendMessageTooLargeAtMinimum(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		t.Skip("send message size errors are not recognized on this platform")
+	}
+	synctest.Test(t, func(t *testing.T) {
+		router := &simnet.PerfectRouter{}
+		client := &mtuLimitedPacketConn{
+			PacketConn: simnet.NewSimConn(&net.UDPAddr{IP: net.IPv4(1, 0, 0, 1), Port: 9001}, router),
+			limit:      protocol.MinInitialPacketSize - 1,
+		}
+		defer client.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := quic.Dial(ctx, client, &net.UDPAddr{IP: net.IPv4(1, 0, 0, 2), Port: 9002}, getTLSClientConfig(), getQuicConfig(&quic.Config{
+			HandshakeIdleTimeout: 10 * time.Second,
+		}))
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		// Retries at the minimum still follow the PTO timer, rather than spinning
+		// or producing invalid Initial datagrams smaller than 1200 bytes.
+		require.Greater(t, client.rejected.Load(), int32(1))
+		require.Less(t, client.rejected.Load(), int32(30))
+	})
+}

--- a/integrationtests/self/mtu_test.go
+++ b/integrationtests/self/mtu_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -43,6 +44,16 @@ func TestInitialPacketSize(t *testing.T) {
 }
 
 func TestPathMTUDiscovery(t *testing.T) {
+	t.Run("configured initial size", func(t *testing.T) { testPathMTUDiscovery(t, false) })
+	t.Run("handshake EMSGSIZE fallback", func(t *testing.T) {
+		if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+			t.Skip("requires WriteMsgUDP support and send message size error recognition")
+		}
+		testPathMTUDiscovery(t, true)
+	})
+}
+
+func testPathMTUDiscovery(t *testing.T, handshakeFallback bool) {
 	rtt := scaleDuration(5 * time.Millisecond)
 	const mtu = 1400
 
@@ -106,7 +117,15 @@ func TestPathMTUDiscovery(t *testing.T) {
 
 	// Make sure to use v4-only socket here.
 	// We can't reliably set the DF bit on dual-stack sockets on older versions of macOS (before Sequoia).
-	tr := &quic.Transport{Conn: newUDPConnLocalhost(t)}
+	udpConn := newUDPConnLocalhost(t)
+	tr := &quic.Transport{Conn: udpConn}
+	initialPacketSize := uint16(protocol.MinInitialPacketSize)
+	if handshakeFallback {
+		limited := &handshakeMTULimitedUDPConn{UDPConn: udpConn}
+		tr.Conn = limited
+		initialPacketSize = protocol.InitialPacketSize
+		defer func() { require.Positive(t, limited.rejected.Load()) }()
+	}
 	defer tr.Close()
 
 	var eventRecorder events.Recorder
@@ -115,7 +134,7 @@ func TestPathMTUDiscovery(t *testing.T) {
 		proxy.LocalAddr(),
 		getTLSClientConfig(),
 		getQuicConfig(&quic.Config{
-			InitialPacketSize: protocol.MinInitialPacketSize,
+			InitialPacketSize: initialPacketSize,
 			EnableDatagrams:   true,
 			Tracer:            newTracer(&eventRecorder),
 		}),
@@ -128,6 +147,7 @@ func TestPathMTUDiscovery(t *testing.T) {
 	var datagramErr *quic.DatagramTooLargeError
 	require.ErrorAs(t, err, &datagramErr)
 	initialMaxDatagramSize := datagramErr.MaxDatagramPayloadSize
+	require.Less(t, initialMaxDatagramSize, int64(protocol.MinInitialPacketSize))
 
 	str, err := conn.OpenStream()
 	require.NoError(t, err)

--- a/internal/congestion/cubic_sender.go
+++ b/internal/congestion/cubic_sender.go
@@ -1,8 +1,6 @@
 package congestion
 
 import (
-	"fmt"
-
 	"github.com/quic-go/quic-go/internal/monotime"
 	"github.com/quic-go/quic-go/internal/protocol"
 	"github.com/quic-go/quic-go/internal/utils"
@@ -318,9 +316,6 @@ func (c *cubicSender) maybeQlogStateChange(new qlog.CongestionState) {
 }
 
 func (c *cubicSender) SetMaxDatagramSize(s protocol.ByteCount) {
-	if s < c.maxDatagramSize {
-		panic(fmt.Sprintf("congestion BUG: decreased max datagram size from %d to %d", c.maxDatagramSize, s))
-	}
 	cwndIsMinCwnd := c.congestionWindow == c.minCongestionWindow()
 	c.maxDatagramSize = s
 	if cwndIsMinCwnd {

--- a/internal/congestion/cubic_sender_test.go
+++ b/internal/congestion/cubic_sender_test.go
@@ -511,8 +511,24 @@ func TestCubicSenderSlowStartsUpToMaximumCongestionWindow(t *testing.T) {
 }
 
 func TestCubicSenderMaximumPacketSizeReduction(t *testing.T) {
-	sender := newTestCubicSender(false)
-	require.Panics(t, func() { sender.sender.SetMaxDatagramSize(initialMaxDatagramSize - 1) })
+	for _, minWindow := range []bool{false, true} {
+		t.Run(fmt.Sprintf("minimum window: %t", minWindow), func(t *testing.T) {
+			sender := newTestCubicSender(false).sender
+			if minWindow {
+				sender.congestionWindow = sender.minCongestionWindow()
+			}
+			oldWindow := sender.GetCongestionWindow()
+			sender.SetMaxDatagramSize(protocol.MinInitialPacketSize)
+			require.Equal(t, protocol.ByteCount(protocol.MinInitialPacketSize), sender.maxDatagramSize)
+			require.Equal(t, protocol.ByteCount(protocol.MinInitialPacketSize), sender.pacer.maxDatagramSize)
+			if minWindow {
+				// Keep the minimum window's size in packets constant.
+				require.Equal(t, sender.minCongestionWindow(), sender.GetCongestionWindow())
+			} else {
+				require.Equal(t, oldWindow, sender.GetCongestionWindow())
+			}
+		})
+	}
 }
 
 func TestCubicSenderSlowStartsPacketSizeIncrease(t *testing.T) {

--- a/send_queue.go
+++ b/send_queue.go
@@ -22,24 +22,26 @@ type queueEntry struct {
 }
 
 type sendQueue struct {
-	queue       chan queueEntry
-	closeCalled chan struct{} // runStopped when Close() is called
-	runStopped  chan struct{} // runStopped when the run loop returns
-	available   chan struct{}
-	conn        sendConn
+	queue          chan queueEntry
+	closeCalled    chan struct{} // runStopped when Close() is called
+	runStopped     chan struct{} // runStopped when the run loop returns
+	available      chan struct{}
+	conn           sendConn
+	sendMsgSizeErr chan<- struct{}
 }
 
 var _ sender = &sendQueue{}
 
 const sendQueueCapacity = 8
 
-func newSendQueue(conn sendConn) sender {
+func newSendQueue(conn sendConn, sendMsgSizeErr chan<- struct{}) sender {
 	return &sendQueue{
-		conn:        conn,
-		runStopped:  make(chan struct{}),
-		closeCalled: make(chan struct{}),
-		available:   make(chan struct{}, 1),
-		queue:       make(chan queueEntry, sendQueueCapacity),
+		conn:           conn,
+		sendMsgSizeErr: sendMsgSizeErr,
+		runStopped:     make(chan struct{}),
+		closeCalled:    make(chan struct{}),
+		available:      make(chan struct{}, 1),
+		queue:          make(chan queueEntry, sendQueueCapacity),
 	}
 }
 
@@ -88,12 +90,17 @@ func (h *sendQueue) Run() error {
 			shouldClose = true
 		case e := <-h.queue:
 			if err := h.conn.Write(e.buf.Data, e.gsoSize, e.ecn); err != nil {
-				// This additional check enables:
-				// 1. Checking for "datagram too large" message from the kernel, as such,
-				// 2. Path MTU discovery,and
-				// 3. Eventual detection of loss PingFrame.
 				if !isSendMsgSizeErr(err) {
 					return err
+				}
+				// Notify the connection without blocking the send queue. Loss recovery
+				// still handles the rejected packet; the connection can reduce the
+				// size used for handshake retransmissions before PMTUD starts.
+				if e.buf.Len() > protocol.MinInitialPacketSize {
+					select {
+					case h.sendMsgSizeErr <- struct{}{}:
+					default:
+					}
 				}
 			}
 			e.buf.Release()

--- a/send_queue_test.go
+++ b/send_queue_test.go
@@ -1,8 +1,12 @@
 package quic
 
 import (
+	"fmt"
 	"net"
 	"net/netip"
+	"os"
+	"runtime"
+	"syscall"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -25,7 +29,7 @@ func TestSendQueueSendOnePacket(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		c := NewMockSendConn(mockCtrl)
-		q := newSendQueue(c)
+		q := newSendQueue(c, nil)
 
 		written := make(chan struct{})
 		c.EXPECT().Write([]byte("foobar"), uint16(10), protocol.ECT1).Do(
@@ -62,7 +66,7 @@ func TestSendQueueBlocking(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		c := NewMockSendConn(mockCtrl)
-		q := newSendQueue(c)
+		q := newSendQueue(c, nil)
 
 		blockWrite := make(chan struct{})
 		written := make(chan struct{}, 1)
@@ -155,7 +159,7 @@ func TestSendQueueWriteError(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		c := NewMockSendConn(mockCtrl)
-		q := newSendQueue(c)
+		q := newSendQueue(c, nil)
 
 		c.EXPECT().Write(gomock.Any(), gomock.Any(), gomock.Any()).Return(assert.AnError)
 		q.Send(getPacketWithContents([]byte("foobar")), 6, protocol.ECNNon)
@@ -194,7 +198,7 @@ func TestSendQueueWriteError(t *testing.T) {
 func TestSendQueueSendProbe(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	c := NewMockSendConn(mockCtrl)
-	q := newSendQueue(c)
+	q := newSendQueue(c, nil)
 
 	addr := &net.UDPAddr{IP: net.IPv4(42, 42, 42, 42), Port: 42}
 	localAddr := netip.MustParseAddr("43.43.43.43")
@@ -204,4 +208,41 @@ func TestSendQueueSendProbe(t *testing.T) {
 	q.SendProbe(getPacketWithContents([]byte("foobar")), addr, packetInfo{
 		addr: localAddr,
 	})
+}
+
+func TestSendQueueSendMessageTooLarge(t *testing.T) {
+	err := syscall.EMSGSIZE
+	if runtime.GOOS == "windows" {
+		err = syscall.Errno(10040) // WSAEMSGSIZE
+	}
+	if !isSendMsgSizeErr(err) {
+		t.Skip("send message size errors are not recognized on this platform")
+	}
+	for _, size := range []int{protocol.MinInitialPacketSize, protocol.InitialPacketSize} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				conn := NewMockSendConn(ctrl)
+				notify := make(chan struct{}, 1)
+				q := newSendQueue(conn, notify)
+				conn.EXPECT().Write(gomock.Any(), uint16(0), protocol.ECNNon).Return(
+					&net.OpError{Op: "write", Err: &os.SyscallError{Syscall: "sendmsg", Err: err}},
+				).Times(2 * sendQueueCapacity)
+				done := make(chan error, 1)
+				go func() { done <- q.Run() }()
+				// An unread notification must not block further writes or Close.
+				for range 2 * sendQueueCapacity {
+					q.Send(getPacketWithContents(make([]byte, size)), 0, protocol.ECNNon)
+					synctest.Wait()
+				}
+				q.Close()
+				require.NoError(t, <-done)
+				if size > protocol.MinInitialPacketSize {
+					require.Len(t, notify, 1)
+				} else {
+					require.Empty(t, notify)
+				}
+			})
+		})
+	}
 }


### PR DESCRIPTION
On `EMSGSIZE` before handshake confirmation, fall back to 1200 bytes for that connection. Keeps the 1280 default and lets PMTUD probe upward afterward.

The connection owns the fallback and keeps DATAGRAM and congestion-control sizing consistent.

Reproduced on v0.62.0. Regression tests, full suite, and focused race tests pass.

Fixes #5815.
