### PR TITLE
ackhandler: remove unused sentPacketHistory.LowestPacketNumber

### DIFF
--- a/internal/ackhandler/sent_packet_history.go
+++ b/internal/ackhandler/sent_packet_history.go
@@ -227,13 +227,6 @@ func (h *sentPacketHistory) cleanupStart() {
 	h.firstPacketNumber = protocol.InvalidPacketNumber
 }
 
-func (h *sentPacketHistory) LowestPacketNumber() protocol.PacketNumber {
-	if len(h.packets) == 0 {
-		return protocol.InvalidPacketNumber
-	}
-	return h.firstPacketNumber
-}
-
 func (h *sentPacketHistory) DeclareLost(pn protocol.PacketNumber) {
 	idx, ok := h.getIndex(pn)
 	if !ok {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove unused `sentPacketHistory.LowestPacketNumber` method
Removes the unused `LowestPacketNumber` method from `sentPacketHistory`. The method returned `InvalidPacketNumber` for an empty history and otherwise returned the first packet number. No callers existed, so runtime behavior is unchanged.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 388c757.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed an unused public method. No other user-visible behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->