### PR TITLE
reenable OSS-Fuzz by rebuilding fuzz utils

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -2,6 +2,37 @@
 
 set -euo pipefail
 
+# Go toolchain setup adapted from Tailscale:
+# https://github.com/tailscale/tailscale/pull/21057
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Pin the adapter to the commit used in that PR.
+fuzzbuild_ref=fc5dc53b9db8a38c394c53d6e439a1410cf8fc19
+
+# Copy downloaded toolchains out of the module cache so OSS-Fuzz can overlay
+# the standard library when building fuzzers.
+goroot=$(go env GOROOT)
+gomodcache=$(go env GOMODCACHE)
+if [[ "$goroot" == "$gomodcache"* ]]; then
+	cp -r "$goroot/." "$tmpdir/goroot"
+	# Toolchain files are read-only; make them writable so cleanup works for any user.
+	chmod -R u+rwX "$tmpdir/goroot"
+	export GOROOT="$tmpdir/goroot"
+	export PATH="$GOROOT/bin:$PATH"
+	export GOTOOLCHAIN=local
+fi
+
+# Rebuild the adapter with the selected Go version so it can process our source.
+git clone --depth 1 https://github.com/AdamKorcz/go-118-fuzz-build "$tmpdir/v2"
+(
+	cd "$tmpdir/v2"
+	git fetch --depth 1 origin "$fuzzbuild_ref"
+	git checkout -q FETCH_HEAD
+	GOFLAGS=-mod=mod go build -o "$tmpdir/bin/go-118-fuzz-build_v2" .
+)
+export PATH="$tmpdir/bin:$PATH"
+
 go version
 go env
 

--- a/.github/workflows/clusterfuzz-coverage.yml
+++ b/.github/workflows/clusterfuzz-coverage.yml
@@ -1,9 +1,7 @@
 name: ClusterFuzz coverage
 on:
-  # Disabled because OSS-Fuzz still uses Go 1.25, while quic-go requires Go 1.27.
-  # Re-enable once OSS-Fuzz supports Go 1.27; tracked in https://github.com/google/oss-fuzz/issues/15307.
-  # schedule:
-  #   - cron: '12 3,11,19 * * *'
+  schedule:
+    - cron: '12 3,11,19 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/clusterfuzz-lite-batch.yml
+++ b/.github/workflows/clusterfuzz-lite-batch.yml
@@ -1,9 +1,7 @@
 name: ClusterFuzzLite batch fuzzing
 on:
-  # Disabled because OSS-Fuzz still uses Go 1.25, while quic-go requires Go 1.27.
-  # Re-enable once OSS-Fuzz supports Go 1.27; tracked in https://github.com/google/oss-fuzz/issues/15307.
-  # schedule:
-  #   - cron: '0 0/6 * * *'
+  schedule:
+    - cron: '0 0/6 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/clusterfuzz-lite-pr.yml
+++ b/.github/workflows/clusterfuzz-lite-pr.yml
@@ -1,10 +1,8 @@
 name: ClusterFuzzLite PR fuzzing
 on:
-  # Disabled because OSS-Fuzz still uses Go 1.25, while quic-go requires Go 1.27.
-  # Re-enable once OSS-Fuzz supports Go 1.27; tracked in https://github.com/google/oss-fuzz/issues/15307.
-  # pull_request:
-  #   paths:
-  #     - '**'
+  pull_request:
+    paths:
+      - '**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/clusterfuzz-lite-prune.yml
+++ b/.github/workflows/clusterfuzz-lite-prune.yml
@@ -1,9 +1,7 @@
 name: ClusterFuzzLite pruning
 on:
