### PR TITLE
add client-side support for the server's preferred address

### DIFF
--- a/conn_id_manager.go
+++ b/conn_id_manager.go
@@ -24,6 +24,15 @@ type connIDManager struct {
 	pathMx           sync.Mutex
 	pathProbing      map[pathID]newConnID // initialized lazily
 
+	// The connection ID the server sent alongside its preferred address.
+	// It belongs to that path, so it is held apart from the queue until the path
+	// is taken into use. See AddFromPreferredAddress.
+	preferredAddressConnID *newConnID
+	// Whether the reserved connection ID's stateless reset token has been
+	// registered. That happens when the ID first goes on the wire - the first
+	// probe - not when the reservation is made and not only at the move.
+	preferredAddressTokenAdded bool
+
 	handshakeComplete         bool
 	activeSequenceNumber      uint64
 	highestRetired            uint64
@@ -59,8 +68,107 @@ func newConnIDManager(
 	}
 }
 
-func (h *connIDManager) AddFromPreferredAddress(connID protocol.ConnectionID, resetToken protocol.StatelessResetToken) error {
-	return h.addConnectionID(1, connID, resetToken)
+// AddFromPreferredAddress reserves the connection ID that the server sent
+// alongside its preferred address.
+//
+// The ID is not queued for general use. It belongs to the preferred-address
+// path, and it always occupies sequence number 1 (RFC 9000, section 5.1.1),
+// which is also the first sequence number the server's own NEW_CONNECTION_ID
+// frames take. Letting both reach the queue reports conflicting connection IDs
+// and kills the connection.
+//
+// Its stateless reset token is deliberately not registered here. An endpoint
+// must not look for reset tokens belonging to connection IDs it hasn't used
+// (RFC 9000, section 10.3.1); the token is registered when the ID first goes on
+// the wire, by RegisterPreferredAddressResetToken.
+func (h *connIDManager) AddFromPreferredAddress(connID protocol.ConnectionID, resetToken protocol.StatelessResetToken) {
+	h.assertNotClosed()
+	h.preferredAddressConnID = &newConnID{
+		SequenceNumber:      1,
+		ConnectionID:        connID,
+		StatelessResetToken: resetToken,
+	}
+}
+
+// RegisterPreferredAddressResetToken starts recognizing the stateless reset
+// token that came with the reserved connection ID. It is called when the first
+// probe carrying that ID is sent: the ID is in use from that moment, which is
+// exactly when the ordinary path-probing machinery registers its tokens, and
+// the description ties the token to the connection ID rather than to the move.
+func (h *connIDManager) RegisterPreferredAddressResetToken() {
+	if h.preferredAddressConnID == nil || h.preferredAddressTokenAdded {
+		return
+	}
+	h.preferredAddressTokenAdded = true
+	h.addStatelessResetToken(h.preferredAddressConnID.StatelessResetToken)
+}
+
+// PreferredAddressConnID returns the connection ID reserved for the preferred
+// address. It reports false once that ID has been retired or taken into use,
+// which is what stops a retired connection ID from being put back on the wire
+// by a retransmitted probe.
+func (h *connIDManager) PreferredAddressConnID() (protocol.ConnectionID, bool) {
+	h.assertNotClosed()
+	if h.preferredAddressConnID == nil {
+		return protocol.ConnectionID{}, false
+	}
+	return h.preferredAddressConnID.ConnectionID, true
+}
+
+// UsePreferredAddressConnID makes the reserved connection ID the active one and
+// retires the ID the connection was using until now. This mirrors
+// updateConnectionID, which does the same for an ordinary rotation.
+func (h *connIDManager) UsePreferredAddressConnID() bool {
+	h.assertNotClosed()
+	entry := h.preferredAddressConnID
+	if entry == nil {
+		return false
+	}
+	h.preferredAddressConnID = nil
+
+	h.queueControlFrame(&wire.RetireConnectionIDFrame{SequenceNumber: h.activeSequenceNumber})
+	// highestRetired is read by add() as "every sequence strictly below this is
+	// dead". The rotation we are undoing retired every sequence up to and
+	// including the old active one (sequence 1 excepted, and that is the one
+	// becoming active), so record the boundary as one past it. Recording the
+	// exact number instead would let a duplicate of the old active sequence back
+	// into the queue after the move.
+	h.highestRetired = max(h.highestRetired, h.activeSequenceNumber+1)
+	if h.activeStatelessResetToken != nil {
+		h.removeStatelessResetToken(*h.activeStatelessResetToken)
+	}
+	h.activeSequenceNumber = entry.SequenceNumber
+	h.activeConnectionID = entry.ConnectionID
+	h.activeStatelessResetToken = &entry.StatelessResetToken
+	h.packetsSinceLastChange = 0
+	h.packetsPerConnectionID = protocol.PacketsPerConnectionID/2 + uint32(h.rand.Int31n(protocol.PacketsPerConnectionID))
+	if !h.preferredAddressTokenAdded {
+		h.preferredAddressTokenAdded = true
+		h.addStatelessResetToken(entry.StatelessResetToken)
+	}
+	return true
+}
+
+// RetirePreferredAddressConnID hands the reserved connection ID back when the
+// preferred address will not be used after all. Nothing needs to be
+// unregistered: the ID was never used, so its reset token was never registered.
+func (h *connIDManager) RetirePreferredAddressConnID() {
+	if h.closed || h.preferredAddressConnID == nil {
+		return
+	}
+	entry := h.preferredAddressConnID
+	h.preferredAddressConnID = nil
+	// A probe may already have put the ID on the wire and registered its token;
+	// a retired ID's token stops being recognized with it.
+	if h.preferredAddressTokenAdded {
+		h.preferredAddressTokenAdded = false
+		h.removeStatelessResetToken(entry.StatelessResetToken)
+	}
+	h.queueControlFrame(&wire.RetireConnectionIDFrame{SequenceNumber: entry.SequenceNumber})
+	// One past the retired sequence, for the same reason as in
+	// UsePreferredAddressConnID: a reissue of the abandoned sequence number must
+	// read as retired, not as an ordinary addition.
+	h.highestRetired = max(h.highestRetired, entry.SequenceNumber+1)
 }
 
 func (h *connIDManager) Add(f *wire.NewConnectionIDFrame) error {
@@ -70,7 +178,15 @@ func (h *connIDManager) Add(f *wire.NewConnectionIDFrame) error {
 	if err := h.add(f); err != nil {
 		return err
 	}
-	if len(h.queue) >= protocol.MaxActiveConnectionIDs {
+	// The reserved preferred-address ID is one of the connection IDs we are
+	// storing, so it counts against the limit we advertised even though it is
+	// held outside the queue (see conn_id_generator.go, which says the limit
+	// includes the ID in preferred_address).
+	stored := len(h.queue)
+	if h.preferredAddressConnID != nil {
+		stored++
+	}
+	if stored >= protocol.MaxActiveConnectionIDs {
 		return &qerr.TransportError{ErrorCode: qerr.ConnectionIDLimitError}
 	}
 	return nil
@@ -83,9 +199,67 @@ func (h *connIDManager) add(f *wire.NewConnectionIDFrame) error {
 			ErrorMessage: "received NEW_CONNECTION_ID frame but zero-length connection IDs are in use",
 		}
 	}
+	// The connection ID reserved for the preferred address sits outside the
+	// queue, so it needs its own conflict check: the server must not hand out
+	// sequence number 1 a second time. This has to come BEFORE the reordering
+	// shortcut below. Once an ordinary rotation has moved the active sequence
+	// past 1, a repeat of the reserved frame looks stale, and retiring it would
+	// tell the server we had given up the very connection ID the preferred path
+	// is about to move with.
+	// A duplicate of the reservation is tolerated, but not returned from early:
+	// the frame may still carry a RetirePriorTo directive, and dropping that
+	// would leave the client using a connection ID the peer has retired. The
+	// flag routes the frame past the checks below that do not apply to it.
+	var reservedDuplicate bool
+	if h.preferredAddressConnID != nil && f.SequenceNumber == h.preferredAddressConnID.SequenceNumber {
+		if f.ConnectionID != h.preferredAddressConnID.ConnectionID {
+			return fmt.Errorf("received conflicting connection IDs for sequence number %d", f.SequenceNumber)
+		}
+		if f.StatelessResetToken != h.preferredAddressConnID.StatelessResetToken {
+			return fmt.Errorf("received conflicting stateless reset tokens for sequence number %d", f.SequenceNumber)
+		}
+		reservedDuplicate = true
+	}
+
+	// The reservation's retirement, also before the reordering shortcut. The
+	// ordinary manager assumes sequence numbers only advance, but a preferred
+	// address deliberately holds sequence 1 while old-path traffic rotates past
+	// it. A delayed frame whose own sequence looks stale can still carry a
+	// RetirePriorTo that retires the reservation, and taking the shortcut first
+	// would drop that retirement and let the move happen with a connection ID
+	// the server has taken back (RFC 9000, section 5.1.2).
+	if h.preferredAddressConnID != nil && h.preferredAddressConnID.SequenceNumber < f.RetirePriorTo {
+		entry := h.preferredAddressConnID
+		h.preferredAddressConnID = nil
+		// A probe may already have registered the token. It goes with the
+		// connection ID it belongs to - leaving it behind would keep routing
+		// reset-shaped packets for a retired ID to this connection for the
+		// transport's lifetime.
+		if h.preferredAddressTokenAdded {
+			h.preferredAddressTokenAdded = false
+			h.removeStatelessResetToken(entry.StatelessResetToken)
+		}
+		h.queueControlFrame(&wire.RetireConnectionIDFrame{
+			SequenceNumber: entry.SequenceNumber,
+		})
+	}
+
 	// If the NEW_CONNECTION_ID frame is reordered, such that its sequence number is smaller than the currently active
 	// connection ID or if it was already retired, send the RETIRE_CONNECTION_ID frame immediately.
-	if f.SequenceNumber < max(h.activeSequenceNumber, h.highestProbingID) || f.SequenceNumber < h.highestRetired {
+	// The active sequence itself is exempt from the retired-set clause: after the
+	// preferred-address move the active sequence steps back to 1 while
+	// highestRetired stays above it, and a network duplicate of the active
+	// connection ID is a repeat to tolerate, not a stale frame - retiring it
+	// would tell the server we had given up the connection ID in use on the new
+	// path. In ordinary operation the active sequence never trails highestRetired,
+	// so this exemption changes nothing there.
+	staleByRetired := f.SequenceNumber < h.highestRetired && f.SequenceNumber != h.activeSequenceNumber
+	// The probing clause needs the same exemption: after the move the active
+	// sequence is 1, and a path probe taken through the public API pushes
+	// highestProbingID above it, so without this a duplicate of the active
+	// frame would satisfy the max() and retire the connection ID in use.
+	staleBySequence := f.SequenceNumber < max(h.activeSequenceNumber, h.highestProbingID) && f.SequenceNumber != h.activeSequenceNumber
+	if !reservedDuplicate && (staleBySequence || staleByRetired) {
 		h.queueControlFrame(&wire.RetireConnectionIDFrame{
 			SequenceNumber: f.SequenceNumber,
 		})
@@ -122,13 +296,18 @@ func (h *connIDManager) add(f *wire.NewConnectionIDFrame) error {
 		return nil
 	}
 
-	if err := h.addConnectionID(f.SequenceNumber, f.ConnectionID, f.StatelessResetToken); err != nil {
-		return err
+	if !reservedDuplicate {
+		if err := h.addConnectionID(f.SequenceNumber, f.ConnectionID, f.StatelessResetToken); err != nil {
+			return err
+		}
 	}
 
 	// Retire the active connection ID, if necessary.
-	if h.activeSequenceNumber < f.RetirePriorTo {
-		// The queue is guaranteed to have at least one element at this point.
+	// For an ordinary frame the queue is guaranteed non-empty here, because the
+	// frame itself was just added. A duplicate of the reservation added nothing,
+	// and with nothing left to rotate onto the active ID stays where it is: the
+	// reserved ID belongs to the new path and is not a substitute.
+	if h.activeSequenceNumber < f.RetirePriorTo && len(h.queue) > 0 {
 		h.updateConnectionID()
 	}
 	return nil
@@ -202,6 +381,12 @@ func (h *connIDManager) Close() {
 		h.removeStatelessResetToken(entry.StatelessResetToken)
 	}
 	clear(h.pathProbing)
+	// An in-flight preferred-address probe registered its token too; once it
+	// becomes active the loop above covers it, but until then it has to be
+	// removed here or the transport retains the closed connection.
+	if h.preferredAddressTokenAdded && h.preferredAddressConnID != nil {
+		h.removeStatelessResetToken(h.preferredAddressConnID.StatelessResetToken)
+	}
 }
 
 // is called when the server performs a Retry
@@ -316,6 +501,12 @@ func (h *connIDManager) IsActiveStatelessResetToken(token protocol.StatelessRese
 				return true
 			}
 		}
+	}
+	// The reserved preferred-address ID is being probed too, once its token has
+	// been registered - the same recognition the entries above get.
+	if h.preferredAddressTokenAdded && h.preferredAddressConnID != nil &&
+		h.preferredAddressConnID.StatelessResetToken == token {
+		return true
 	}
 	return false
 }

--- a/connection.go
+++ b/connection.go
@@ -142,6 +142,9 @@ type Conn struct {
 	pathManager         *pathManager
 	largestRcvdAppData  protocol.PacketNumber
 	pathManagerOutgoing atomic.Pointer[pathManagerOutgoing]
+	// The client's move to the address the server asked it to use.
+	// Only set on clients, and only touched from the run loop.
+	preferredAddress *preferredAddressMigration
 
 	streamsMap      *streamsMap
 	connIDManager   *connIDManager
@@ -986,6 +989,7 @@ func (c *Conn) handleHandshakeConfirmed(now monotime.Time) error {
 
 	c.handshakeConfirmed = true
 	c.cryptoStreamHandler.SetHandshakeConfirmed()
+	c.startPreferredAddressMigration()
 
 	if !c.config.DisablePathMTUDiscovery && c.conn.capabilities().DF {
 		c.mtuDiscoverer.Start(now)
@@ -1250,7 +1254,7 @@ func (c *Conn) handleShortHeaderPacket(
 			})
 		}
 	}
-	isNonProbing, pathChallenge, err := c.handleUnpackedShortHeaderPacket(destConnID, pn, data, p.ecn, p.rcvTime, log)
+	isNonProbing, pathChallenge, err := c.handleUnpackedShortHeaderPacket(destConnID, pn, data, p.ecn, p.rcvTime, log, p.remoteAddr)
 	if err != nil {
 		return false, err
 	}
@@ -1379,7 +1383,7 @@ func (c *Conn) handleLongHeaderPacket(p receivedPacket, hdr *wire.Header, datagr
 		return false, nil
 	}
 
-	if err := c.handleUnpackedLongHeaderPacket(packet, p.ecn, p.rcvTime, datagramPayloadChecksum, p.Size()); err != nil {
+	if err := c.handleUnpackedLongHeaderPacket(packet, p.ecn, p.rcvTime, datagramPayloadChecksum, p.Size(), p.remoteAddr); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -1641,6 +1645,7 @@ func (c *Conn) handleUnpackedLongHeaderPacket(
 	rcvTime monotime.Time,
 	datagramPayloadChecksum qlog.DatagramPayloadChecksum, // only for logging
 	packetSize protocol.ByteCount, // only for logging
+	remoteAddr net.Addr,
 ) error {
 	if !c.receivedFirstPacket {
 		c.receivedFirstPacket = true
@@ -1729,7 +1734,7 @@ func (c *Conn) handleUnpackedLongHeaderPacket(
 			})
 		}
 	}
-	isAckEliciting, _, _, err := c.handleFrames(packet.data, packet.hdr.DestConnectionID, packet.encryptionLevel, log, rcvTime)
+	isAckEliciting, _, _, err := c.handleFrames(packet.data, packet.hdr.DestConnectionID, packet.encryptionLevel, log, rcvTime, remoteAddr)
 	if err != nil {
 		return err
 	}
@@ -1744,12 +1749,13 @@ func (c *Conn) handleUnpackedShortHeaderPacket(
 	ecn protocol.ECN,
 	rcvTime monotime.Time,
 	log func([]qlog.Frame),
+	remoteAddr net.Addr,
 ) (isNonProbing bool, pathChallenge *wire.PathChallengeFrame, _ error) {
 	c.lastPacketReceivedTime = rcvTime
 	c.firstAckElicitingPacketAfterIdleSentTime = 0
 	c.keepAlivePingSent = false
 
-	isAckEliciting, isNonProbing, pathChallenge, err := c.handleFrames(data, destConnID, protocol.Encryption1RTT, log, rcvTime)
+	isAckEliciting, isNonProbing, pathChallenge, err := c.handleFrames(data, destConnID, protocol.Encryption1RTT, log, rcvTime, remoteAddr)
 	if err != nil {
 		return false, nil, err
 	}
@@ -1757,6 +1763,10 @@ func (c *Conn) handleUnpackedShortHeaderPacket(
 	if err := c.receivedPacketHandler.ReceivedPacket(pn, ecn, protocol.Encryption1RTT, rcvTime, isAckEliciting); err != nil {
 		return false, nil, err
 	}
+	// Every frame of this packet has been processed; a response recorded during
+	// parsing may now move the connection, unless something later in the packet
+	// took the reserved connection ID away.
+	c.commitPreferredAddressMove(rcvTime)
 	return isNonProbing, pathChallenge, nil
 }
 
@@ -1768,6 +1778,7 @@ func (c *Conn) handleFrames(
 	encLevel protocol.EncryptionLevel,
 	log func([]qlog.Frame),
 	rcvTime monotime.Time,
+	remoteAddr net.Addr,
 ) (isAckEliciting, isNonProbing bool, pathChallenge *wire.PathChallengeFrame, _ error) {
 	// Only used for tracing.
 	// If we're not tracing, this slice will always remain empty.
@@ -1861,7 +1872,7 @@ func (c *Conn) handleFrames(
 			if skipHandling {
 				continue
 			}
-			pc, err := c.handleFrame(frame, encLevel, destConnID, rcvTime)
+			pc, err := c.handleFrame(frame, encLevel, destConnID, rcvTime, remoteAddr)
 			if pc != nil {
 				pathChallenge = pc
 			}
@@ -1901,6 +1912,7 @@ func (c *Conn) handleFrame(
 	encLevel protocol.EncryptionLevel,
 	destConnID protocol.ConnectionID,
 	rcvTime monotime.Time,
+	remoteAddr net.Addr,
 ) (pathChallenge *wire.PathChallengeFrame, _ error) {
 	var err error
 	wire.LogFrame(c.logger, f, false)
@@ -1928,7 +1940,7 @@ func (c *Conn) handleFrame(
 		c.handlePathChallengeFrame(frame)
 		pathChallenge = frame
 	case *wire.PathResponseFrame:
-		err = c.handlePathResponseFrame(frame)
+		err = c.handlePathResponseFrame(frame, remoteAddr)
 	case *wire.NewTokenFrame:
 		err = c.handleNewTokenFrame(frame)
 	case *wire.NewConnectionIDFrame:
@@ -2052,10 +2064,10 @@ func (c *Conn) handlePathChallengeFrame(f *wire.PathChallengeFrame) {
 	}
 }
 
-func (c *Conn) handlePathResponseFrame(f *wire.PathResponseFrame) error {
+func (c *Conn) handlePathResponseFrame(f *wire.PathResponseFrame, remoteAddr net.Addr) error {
 	switch c.perspective {
 	case protocol.PerspectiveClient:
-		return c.handlePathResponseFrameClient(f)
+		return c.handlePathResponseFrameClient(f, remoteAddr)
 	case protocol.PerspectiveServer:
 		return c.handlePathResponseFrameServer(f)
 	default:
@@ -2063,7 +2075,10 @@ func (c *Conn) handlePathResponseFrame(f *wire.PathResponseFrame) error {
 	}
 }
 
-func (c *Conn) handlePathResponseFrameClient(f *wire.PathResponseFrame) error {
+func (c *Conn) handlePathResponseFrameClient(f *wire.PathResponseFrame, remoteAddr net.Addr) error {
+	if c.handlePreferredAddressResponse(f, remoteAddr) {
+		return nil
+	}
 	pm := c.pathManagerOutgoing.Load()
 	if pm == nil {
 		return &qerr.TransportError{
@@ -2431,9 +2446,10 @@ func (c *Conn) applyTransportParameters() {
 	if params.StatelessResetToken != nil {
 		c.connIDManager.SetStatelessResetToken(*params.StatelessResetToken)
 	}
-	// We don't support connection migration yet, so we don't have any use for the preferred_address.
+	// The connection ID that arrives with the preferred address belongs to that
+	// path. It is set aside until the path has been validated, which cannot
+	// happen before the handshake is confirmed.
 	if params.PreferredAddress != nil {
-		// Retire the connection ID.
 		c.connIDManager.AddFromPreferredAddress(params.PreferredAddress.ConnectionID, params.PreferredAddress.StatelessResetToken)
 	}
 	maxPacketSize := protocol.ByteCount(protocol.MaxPacketBufferSize)
@@ -2452,6 +2468,28 @@ func (c *Conn) triggerSending(now monotime.Time) error {
 	c.pacingDeadline = 0
 
 	sendMode := c.sentPacketHandler.SendMode(now)
+
+	// An armed preferred-address probe goes out ahead of the send-mode switch.
+	// The mode reflects congestion on the path the connection is still using,
+	// and the probe is how it leaves that path: it is packed as a path probe,
+	// accounted outside bytes in flight, and written directly rather than
+	// through the send queue. Letting only SendAny through would leave a
+	// congestion window full of old-path data starving the probe indefinitely,
+	// so the probe is allowed under every mode EXCEPT SendNone: SendNone is the
+	// hard stop that caps the number of tracked sent packets, and a probe is a
+	// tracked packet like any other.
+	if sendMode != ackhandler.SendNone && c.perspective == protocol.PerspectiveClient && c.handshakeConfirmed {
+		sent, err := c.sendPreferredAddressProbe(now)
+		if err != nil {
+			return err
+		}
+		if sent {
+			// There's (likely) more data to send. Loop around again.
+			c.scheduleSending()
+			return nil
+		}
+	}
+
 	switch sendMode {
 	case ackhandler.SendAny:
 		return c.sendPackets(now)

--- a/connection_test.go
+++ b/connection_test.go
@@ -230,7 +230,7 @@ func TestConnectionHandleStreamRelatedFrames(t *testing.T) {
 			tc := newServerTestConnection(t, gomock.NewController(t), nil, false)
 			data, err := test.frame.Append(nil, protocol.Version1)
 			require.NoError(t, err)
-			_, _, _, err = tc.conn.handleFrames(data, connID, protocol.Encryption1RTT, nil, monotime.Now())
+			_, _, _, err = tc.conn.handleFrames(data, connID, protocol.Encryption1RTT, nil, monotime.Now(), tc.conn.RemoteAddr())
 			require.ErrorIs(t, err, &qerr.TransportError{ErrorCode: qerr.StreamStateError})
 		})
 	}
@@ -244,11 +244,11 @@ func TestConnectionHandleConnectionFlowControlFrames(t *testing.T) {
 	now := monotime.Now()
 	connID := protocol.ConnectionID{}
 	// MAX_DATA frame
-	_, err := tc.conn.handleFrame(&wire.MaxDataFrame{MaximumData: 1337}, protocol.Encryption1RTT, connID, now)
+	_, err := tc.conn.handleFrame(&wire.MaxDataFrame{MaximumData: 1337}, protocol.Encryption1RTT, connID, now, tc.conn.RemoteAddr())
 	require.NoError(t, err)
 	require.Equal(t, protocol.ByteCount(1337), connFC.SendWindowSize())
 	// DATA_BLOCKED frame
-	_, err = tc.conn.handleFrame(&wire.DataBlockedFrame{MaximumData: 1337}, protocol.Encryption1RTT, connID, now)
+	_, err = tc.conn.handleFrame(&wire.DataBlockedFrame{MaximumData: 1337}, protocol.Encryption1RTT, connID, now, tc.conn.RemoteAddr())
 	require.NoError(t, err)
 }
 
@@ -265,7 +265,7 @@ func TestConnectionServerInvalidFrames(t *testing.T) {
 		{Name: "PATH_RESPONSE", Frame: &wire.PathResponseFrame{Data: [8]byte{1, 2, 3, 4, 5, 6, 7, 8}}},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			_, err := tc.conn.handleFrame(test.Frame, protocol.Encryption1RTT, protocol.ConnectionID{}, monotime.Now())
+			_, err := tc.conn.handleFrame(test.Frame, protocol.Encryption1RTT, protocol.ConnectionID{}, monotime.Now(), tc.conn.RemoteAddr())
 			require.ErrorIs(t, err, &qerr.TransportError{ErrorCode: qerr.ProtocolViolation})
 		})
 	}
@@ -1117,6 +1117,7 @@ func TestConnectionHandleMaxStreamsFrame(t *testing.T) {
 			protocol.Encryption1RTT,
 			protocol.ConnectionID{},
 			monotime.Now(),
+			tc.conn.RemoteAddr(),
 		)
 		require.NoError(t, err)
 
@@ -1140,6 +1141,7 @@ func TestConnectionHandleMaxStreamsFrame(t *testing.T) {
 			protocol.Encryption1RTT,
 			protocol.ConnectionID{},
 			monotime.Now(),
+			tc.conn.RemoteAddr(),
 		)
 		require.NoError(t, err)
 
@@ -1419,6 +1421,39 @@ func testConnectionHandshakeClient(t *testing.T, usePreferredAddress bool) {
 	require.True(t, mockCtrl.Satisfied())
 	// the handshake isn't confirmed until we receive a HANDSHAKE_DONE frame from the server
 
+	// Confirming the handshake starts the move to the server's preferred address.
+	// The PATH_CHALLENGE goes out on the socket the connection is already using,
+	// addressed to the preferred address.
+	probedAddr := make(chan net.Addr, 1)
+	pathChallenges := make(chan [8]byte, 1)
+	if usePreferredAddress {
+		// The stateless reset token is registered when the offered connection
+		// ID first goes on the wire, i.e. with the first probe.
+		tc.connRunner.EXPECT().AddResetToken(preferredAddressResetToken, gomock.Any())
+		tc.packer.EXPECT().PackPathProbePacket(preferredAddressConnID, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ protocol.ConnectionID, frames []ackhandler.Frame, _ protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
+				for _, f := range frames {
+					if pc, ok := f.Frame.(*wire.PathChallengeFrame); ok {
+						select {
+						case pathChallenges <- pc.Data:
+						default:
+						}
+					}
+				}
+				return shortHeaderPacket{PacketNumber: 1, Frames: frames, Length: 1200, IsPathProbePacket: true}, getPacketBuffer(), nil
+			},
+		).AnyTimes()
+		tc.sendConn.EXPECT().WriteTo(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ []byte, addr net.Addr, _ packetInfo) error {
+				select {
+				case probedAddr <- addr:
+				default:
+				}
+				return nil
+			},
+		).AnyTimes()
+	}
+
 	data, err = (&wire.HandshakeDoneFrame{}).Append(nil, protocol.Version1)
 	require.NoError(t, err)
 	done := make(chan struct{})
@@ -1447,11 +1482,49 @@ func testConnectionHandshakeClient(t *testing.T, usePreferredAddress bool) {
 	}
 
 	if usePreferredAddress {
-		tc.connRunner.EXPECT().AddResetToken(preferredAddressResetToken, gomock.Any())
-	}
-	nextConnID := tc.conn.connIDManager.Get()
-	if usePreferredAddress {
-		require.Equal(t, preferredAddressConnID, nextConnID)
+		select {
+		case addr := <-probedAddr:
+			require.Equal(t, "127.0.0.1:42", addr.String())
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for the preferred address to be probed")
+		}
+		// The connection ID that came with the preferred address belongs to that
+		// path. Until the path has been validated it is only reserved, so the
+		// active connection ID is still the one from the handshake.
+		require.NotEqual(t, preferredAddressConnID, tc.conn.connIDManager.Get())
+
+		var pathChallenge [8]byte
+		select {
+		case pathChallenge = <-pathChallenges:
+		case <-time.After(time.Second):
+			t.Fatal("timeout")
+		}
+		// Answering the PATH_CHALLENGE validates the path: the connection moves
+		// to the preferred address and starts using the connection ID offered
+		// alongside it.
+		movedTo := make(chan net.Addr, 1)
+		tc.sendConn.EXPECT().ChangeRemoteAddr(gomock.Any(), gomock.Any()).Do(
+			func(addr net.Addr, _ packetInfo) { movedTo <- addr },
+		)
+		frameData, err := (&wire.PathResponseFrame{Data: pathChallenge}).Append(nil, protocol.Version1)
+		require.NoError(t, err)
+		unpacker.EXPECT().UnpackShortHeader(gomock.Any(), gomock.Any()).Return(
+			protocol.PacketNumber(3), protocol.PacketNumberLen2, protocol.KeyPhaseOne, frameData, nil,
+		)
+		// The answer arrives from the preferred address, which is the path the
+		// PATH_CHALLENGE was sent to and the only one that can validate it.
+		preferredAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:42")
+		require.NoError(t, err)
+		tc.conn.handlePacket(getShortHeaderPacket(t, preferredAddr, tc.srcConnID, 3, nil))
+		select {
+		case addr := <-movedTo:
+			require.Equal(t, "127.0.0.1:42", addr.String())
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for the connection to move")
+		}
+		require.Equal(t, preferredAddressConnID, tc.conn.connIDManager.Get())
+	} else {
+		tc.conn.connIDManager.Get()
 	}
 
 	// test teardown
@@ -3442,7 +3515,7 @@ func testConnectionMigration(t *testing.T, enabled bool) {
 	_, err = tc.conn.handleFrame(&wire.NewConnectionIDFrame{
 		SequenceNumber: 1,
 		ConnectionID:   protocol.ParseConnectionID([]byte{1, 2, 3, 4}),
-	}, protocol.EncryptionInitial, tc.destConnID, monotime.Now())
+	}, protocol.EncryptionInitial, tc.destConnID, monotime.Now(), tc.conn.RemoteAddr())
 	require.NoError(t, err)
 	errChan := make(chan error, 1)
 	go func() { errChan <- tc.conn.run() }()
@@ -3490,7 +3563,7 @@ func testConnectionDatagrams(t *testing.T, enabled bool) {
 	require.NoError(t, err)
 	data, err = (&wire.DatagramFrame{Data: []byte("bar")}).Append(data, protocol.Version1)
 	require.NoError(t, err)
-	_, _, _, err = tc.conn.handleFrames(data, protocol.ConnectionID{}, protocol.Encryption1RTT, nil, monotime.Now())
+	_, _, _, err = tc.conn.handleFrames(data, protocol.ConnectionID{}, protocol.Encryption1RTT, nil, monotime.Now(), tc.conn.RemoteAddr())
 
 	if !enabled {
 		require.ErrorIs(t, err, &qerr.TransportError{ErrorCode: qerr.FrameEncodingError, FrameType: uint64(wire.FrameTypeDatagramWithLength)})
@@ -3506,4 +3579,184 @@ func testConnectionDatagrams(t *testing.T, enabled bool) {
 	d, err = tc.conn.ReceiveDatagram(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []byte("bar"), d)
+}
+
+// A packet from the preferred address may legally carry the matching
+// PATH_RESPONSE and, later in the same packet, a NEW_CONNECTION_ID retiring
+// the reserved sequence-1 connection ID. The retirement happened before the
+// connection moved, so the move must not happen: the migration decision is
+// committed only once every frame of the packet has been processed.
+func TestConnectionPreferredAddressSamePacketRetirement(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	unpacker := NewMockUnpacker(mockCtrl)
+	tc := newClientTestConnection(t, mockCtrl, nil, false, connectionOptUnpacker(unpacker))
+
+	preferredConnID := protocol.ParseConnectionID([]byte{10, 8, 6, 4})
+	preferredToken := protocol.StatelessResetToken{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+
+	probed := make(chan [8]byte, 1)
+	tc.packer.EXPECT().PackPathProbePacket(preferredConnID, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ protocol.ConnectionID, frames []ackhandler.Frame, _ protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
+			for _, f := range frames {
+				if pc, ok := f.Frame.(*wire.PathChallengeFrame); ok {
+					select {
+					case probed <- pc.Data:
+					default:
+					}
+				}
+			}
+			return shortHeaderPacket{PacketNumber: 1, Frames: frames, Length: 1200, IsPathProbePacket: true}, getPacketBuffer(), nil
+		},
+	).AnyTimes()
+	tc.packer.EXPECT().PackCoalescedPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	tc.packer.EXPECT().PackAckOnlyPacket(gomock.Any(), gomock.Any(), gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
+	tc.packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(shortHeaderPacket{}, errNothingToPack).AnyTimes()
+	tc.sendConn.EXPECT().WriteTo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	tc.sendConn.EXPECT().Write(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	tc.connRunner.EXPECT().AddResetToken(gomock.Any(), gomock.Any()).AnyTimes()
+	tc.connRunner.EXPECT().RemoveResetToken(gomock.Any()).AnyTimes()
+	tc.connRunner.EXPECT().Remove(gomock.Any()).AnyTimes()
+	tc.connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	moved := make(chan net.Addr, 1)
+	tc.sendConn.EXPECT().ChangeRemoteAddr(gomock.Any(), gomock.Any()).Do(
+		func(addr net.Addr, _ packetInfo) { moved <- addr },
+	).AnyTimes()
+
+	require.NoError(t, tc.conn.handleTransportParameters(&wire.TransportParameters{
+		InitialSourceConnectionID:       tc.destConnID,
+		OriginalDestinationConnectionID: tc.destConnID,
+		ActiveConnectionIDLimit:         protocol.MaxActiveConnectionIDs,
+		PreferredAddress: &wire.PreferredAddress{
+			IPv4:                netip.AddrPortFrom(netip.AddrFrom4([4]byte{127, 0, 0, 1}), 42),
+			ConnectionID:        preferredConnID,
+			StatelessResetToken: preferredToken,
+		},
+	}))
+	tc.conn.applyTransportParameters()
+	tc.conn.handshakeComplete = true
+	tc.conn.handshakeConfirmed = true
+	tc.conn.connIDManager.SetHandshakeComplete()
+	require.NoError(t, tc.conn.handleHandshakeConfirmed(monotime.Now()))
+
+	errChan := make(chan error, 1)
+	go func() { errChan <- tc.conn.run() }()
+
+	var pathChallenge [8]byte
+	select {
+	case pathChallenge = <-probed:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for the preferred-address probe")
+	}
+
+	// Response first, retirement second, one packet, from the preferred address.
+	frameData, err := (&wire.PathResponseFrame{Data: pathChallenge}).Append(nil, protocol.Version1)
+	require.NoError(t, err)
+	frameData, err = (&wire.NewConnectionIDFrame{
+		SequenceNumber:      2,
+		RetirePriorTo:       2,
+		ConnectionID:        protocol.ParseConnectionID([]byte{7, 7, 7, 7}),
+		StatelessResetToken: protocol.StatelessResetToken{7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7},
+	}).Append(frameData, protocol.Version1)
+	require.NoError(t, err)
+	unpacker.EXPECT().UnpackShortHeader(gomock.Any(), gomock.Any()).Return(
+		protocol.PacketNumber(3), protocol.PacketNumberLen2, protocol.KeyPhaseOne, frameData, nil,
+	)
+	preferredUDPAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:42")
+	require.NoError(t, err)
+	tc.conn.handlePacket(getShortHeaderPacket(t, preferredUDPAddr, tc.srcConnID, 3, nil))
+
+	select {
+	case addr := <-moved:
+		t.Fatalf("the connection moved to %s although the same packet retired the connection ID the move depends on", addr)
+	case err := <-errChan:
+		t.Fatalf("connection died: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	tc.conn.destroy(nil)
+	select {
+	case <-errChan:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for run loop to return")
+	}
+}
+
+// A confirmed client whose congestion controller refuses ordinary sends must
+// still probe the server's preferred address. The probe is a path probe,
+// accounted outside bytes in flight, so congestion on the path being left does
+// not gate it.
+func TestConnectionPreferredAddressProbeWhenCongestionLimited(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		sph := mockackhandler.NewMockSentPacketHandler(mockCtrl)
+		tc := newClientTestConnection(t, mockCtrl, nil, false,
+			connectionOptSentPacketHandler(sph),
+		)
+
+		preferredConnID := protocol.ParseConnectionID([]byte{10, 8, 6, 4})
+		preferredToken := protocol.StatelessResetToken{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+
+		// The congestion controller never allows ordinary sends.
+		sph.EXPECT().SendMode(gomock.Any()).Return(ackhandler.SendAck).AnyTimes()
+		sph.EXPECT().GetLossDetectionTimeout().Return(monotime.Now().Add(time.Hour)).AnyTimes()
+		sph.EXPECT().ECNMode(gomock.Any()).Return(protocol.ECNNon).AnyTimes()
+		sph.EXPECT().DropPackets(gomock.Any(), gomock.Any()).AnyTimes()
+		sph.EXPECT().SentPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+		probed := make(chan [8]byte, 1)
+		tc.packer.EXPECT().PackPathProbePacket(preferredConnID, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ protocol.ConnectionID, frames []ackhandler.Frame, _ protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
+				for _, f := range frames {
+					if pc, ok := f.Frame.(*wire.PathChallengeFrame); ok {
+						select {
+						case probed <- pc.Data:
+						default:
+						}
+					}
+				}
+				return shortHeaderPacket{PacketNumber: 1, Frames: frames, Length: 1200, IsPathProbePacket: true}, getPacketBuffer(), nil
+			},
+		).AnyTimes()
+		tc.packer.EXPECT().PackAckOnlyPacket(gomock.Any(), gomock.Any(), gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
+		tc.sendConn.EXPECT().WriteTo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		tc.connRunner.EXPECT().AddResetToken(gomock.Any(), gomock.Any()).AnyTimes()
+		tc.connRunner.EXPECT().RemoveResetToken(gomock.Any()).AnyTimes()
+		tc.connRunner.EXPECT().Remove(gomock.Any()).AnyTimes()
+		tc.connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+		require.NoError(t, tc.conn.handleTransportParameters(&wire.TransportParameters{
+			InitialSourceConnectionID:       tc.destConnID,
+			OriginalDestinationConnectionID: tc.destConnID,
+			ActiveConnectionIDLimit:         protocol.MaxActiveConnectionIDs,
+			PreferredAddress: &wire.PreferredAddress{
+				IPv4:                netip.AddrPortFrom(netip.AddrFrom4([4]byte{127, 0, 0, 1}), 42),
+				ConnectionID:        preferredConnID,
+				StatelessResetToken: preferredToken,
+			},
+		}))
+		tc.conn.applyTransportParameters()
+		tc.conn.handshakeComplete = true
+		tc.conn.connIDManager.SetHandshakeComplete()
+		require.NoError(t, tc.conn.handleHandshakeConfirmed(monotime.Now()))
+
+		errChan := make(chan error, 1)
+		go func() { errChan <- tc.conn.run() }()
+		synctest.Wait()
+
+		select {
+		case <-probed:
+		default:
+			t.Fatal("the preferred address should have been probed despite the congestion limit")
+		}
+
+		// test teardown
+		tc.conn.destroy(nil)
+		synctest.Wait()
+		select {
+		case <-errChan:
+		default:
+			t.Fatal("run should have returned")
+		}
+	})
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -3587,98 +3587,103 @@ func testConnectionDatagrams(t *testing.T, enabled bool) {
 // connection moved, so the move must not happen: the migration decision is
 // committed only once every frame of the packet has been processed.
 func TestConnectionPreferredAddressSamePacketRetirement(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	unpacker := NewMockUnpacker(mockCtrl)
-	tc := newClientTestConnection(t, mockCtrl, nil, false, connectionOptUnpacker(unpacker))
+	synctest.Test(t, func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		unpacker := NewMockUnpacker(mockCtrl)
+		tc := newClientTestConnection(t, mockCtrl, nil, false, connectionOptUnpacker(unpacker))
 
-	preferredConnID := protocol.ParseConnectionID([]byte{10, 8, 6, 4})
-	preferredToken := protocol.StatelessResetToken{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+		preferredConnID := protocol.ParseConnectionID([]byte{10, 8, 6, 4})
+		preferredToken := protocol.StatelessResetToken{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
 
-	probed := make(chan [8]byte, 1)
-	tc.packer.EXPECT().PackPathProbePacket(preferredConnID, gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ protocol.ConnectionID, frames []ackhandler.Frame, _ protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
-			for _, f := range frames {
-				if pc, ok := f.Frame.(*wire.PathChallengeFrame); ok {
-					select {
-					case probed <- pc.Data:
-					default:
+		probed := make(chan [8]byte, 1)
+		tc.packer.EXPECT().PackPathProbePacket(preferredConnID, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ protocol.ConnectionID, frames []ackhandler.Frame, _ protocol.Version) (shortHeaderPacket, *packetBuffer, error) {
+				for _, f := range frames {
+					if pc, ok := f.Frame.(*wire.PathChallengeFrame); ok {
+						select {
+						case probed <- pc.Data:
+						default:
+						}
 					}
 				}
-			}
-			return shortHeaderPacket{PacketNumber: 1, Frames: frames, Length: 1200, IsPathProbePacket: true}, getPacketBuffer(), nil
-		},
-	).AnyTimes()
-	tc.packer.EXPECT().PackCoalescedPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	tc.packer.EXPECT().PackAckOnlyPacket(gomock.Any(), gomock.Any(), gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
-	tc.packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(shortHeaderPacket{}, errNothingToPack).AnyTimes()
-	tc.sendConn.EXPECT().WriteTo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	tc.sendConn.EXPECT().Write(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	tc.connRunner.EXPECT().AddResetToken(gomock.Any(), gomock.Any()).AnyTimes()
-	tc.connRunner.EXPECT().RemoveResetToken(gomock.Any()).AnyTimes()
-	tc.connRunner.EXPECT().Remove(gomock.Any()).AnyTimes()
-	tc.connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	moved := make(chan net.Addr, 1)
-	tc.sendConn.EXPECT().ChangeRemoteAddr(gomock.Any(), gomock.Any()).Do(
-		func(addr net.Addr, _ packetInfo) { moved <- addr },
-	).AnyTimes()
+				return shortHeaderPacket{PacketNumber: 1, Frames: frames, Length: 1200, IsPathProbePacket: true}, getPacketBuffer(), nil
+			},
+		).AnyTimes()
+		tc.packer.EXPECT().PackCoalescedPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		tc.packer.EXPECT().PackAckOnlyPacket(gomock.Any(), gomock.Any(), gomock.Any()).Return(shortHeaderPacket{}, nil, errNothingToPack).AnyTimes()
+		tc.packer.EXPECT().AppendPacket(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(shortHeaderPacket{}, errNothingToPack).AnyTimes()
+		tc.sendConn.EXPECT().WriteTo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		tc.sendConn.EXPECT().Write(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		tc.connRunner.EXPECT().AddResetToken(gomock.Any(), gomock.Any()).AnyTimes()
+		tc.connRunner.EXPECT().RemoveResetToken(gomock.Any()).AnyTimes()
+		tc.connRunner.EXPECT().Remove(gomock.Any()).AnyTimes()
+		tc.connRunner.EXPECT().ReplaceWithClosed(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		moved := make(chan net.Addr, 1)
+		tc.sendConn.EXPECT().ChangeRemoteAddr(gomock.Any(), gomock.Any()).Do(
+			func(addr net.Addr, _ packetInfo) { moved <- addr },
+		).AnyTimes()
 
-	require.NoError(t, tc.conn.handleTransportParameters(&wire.TransportParameters{
-		InitialSourceConnectionID:       tc.destConnID,
-		OriginalDestinationConnectionID: tc.destConnID,
-		ActiveConnectionIDLimit:         protocol.MaxActiveConnectionIDs,
-		PreferredAddress: &wire.PreferredAddress{
-			IPv4:                netip.AddrPortFrom(netip.AddrFrom4([4]byte{127, 0, 0, 1}), 42),
-			ConnectionID:        preferredConnID,
-			StatelessResetToken: preferredToken,
-		},
-	}))
-	tc.conn.applyTransportParameters()
-	tc.conn.handshakeComplete = true
-	tc.conn.handshakeConfirmed = true
-	tc.conn.connIDManager.SetHandshakeComplete()
-	require.NoError(t, tc.conn.handleHandshakeConfirmed(monotime.Now()))
+		require.NoError(t, tc.conn.handleTransportParameters(&wire.TransportParameters{
+			InitialSourceConnectionID:       tc.destConnID,
+			OriginalDestinationConnectionID: tc.destConnID,
+			ActiveConnectionIDLimit:         protocol.MaxActiveConnectionIDs,
+			PreferredAddress: &wire.PreferredAddress{
+				IPv4:                netip.AddrPortFrom(netip.AddrFrom4([4]byte{127, 0, 0, 1}), 42),
+				ConnectionID:        preferredConnID,
+				StatelessResetToken: preferredToken,
+			},
+		}))
+		tc.conn.applyTransportParameters()
+		tc.conn.handshakeComplete = true
+		tc.conn.handshakeConfirmed = true
+		tc.conn.connIDManager.SetHandshakeComplete()
+		require.NoError(t, tc.conn.handleHandshakeConfirmed(monotime.Now()))
 
-	errChan := make(chan error, 1)
-	go func() { errChan <- tc.conn.run() }()
+		errChan := make(chan error, 1)
+		go func() { errChan <- tc.conn.run() }()
 
-	var pathChallenge [8]byte
-	select {
-	case pathChallenge = <-probed:
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for the preferred-address probe")
-	}
+		synctest.Wait()
+		var pathChallenge [8]byte
+		select {
+		case pathChallenge = <-probed:
+		default:
+			t.Fatal("the preferred-address probe was not sent")
+		}
 
-	// Response first, retirement second, one packet, from the preferred address.
-	frameData, err := (&wire.PathResponseFrame{Data: pathChallenge}).Append(nil, protocol.Version1)
-	require.NoError(t, err)
-	frameData, err = (&wire.NewConnectionIDFrame{
-		SequenceNumber:      2,
-		RetirePriorTo:       2,
-		ConnectionID:        protocol.ParseConnectionID([]byte{7, 7, 7, 7}),
-		StatelessResetToken: protocol.StatelessResetToken{7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7},
-	}).Append(frameData, protocol.Version1)
-	require.NoError(t, err)
-	unpacker.EXPECT().UnpackShortHeader(gomock.Any(), gomock.Any()).Return(
-		protocol.PacketNumber(3), protocol.PacketNumberLen2, protocol.KeyPhaseOne, frameData, nil,
-	)
-	preferredUDPAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:42")
-	require.NoError(t, err)
-	tc.conn.handlePacket(getShortHeaderPacket(t, preferredUDPAddr, tc.srcConnID, 3, nil))
+		// Response first, retirement second, one packet, from the preferred address.
+		frameData, err := (&wire.PathResponseFrame{Data: pathChallenge}).Append(nil, protocol.Version1)
+		require.NoError(t, err)
+		frameData, err = (&wire.NewConnectionIDFrame{
+			SequenceNumber:      2,
+			RetirePriorTo:       2,
+			ConnectionID:        protocol.ParseConnectionID([]byte{7, 7, 7, 7}),
+			StatelessResetToken: protocol.StatelessResetToken{7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7},
+		}).Append(frameData, protocol.Version1)
+		require.NoError(t, err)
+		unpacker.EXPECT().UnpackShortHeader(gomock.Any(), gomock.Any()).Return(
+			protocol.PacketNumber(3), protocol.PacketNumberLen2, protocol.KeyPhaseOne, frameData, nil,
+		)
+		preferredUDPAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:42")
+		require.NoError(t, err)
+		tc.conn.handlePacket(getShortHeaderPacket(t, preferredUDPAddr, tc.srcConnID, 3, nil))
 
-	select {
-	case addr := <-moved:
-		t.Fatalf("the connection moved to %s although the same packet retired the connection ID the move depends on", addr)
-	case err := <-errChan:
-		t.Fatalf("connection died: %v", err)
-	case <-time.After(500 * time.Millisecond):
-	}
+		synctest.Wait()
+		select {
+		case addr := <-moved:
+			t.Fatalf("the connection moved to %s although the same packet retired the connection ID the move depends on", addr)
+		case err := <-errChan:
+			t.Fatalf("connection died: %v", err)
+		default:
+		}
 
-	tc.conn.destroy(nil)
-	select {
-	case <-errChan:
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for run loop to return")
-	}
+		tc.conn.destroy(nil)
+		synctest.Wait()
+		select {
+		case <-errChan:
+		default:
+			t.Fatal("the run loop did not return")
+		}
+	})
 }
 
 // A confirmed client whose congestion controller refuses ordinary sends must

--- a/mock_sender_test.go
+++ b/mock_sender_test.go
@@ -115,6 +115,42 @@ func (c *MockSenderCloseCall) DoAndReturn(f func()) *MockSenderCloseCall {
 	return c
 }
 
+// CloseAndDiscard mocks base method.
+func (m *MockSender) CloseAndDiscard() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CloseAndDiscard")
+}
+
+// CloseAndDiscard indicates an expected call of CloseAndDiscard.
+func (mr *MockSenderMockRecorder) CloseAndDiscard() *MockSenderCloseAndDiscardCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseAndDiscard", reflect.TypeOf((*MockSender)(nil).CloseAndDiscard))
+	return &MockSenderCloseAndDiscardCall{Call: call}
+}
+
+// MockSenderCloseAndDiscardCall wrap *gomock.Call
+type MockSenderCloseAndDiscardCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockSenderCloseAndDiscardCall) Return() *MockSenderCloseAndDiscardCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockSenderCloseAndDiscardCall) Do(f func()) *MockSenderCloseAndDiscardCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockSenderCloseAndDiscardCall) DoAndReturn(f func()) *MockSenderCloseAndDiscardCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Run mocks base method.
 func (m *MockSender) Run() error {
 	m.ctrl.T.Helper()

--- a/preferred_address.go
+++ b/preferred_address.go
@@ -1,0 +1,304 @@
+package quic
+
+import (
+	"crypto/rand"
+	"net"
+	"net/netip"
+	"slices"
+
+	"github.com/quic-go/quic-go/internal/ackhandler"
+	"github.com/quic-go/quic-go/internal/monotime"
+	"github.com/quic-go/quic-go/internal/protocol"
+	"github.com/quic-go/quic-go/internal/wire"
+)
+
+// The number of PATH_CHALLENGE frames the client is willing to send to the
+// server's preferred address before it concludes that nothing is listening
+// there and stays on the path it is already using.
+const maxPreferredAddressProbes = 3
+
+// preferredAddressMigration tracks the client's move to the address the server
+// asked it to use (RFC 9000, section 9.6).
+//
+// The outgoing path manager models a change of local socket, which is the wrong
+// shape here: the socket stays put and it is the peer's address that changes.
+// The state machine is otherwise the same one - probe, wait for the matching
+// PATH_RESPONSE, then switch - so it keeps the same shape as pathOutgoing.
+//
+// It is only ever touched from the connection's run loop.
+type preferredAddressMigration struct {
+	addr net.Addr
+	// The data of every PATH_CHALLENGE sent for this migration. Retransmissions
+	// use fresh data (RFC 9000, section 8.2.1), and a PATH_RESPONSE answering
+	// any of them validates the path. The list is kept after validation so that
+	// a duplicate PATH_RESPONSE is still recognized as ours.
+	pathChallenges [][8]byte
+	// Set when a PATH_CHALLENGE is waiting to be packed.
+	armed bool
+	// Number of PATH_CHALLENGE frames sent so far.
+	attempts int
+	// Set when a PATH_RESPONSE matching one of the sent probes has arrived from
+	// the preferred address. The move itself is committed only after the whole
+	// packet carrying it has been processed.
+	responseReceived bool
+	// Set once the path has been validated and the connection moved.
+	done bool
+	// Set when the migration has been given up on: either the probes went
+	// unanswered, or the server retired the connection ID it reserved for the
+	// new path.
+	abandoned bool
+}
+
+// preferredAddressFor picks the offered address whose family matches the path
+// the connection is already on. A client that switched families would be
+// probing a path its network may not carry at all, so if the matching family
+// isn't on offer it stays where it is.
+func preferredAddressFor(pa *wire.PreferredAddress, current net.Addr) (net.Addr, bool) {
+	udpAddr, ok := current.(*net.UDPAddr)
+	if !ok {
+		return nil, false
+	}
+	var addr netip.AddrPort
+	// To4 also matches IPv4-mapped IPv6 addresses, which is what we want: the
+	// datagrams on such a path are IPv4 datagrams.
+	if udpAddr.IP.To4() != nil {
+		addr = pa.IPv4
+	} else {
+		addr = pa.IPv6
+	}
+	if !addr.IsValid() || addr.Addr().IsUnspecified() || addr.Port() == 0 {
+		return nil, false
+	}
+	// A link-local preferred address is only reachable through the interface
+	// the current path already uses, and converting through netip drops the
+	// zone that names it.
+	if a := addr.Addr(); a.Is6() && a.IsLinkLocalUnicast() && udpAddr.Zone != "" {
+		addr = netip.AddrPortFrom(a.WithZone(udpAddr.Zone), addr.Port())
+	}
+	return net.UDPAddrFromAddrPort(addr), true
+}
+
+// startPreferredAddressMigration arms the migration to the server's preferred
+// address. It is called when the handshake is confirmed: before that point the
+// transport parameters aren't authenticated, so probing an address taken from
+// them would let an attacker aim traffic at a third party.
+//
+// Nothing moves yet. The address has to answer a PATH_CHALLENGE first.
+func (c *Conn) startPreferredAddressMigration() {
+	if c.perspective != protocol.PerspectiveClient || c.preferredAddress != nil {
+		return
+	}
+	if c.peerParams == nil || c.peerParams.PreferredAddress == nil {
+		return
+	}
+	addr, ok := preferredAddressFor(c.peerParams.PreferredAddress, c.conn.RemoteAddr())
+	if !ok {
+		// The offer is unusable, but the connection ID that came with it still
+		// holds sequence number 1 and the server may not issue that number
+		// again. Keeping it reserved is what stops a later NEW_CONNECTION_ID
+		// for the same sequence number being taken as an ordinary addition.
+		return
+	}
+	c.preferredAddress = &preferredAddressMigration{addr: addr, armed: true}
+	c.scheduleSending()
+}
+
+// sendPreferredAddressProbe packs and sends a PATH_CHALLENGE to the preferred
+// address. It reports whether a packet was written.
+//
+// The probe is sent from the socket the connection is already using, addressed
+// to the preferred address, and it carries the connection ID the server
+// reserved for that path.
+func (c *Conn) sendPreferredAddressProbe(now monotime.Time) (bool, error) {
+	m := c.preferredAddress
+	if m == nil || !m.armed || m.done || m.abandoned {
+		return false, nil
+	}
+	// The connection ID is looked up again for every probe rather than
+	// remembered: the server can retire it at any point, and a retired
+	// connection ID must not appear on the wire again (RFC 9000, section 5.1.2).
+	connID, ok := c.connIDManager.PreferredAddressConnID()
+	if !ok {
+		c.abandonPreferredAddressMigration()
+		return false, nil
+	}
+	var data [8]byte
+	if _, err := rand.Read(data[:]); err != nil {
+		return false, err
+	}
+	frame := ackhandler.Frame{
+		Frame:   &wire.PathChallengeFrame{Data: data},
+		Handler: (*preferredAddressProbeHandler)(c),
+	}
+	probe, buf, err := c.packer.PackPathProbePacket(connID, []ackhandler.Frame{frame}, c.version)
+	if err != nil {
+		return false, err
+	}
+	m.pathChallenges = append(m.pathChallenges, data)
+	m.armed = false
+	m.attempts++
+	c.logger.Debugf("sending path probe packet to preferred address %s", m.addr)
+	c.logShortHeaderPacket(probe, protocol.ECNNon, buf.Len())
+	c.registerPackedShortHeaderPacket(probe, protocol.ECNNon, now)
+	c.sendQueue.SendProbe(buf, m.addr, packetInfo{})
+	// The connection ID is on the wire now, and the stateless reset token that
+	// came with it takes effect with it - the same moment the ordinary path
+	// probing machinery registers its tokens.
+	c.connIDManager.RegisterPreferredAddressResetToken()
+	return true, nil
+}
+
+// handlePreferredAddressResponse completes the migration when the probe is
+// answered. It reports whether the frame belonged to this migration, so that
+// the caller knows to stop looking for an outgoing path it matches.
+//
+// A PATH_RESPONSE that repeats one already seen is ours as well: the peer is
+// allowed to send it, so it is accepted and ignored rather than treated as a
+// frame nobody asked for.
+func (c *Conn) handlePreferredAddressResponse(f *wire.PathResponseFrame, from net.Addr) bool {
+	m := c.preferredAddress
+	if m == nil || !slices.Contains(m.pathChallenges, f.Data) {
+		return false
+	}
+	// From here on the frame is ours: it answers a PATH_CHALLENGE this
+	// connection really sent. Whatever else is wrong with it, it may not fall
+	// through to the generic handler - PROTOCOL_VIOLATION is only for a
+	// PATH_RESPONSE whose content does not match any PATH_CHALLENGE previously sent
+	// (RFC 9000, section 19.18), and closing a working connection over a frame
+	// we solicited is worse than ignoring it.
+	if m.done || m.abandoned {
+		return true
+	}
+	// The answer has to come back from the path being validated. A response
+	// carrying the right data but arriving elsewhere demonstrates nothing about
+	// whether the preferred address is reachable - a server bound to a wildcard
+	// socket routinely answers from its primary source address - so it is
+	// consumed without validating the path, and the probe keeps waiting.
+	if !addrUsable(from) || !addrsEqual(from, m.addr) {
+		return true
+	}
+	// Record only. The rest of this packet has not been parsed yet, and a later
+	// frame in it may retire the connection ID this move depends on - "before
+	// the connection has moved" includes the frames sharing the response's own
+	// packet. The caller commits once the whole packet has been processed, the
+	// same way a PATH_CHALLENGE is carried out of frame parsing and answered
+	// afterwards.
+	m.responseReceived = true
+	return true
+}
+
+// commitPreferredAddressMove completes a migration whose probe was answered,
+// once every frame of the packet carrying the answer has been processed. If a
+// frame later in that packet retired the reserved connection ID, there is
+// nothing left to move with and the connection stays where it is.
+func (c *Conn) commitPreferredAddressMove(now monotime.Time) {
+	m := c.preferredAddress
+	if m == nil || m.done || m.abandoned || !m.responseReceived {
+		return
+	}
+	m.armed = false
+	if !c.connIDManager.UsePreferredAddressConnID() {
+		// A frame later in the same packet retired the reserved connection ID:
+		// there is nothing to move with, so this is an abandonment, not a move.
+		m.abandoned = true
+		return
+	}
+	m.done = true
+	initialPacketSize := protocol.ByteCount(c.config.InitialPacketSize)
+	// The new path has a congestion window and an MTU of its own; nothing
+	// learned about the old one carries over.
+	c.sentPacketHandler.MigratedPath(now, initialPacketSize)
+	maxPacketSize := protocol.ByteCount(protocol.MaxPacketBufferSize)
+	if c.peerParams.MaxUDPPayloadSize > 0 && c.peerParams.MaxUDPPayloadSize < maxPacketSize {
+		maxPacketSize = c.peerParams.MaxUDPPayloadSize
+	}
+	c.mtuDiscoverer.Reset(now, initialPacketSize, maxPacketSize)
+	// Packets already handed to the send queue were packed with the old path's
+	// connection ID and addressed to the old path. A packet is not on the
+	// network when it is queued, and the send connection is read at write time,
+	// so redirecting the connection in place would send them to the preferred
+	// address under the wrong connection ID - and draining them where they were
+	// headed would keep using an address the connection has left. Drop them
+	// instead: to the peer that is ordinary loss, and loss recovery repacks
+	// their frames for the new path.
+	if sc, ok := c.conn.(*sconn); ok {
+		c.conn = newSendConn(sc.rawConn, m.addr, packetInfo{}, sc.logger)
+		c.sendQueue.CloseAndDiscard()
+		c.sendQueue = newSendQueue(c.conn)
+		go func() {
+			if err := c.sendQueue.Run(); err != nil {
+				c.destroyImpl(err)
+			}
+		}()
+	} else {
+		// A send connection this package did not build cannot be rebuilt
+		// around its socket; redirecting it is all that is left.
+		c.conn.ChangeRemoteAddr(m.addr, packetInfo{})
+	}
+	c.scheduleSending()
+}
+
+// abandonPreferredAddressMigration gives up on the move and leaves the
+// connection on the path it is already using. The connection ID that was
+// reserved for the new path is handed back, since it will never be used.
+func (c *Conn) abandonPreferredAddressMigration() {
+	m := c.preferredAddress
+	if m == nil || m.done || m.abandoned {
+		return
+	}
+	m.abandoned = true
+	m.armed = false
+	// The pathChallenges list stays on the record. It is what tells a late
+	// response apart from one nobody asked for.
+	c.logger.Debugf("giving up on the preferred address %s", m.addr)
+	c.connIDManager.RetirePreferredAddressConnID()
+}
+
+// preferredAddressProbeLost re-arms the probe when a PATH_CHALLENGE is declared
+// lost. After maxPreferredAddressProbes attempts the address is treated as
+// unreachable.
+func (c *Conn) preferredAddressProbeLost(data [8]byte) {
+	m := c.preferredAddress
+	if m == nil || m.done || m.abandoned || !slices.Contains(m.pathChallenges, data) {
+		return
+	}
+	if m.attempts >= maxPreferredAddressProbes {
+		c.abandonPreferredAddressMigration()
+		return
+	}
+	m.armed = true
+	c.scheduleSending()
+}
+
+// preferredAddressProbeHandler is notified about the fate of the packets
+// carrying the PATH_CHALLENGE frames sent to the preferred address.
+type preferredAddressProbeHandler Conn
+
+var _ ackhandler.FrameHandler = (*preferredAddressProbeHandler)(nil)
+
+// OnAcked is called when the packet carrying the PATH_CHALLENGE is
+// acknowledged. That says nothing about the new path: the acknowledgement comes
+// back on the old one. Only the PATH_RESPONSE validates the path.
+func (h *preferredAddressProbeHandler) OnAcked(wire.Frame) {}
+
+func (h *preferredAddressProbeHandler) OnLost(f wire.Frame) {
+	pc, ok := f.(*wire.PathChallengeFrame)
+	if !ok {
+		return
+	}
+	(*Conn)(h).preferredAddressProbeLost(pc.Data)
+}
+
+// addrUsable reports whether an address can be compared. A *net.UDPAddr can be
+// nil inside a non-nil net.Addr, which survives an ordinary nil check and then
+// panics on the first field access; the test connections in this package hand
+// exactly that shape to client packets.
+func addrUsable(a net.Addr) bool {
+	if a == nil {
+		return false
+	}
+	if u, ok := a.(*net.UDPAddr); ok && u == nil {
+		return false
+	}
+	return true
+}

--- a/send_queue.go
+++ b/send_queue.go
@@ -13,6 +13,7 @@ type sender interface {
 	WouldBlock() bool
 	Available() <-chan struct{}
 	Close()
+	CloseAndDiscard()
 }
 
 type queueEntry struct {
@@ -23,10 +24,11 @@ type queueEntry struct {
 
 type sendQueue struct {
 	queue       chan queueEntry
-	closeCalled chan struct{} // runStopped when Close() is called
+	closeCalled chan struct{} // closed when Close or CloseAndDiscard is called
 	runStopped  chan struct{} // runStopped when the run loop returns
 	available   chan struct{}
 	conn        sendConn
+	discard     bool // written before closeCalled is closed, which publishes it to Run
 }
 
 var _ sender = &sendQueue{}
@@ -78,13 +80,38 @@ func (h *sendQueue) Run() error {
 	defer close(h.runStopped)
 	var shouldClose bool
 	for {
-		if shouldClose && len(h.queue) == 0 {
-			return nil
+		if shouldClose {
+			if h.discard {
+				for {
+					select {
+					case e := <-h.queue:
+						e.buf.Release()
+					default:
+						return nil
+					}
+				}
+			}
+			if len(h.queue) == 0 {
+				return nil
+			}
+		}
+		// Handle a pending close before picking up another packet: once a
+		// discarding close is seen, nothing further is written. At most one
+		// packet the blocking select below has already picked up can still go
+		// out, and both closes wait for the run loop, so nothing is written
+		// after they return.
+		select {
+		case <-h.closeCalled:
+			h.closeCalled = nil
+			shouldClose = true
+			continue
+		default:
 		}
 		select {
 		case <-h.closeCalled:
 			h.closeCalled = nil // prevent this case from being selected again
-			// make sure that all queued packets are actually sent out
+			// for a plain Close, all queued packets are still sent out; a
+			// discarding close is handled at the top of the loop
 			shouldClose = true
 		case e := <-h.queue:
 			if err := h.conn.Write(e.buf.Data, e.gsoSize, e.ecn); err != nil {
@@ -106,6 +133,17 @@ func (h *sendQueue) Run() error {
 }
 
 func (h *sendQueue) Close() {
+	close(h.closeCalled)
+	// wait until the run loop returned
+	<-h.runStopped
+}
+
+// CloseAndDiscard stops the run loop, dropping any packets still queued.
+// It is for leaving a path behind: what is queued was packed for a path the
+// connection is no longer using, so to the peer a dropped packet is ordinary
+// loss, and loss recovery repacks its frames for the path in use now.
+func (h *sendQueue) CloseAndDiscard() {
+	h.discard = true
 	close(h.closeCalled)
 	// wait until the run loop returned
 	<-h.runStopped

--- a/send_queue_test.go
+++ b/send_queue_test.go
@@ -205,3 +205,67 @@ func TestSendQueueSendProbe(t *testing.T) {
 		addr: localAddr,
 	})
 }
+
+func TestSendQueueCloseAndDiscard(t *testing.T) {
+	t.Run("with packets queued", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			c := NewMockSendConn(mockCtrl)
+			q := newSendQueue(c)
+
+			// Two packets are queued, and the queue is told to discard before
+			// its run loop gets to them. Nothing may reach the connection.
+			q.Send(getPacketWithContents([]byte("foo")), 3, protocol.ECNNon)
+			q.Send(getPacketWithContents([]byte("bar")), 3, protocol.ECNNon)
+
+			closed := make(chan struct{})
+			go func() {
+				q.CloseAndDiscard()
+				close(closed)
+			}()
+			synctest.Wait()
+
+			done := make(chan struct{})
+			go func() {
+				q.Run()
+				close(done)
+			}()
+			synctest.Wait()
+
+			select {
+			case <-done:
+			default:
+				t.Fatal("Run should have returned")
+			}
+			select {
+			case <-closed:
+			default:
+				t.Fatal("CloseAndDiscard should have returned")
+			}
+		})
+	})
+
+	// The production ordering: the run loop is already parked when the
+	// discarding close arrives.
+	t.Run("while the run loop is parked", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			c := NewMockSendConn(mockCtrl)
+			q := newSendQueue(c)
+
+			done := make(chan struct{})
+			go func() {
+				q.Run()
+				close(done)
+			}()
+			synctest.Wait()
+
+			q.CloseAndDiscard()
+			select {
+			case <-done:
+			default:
+				t.Fatal("Run should have returned")
+			}
+		})
+	})
+}


### PR DESCRIPTION
Client-side support for the server's preferred address (RFC 9000 section 9.6), the feature tracked in #4965.

When the server advertises a `preferred_address` transport parameter, the client now:

- selects the offered address whose IP family matches the current path
- waits until the handshake is confirmed, then validates the new path with PATH_CHALLENGE / PATH_RESPONSE
- migrates only after a matching PATH_RESPONSE arrives back on the preferred path
- reserves the connection ID that came with the preferred address as sequence number 1, and uses it only on the new path rather than rotating it onto the old one
- retransmits a lost probe a few times, then concludes nothing is listening at the address
- cancels the migration if that connection ID is retired before the switch, including by a NEW_CONNECTION_ID that arrives later in the same packet as the response
- keeps the accompanying stateless reset token inert until its connection ID is in use
- adopts the address even when active migration is disabled, since the server is the one asking for the move
- discards the old send queue on migration instead of draining it, so nothing packed for the old path is written after the switch; loss recovery repacks those frames for the new path

Testing: there are new unit tests for each of those behaviours: address-family selection, the probe/validate/migrate sequence, the bounded retry, the sequence-1 reservation and the conflict it is meant to catch, reset-token timing, the migration-disabled exception, and the send-queue handoff. Locally the main package's unit tests, `go vet`, the race detector on the migration tests, and golangci-lint v2.13.0 all pass. I have not run the networked integration tests.

The preferred-address branches looked to be a couple of years old, so I picked the feature up from the issue. If you would rather drive it yourself, want it built on the `AddFromPreferredAddress` helper from #4235, or would prefer it split into smaller pieces, I am happy to adapt. I can add integration coverage as well if that would help.

Developed with AI assistance and reviewed by me before opening.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add client-side support for server's preferred address migration
> - The client now probes the server's preferred address after handshake confirmation using PATH_CHALLENGE/PATH_RESPONSE, then migrates to it by switching the active connection ID and remote address ([preferred_address.go](https://github.com/quic-go/quic-go/pull/5850/files#diff-317957363c6ab3b398ab5294b0d8a5ae46c175528520130c554c772a607a37d1), [connection.go](https://github.com/quic-go/quic-go/pull/5850/files#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7)).
> - `connIDManager` reserves the preferred-address connection ID (sequence 1) outside the general queue, defers reset-token registration until the first probe is sent, and promotes or retires it based on probe outcome ([conn_id_manager.go](https://github.com/quic-go/quic-go/pull/5850/files#diff-23cbb8c208127b9b8e75a01f91a0cfdf9b93a78f751977fc5b0e3b51b47f2a22)).
> - Probes are retried up to `maxPreferredAddressProbes` (3) times on loss; after that the migration is abandoned and the reserved ID is retired.
> - `sendQueue` gains `CloseAndDiscard` so the old-path send queue can be torn down without sending queued packets after a successful migration ([send_queue.go](https://github.com/quic-go/quic-go/pull/5850/files#diff-d12f687add33eb47886dce4b9d7c0523c14ffb8d1b68f6e321d5ef4828851d46)).
> - Frame handlers now receive the packet's remote address so client PATH_RESPONSE processing can validate that the response came from the preferred address.
> - Risk: `handleFrames`, `handleFrame`, `handleShortHeaderPacket`, `handleLongHeaderPacket`, and `handleUnpackedLongHeaderPacket` signatures changed to pass `net.Addr` through; all in-tree callers are updated but out-of-tree implementations of the `sender` interface must add `CloseAndDiscard`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4308a2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Clients can now migrate to a server-provided preferred address after validating the path.
  - Migration probes retry up to three times and are abandoned if validation fails or the connection ID is unavailable.
  - Preferred-address migration resets relevant connection state and discards queued packets.

- **Bug Fixes**
  - Prevented migration when the reserved connection ID is retired during packet processing.
  - Added support for discarding queued packets when closing a connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->