-  # Disabled because OSS-Fuzz still uses Go 1.25, while quic-go requires Go 1.27.
-  # Re-enable once OSS-Fuzz supports Go 1.27; tracked in https://github.com/google/oss-fuzz/issues/15307.
-  # schedule:
-  #   - cron: '0 2 * * *'
+  schedule:
+    - cron: '0 2 * * *'
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,7 @@
 [![Documentation](https://img.shields.io/badge/docs-quic--go.net-red?style=flat)](https://quic-go.net/docs/)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/quic-go/quic-go)](https://pkg.go.dev/github.com/quic-go/quic-go)
 [![Code Coverage](https://img.shields.io/codecov/c/github/quic-go/quic-go/master.svg?style=flat-square)](https://codecov.io/gh/quic-go/quic-go/)
-<!-- Disabled because OSS-Fuzz still uses Go 1.25, while quic-go requires Go 1.27.
-Re-enable once OSS-Fuzz supports Go 1.27; tracked in https://github.com/google/oss-fuzz/issues/15307.
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/quic-go.svg)](https://issues.oss-fuzz.com/issues?q=quic-go)
--->
 
 quic-go is an implementation of the QUIC protocol ([RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000), [RFC 9001](https://datatracker.ietf.org/doc/html/rfc9001), [RFC 9002](https://datatracker.ietf.org/doc/html/rfc9002)) in Go.
 

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -4,49 +4,15 @@ set -euo pipefail
 
 echo "Build date (UTC): $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
-go version
-go env
+# Select the toolchain from quic-go's go.mod and build its fuzzers.
+cd "$GOPATH/src/github.com/quic-go/quic-go"
+git log -1 --format='quic-go revision: %H (%cI) %s'
+source .clusterfuzzlite/build.sh
 
 # fuzz qpack
-cd $GOPATH/src/github.com/quic-go/qpack
+cd "$GOPATH/src/github.com/quic-go/qpack"
 git log -1 --format='qpack revision: %H (%cI) %s'
 compile_native_go_fuzzer_v2 github.com/quic-go/qpack FuzzDecode qpack_decode_fuzzer
 
-# fuzz quic-go
-cd $GOPATH/src/github.com/quic-go/quic-go/
-git log -1 --format='quic-go revision: %H (%cI) %s'
-
-build_native_go_fuzzer() {
-	local pkg=$1
-	local fuzz=$2
-	local name=$3
-	local corpus_dir="${WORK:-/tmp}/quic-go-seed-corpus/$name"
-	local corpus_zip="$OUT/${name}_seed_corpus.zip"
-
-	# FUZZ_CORPUS_DIR makes go-ossfuzz-seeds write each f.Add seed as a raw
-	# libFuzzer corpus file. OSS-Fuzz picks up <fuzzer>_seed_corpus.zip from
-	# $OUT and unpacks it next to the fuzzer binary.
-	rm -rf "$corpus_dir"
-	mkdir -p "$corpus_dir"
-	FUZZ_CORPUS_DIR="$corpus_dir" go test "$pkg" -run "^${fuzz}$" -count=1 -v
-
-	rm -f "$corpus_zip"
-	corpus_files=$(find "$corpus_dir" -type f | wc -l)
-	echo "$name: generated $corpus_files corpus files"
-	if [[ "$corpus_files" -gt 0 ]]; then
-		(cd "$corpus_dir" && zip -q -r "$corpus_zip" .)
-	fi
-
-	compile_native_go_fuzzer_v2 "$pkg" "$fuzz" "$name"
-}
-
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzFrames frame_fuzzer_v2
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzTransportParameters transportparameter_fuzzer_v2
-build_native_go_fuzzer github.com/quic-go/quic-go/http3 FuzzFrameParser http3_frame_fuzzer
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/wire FuzzHeaderParser header_fuzzer_v2
-build_native_go_fuzzer github.com/quic-go/quic-go/internal/handshake FuzzHandshake handshake_fuzzer_v2
-build_native_go_fuzzer github.com/quic-go/quic-go FuzzFrameSorter frame_sorter_fuzzer
-build_native_go_fuzzer github.com/quic-go/quic-go/http3 FuzzHeaderParsing http3_header_parsing_fuzzer
-
 # for debugging
-ls -al $OUT
+ls -al "$OUT"


### PR DESCRIPTION
This closely mirrors how Tailscale updated their OSS-Fuzz support in https://github.com/tailscale/tailscale/pull/21057.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Re-enabled scheduled ClusterFuzz and OSS-Fuzz workflows for coverage, batch fuzzing, pruning, and pull request validation.
  * Updated fuzzing builds to use a pinned Go toolchain and fuzz adapter for more consistent results.
  * Streamlined the OSS-Fuzz build process while retaining QPACK fuzzing.
* **Documentation**
  * Re-enabled the OSS-Fuzz status badge in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-enable OSS-Fuzz by rebuilding fuzz build utils and scheduling ClusterFuzz workflows
> - Adds [build.sh](https://github.com/quic-go/quic-go/pull/5851/files#diff-2c10f02a79d6592981510922b30964df2d52d82b774ac3d337a535840bb4f3a8), a toolchain bootstrap script that selects a writable Go toolchain, clones a pinned `go-118-fuzz-build` adapter, and prepends its bin directory to `PATH` before fuzzer compilation runs
> - Rewires [oss-fuzz.sh](https://github.com/quic-go/quic-go/pull/5851/files#diff-857b8ac91ce0728a3684db7bff7d929b9818b1cfaeeb81499fea2f08aa39bc05) to source `build.sh`; removes the `build_native_go_fuzzer` helper that generated seed-corpus archives and compiled quic-go fuzzers — only the qpack native fuzzer remains
> - Reactivates cron schedules for the ClusterFuzz coverage (`03:11,19`), batch (`every 6h`), and prune (`02:00 daily`) workflows, and enables `pull_request` triggers on the PR workflow
> - Re-enables the OSS-Fuzz status badge in [README.md](https://github.com/quic-go/quic-go/pull/5851/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
> - Behavioral Change: the OSS-Fuzz build no longer compiles quic-go fuzz targets or produces their seed-corpus archives; qpack is still compiled via `compile_native_go_fuzzer_v2`
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ad08741. 7 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->