### PR TITLE
http3: return consistent error types from stream APIs

### DIFF
--- a/http3/body.go
+++ b/http3/body.go
@@ -68,7 +68,7 @@ func (r *body) Read(b []byte) (int, error) {
 	if err := r.checkContentLengthViolation(); err != nil {
 		return n, err
 	}
-	return n, maybeReplaceError(err)
+	return n, err
 }
 
 func (r *body) Close() error {
@@ -118,7 +118,7 @@ func (r *hijackableBody) Read(b []byte) (int, error) {
 	if err != nil {
 		r.requestDone()
 	}
-	return n, maybeReplaceError(err)
+	return n, err
 }
 
 func (r *hijackableBody) requestDone() {

--- a/http3/client.go
+++ b/http3/client.go
@@ -163,7 +163,7 @@ func (c *ClientConn) openRequestStream(
 		if context.Cause(openCtx) == errGoAway {
 			return nil, errGoAway
 		}
-		return nil, err
+		return nil, maybeReplaceError(err)
 	}
 
 	// Check again in case GOAWAY raced with OpenStreamSync.
@@ -333,9 +333,9 @@ func (c *ClientConn) roundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil { // if any error occurred
 		close(reqDone)
 		<-done
-		return nil, maybeReplaceError(err)
+		return nil, err
 	}
-	return rsp, maybeReplaceError(err)
+	return rsp, nil
 }
 
 // ReceivedSettings returns a channel that is closed once the server's HTTP/3 settings were received.

--- a/http3/error.go
+++ b/http3/error.go
@@ -7,7 +7,8 @@ import (
 	"github.com/quic-go/quic-go"
 )
 
-// Error is returned by [Transport.RoundTrip], [Transport.RoundTripOpt], and
+// Error is returned, possibly wrapped, by [Stream] and [RequestStream] operations,
+// [ClientConn.OpenRequestStream], [Transport.RoundTrip], [Transport.RoundTripOpt], and
 // [ClientConn.RoundTrip] for HTTP clients, and from request-body reads and response
 // writes inside HTTP handlers for HTTP servers, when an HTTP/3 error occurs.
 // See section 8 of RFC 9114.

--- a/http3/response_writer.go
+++ b/http3/response_writer.go
@@ -168,7 +168,7 @@ func (w *responseWriter) doWrite(p []byte) (int, error) {
 	if !w.headerWritten {
 		w.sniffContentType(w.smallResponseBuf)
 		if err := w.writeHeader(w.status); err != nil {
-			return 0, maybeReplaceError(err)
+			return 0, err
 		}
 		w.headerWritten = true
 	}
@@ -188,11 +188,11 @@ func (w *responseWriter) doWrite(p []byte) (int, error) {
 		})
 	}
 	if _, err := w.str.writeUnframed(w.buf); err != nil {
-		return 0, maybeReplaceError(err)
+		return 0, err
 	}
 	if len(w.smallResponseBuf) > 0 {
 		if _, err := w.str.writeUnframed(w.smallResponseBuf); err != nil {
-			return 0, maybeReplaceError(err)
+			return 0, err
 		}
 		w.smallResponseBuf = nil
 	}
@@ -201,7 +201,7 @@ func (w *responseWriter) doWrite(p []byte) (int, error) {
 		var err error
 		n, err = w.str.writeUnframed(p)
 		if err != nil {
-			return n, maybeReplaceError(err)
+			return n, err
 		}
 	}
 	return n, nil
@@ -330,7 +330,7 @@ func (w *responseWriter) writeTrailers() error {
 	if written {
 		w.trailerWritten = true
 	}
-	return err
+	return maybeReplaceError(err)
 }
 
 func (w *responseWriter) HTTPStream() *Stream {

--- a/http3/server.go
+++ b/http3/server.go
@@ -542,7 +542,7 @@ func (s *Server) handleConn(conn *quic.Conn) error {
 			if conn.Context().Err() != nil {
 				appErr, ok := errors.AsType[*quic.ApplicationError](err)
 				if !ok || appErr.ErrorCode != quic.ApplicationErrorCode(ErrCodeNoError) {
-					handleErr = fmt.Errorf("accepting stream failed: %w", err)
+					handleErr = fmt.Errorf("accepting stream failed: %w", maybeReplaceError(err))
 				}
 				break
 			}
@@ -556,7 +556,7 @@ func (s *Server) handleConn(conn *quic.Conn) error {
 			if !inGracefulShutdown {
 				appErr, ok := errors.AsType[*quic.ApplicationError](err)
 				if !ok || appErr.ErrorCode != quic.ApplicationErrorCode(ErrCodeNoError) {
-					handleErr = fmt.Errorf("accepting stream failed: %w", err)
+					handleErr = fmt.Errorf("accepting stream failed: %w", maybeReplaceError(err))
 				}
 				break
 			}

--- a/http3/stream.go
+++ b/http3/stream.go
@@ -81,7 +81,7 @@ func (s *Stream) Read(b []byte) (int, error) {
 				if errors.Is(err, errPriorityUpdateForPush) {
 					s.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
 				}
-				return 0, err
+				return 0, maybeReplaceError(err)
 			}
 			switch f := frame.(type) {
 			case *dataFrame:
@@ -96,7 +96,7 @@ func (s *Stream) Read(b []byte) (int, error) {
 					return 0, errors.New("additional HEADERS frame received after trailers")
 				}
 				s.parsedTrailer = true
-				return 0, s.parseTrailer(s.datagramStream, f)
+				return 0, maybeReplaceError(s.parseTrailer(s.datagramStream, f))
 			default:
 				s.conn.CloseWithError(quic.ApplicationErrorCode(ErrCodeFrameUnexpected), "")
 				// parseNextFrame skips over unknown frame types
@@ -114,7 +114,7 @@ func (s *Stream) Read(b []byte) (int, error) {
 		n, err = s.datagramStream.Read(b)
 	}
 	s.bytesRemainingInFrame -= uint64(n)
-	return n, err
+	return n, maybeReplaceError(err)
 }
 
 func (s *Stream) hasMoreData() bool {
@@ -134,10 +134,10 @@ func (s *Stream) Write(b []byte) (int, error) {
 			Frame: qlog.Frame{Frame: qlog.DataFrame{}},
 		})
 	}
-	if _, err := s.datagramStream.Write(s.buf); err != nil {
+	if _, err := s.writeUnframed(s.buf); err != nil {
 		return 0, err
 	}
-	return s.datagramStream.Write(b)
+	return s.writeUnframed(b)
 }
 
 // TryWriteAll writes b in a DATA frame if the entire frame can be queued immediately.
@@ -147,7 +147,7 @@ func (s *Stream) TryWriteAll(b []byte) error {
 	data = (&dataFrame{Length: uint64(len(b))}).Append(data)
 	data = append(data, b...)
 	if err := s.datagramStream.TryWriteAll(data); err != nil {
-		return err
+		return maybeReplaceError(err)
 	}
 	if s.qlogger != nil {
 		s.qlogger.RecordEvent(qlog.FrameCreated{
@@ -163,7 +163,8 @@ func (s *Stream) TryWriteAll(b []byte) error {
 }
 
 func (s *Stream) writeUnframed(b []byte) (int, error) {
-	return s.datagramStream.Write(b)
+	n, err := s.datagramStream.Write(b)
+	return n, maybeReplaceError(err)
 }
 
 func (s *Stream) StreamID() quic.StreamID {
@@ -172,12 +173,13 @@ func (s *Stream) StreamID() quic.StreamID {
 
 func (s *Stream) SendDatagram(b []byte) error {
 	// TODO: reject if datagrams are not negotiated (yet)
-	return s.datagramStream.SendDatagram(b)
+	return maybeReplaceError(s.datagramStream.SendDatagram(b))
 }
 
 func (s *Stream) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 	// TODO: reject if datagrams are not negotiated (yet)
-	return s.datagramStream.ReceiveDatagram(ctx)
+	b, err := s.datagramStream.ReceiveDatagram(ctx)
+	return b, maybeReplaceError(err)
 }
 
 // A RequestStream is a low-level abstraction representing an HTTP/3 request stream.
@@ -187,6 +189,7 @@ func (s *Stream) ReceiveDatagram(ctx context.Context) ([]byte, error) {
 //
 // This is only needed for advanced use case, e.g. WebTransport and the various
 // MASQUE proxying protocols.
+// Stream and application errors are returned as *[Error], possibly wrapped.
 type RequestStream struct {
 	str *Stream
 
@@ -336,13 +339,13 @@ func (s *RequestStream) sendRequestHeader(req *http.Request) error {
 	}
 	s.isConnect = req.Method == http.MethodConnect
 	s.sentRequest = true
-	return s.requestWriter.WriteRequestHeader(s.str.datagramStream, req, s.requestedGzip, s.str.StreamID(), s.str.qlogger)
+	return maybeReplaceError(s.requestWriter.WriteRequestHeader(s.str.datagramStream, req, s.requestedGzip, s.str.StreamID(), s.str.qlogger))
 }
 
 // sendRequestTrailer sends request trailers to the stream.
 // It should be called after the request body has been fully written.
 func (s *RequestStream) sendRequestTrailer(req *http.Request) error {
-	return s.requestWriter.WriteRequestTrailer(s.str.datagramStream, req, s.str.StreamID(), s.str.qlogger)
+	return maybeReplaceError(s.requestWriter.WriteRequestTrailer(s.str.datagramStream, req, s.str.StreamID(), s.str.qlogger))
 }
 
 // ReadResponse reads the HTTP response from the stream.
@@ -362,7 +365,7 @@ func (s *RequestStream) ReadResponse() (*http.Response, error) {
 		}
 		s.str.CancelRead(quic.StreamErrorCode(ErrCodeFrameError))
 		s.str.CancelWrite(quic.StreamErrorCode(ErrCodeFrameError))
-		return nil, fmt.Errorf("http3: parsing frame failed: %w", err)
+		return nil, fmt.Errorf("http3: parsing frame failed: %w", maybeReplaceError(err))
 	}
 	hf, ok := frame.(*headersFrame)
 	if !ok {
@@ -380,7 +383,7 @@ func (s *RequestStream) ReadResponse() (*http.Response, error) {
 		maybeQlogInvalidHeadersFrame(s.str.qlogger, s.str.StreamID(), hf.Length)
 		s.str.CancelRead(quic.StreamErrorCode(ErrCodeRequestIncomplete))
 		s.str.CancelWrite(quic.StreamErrorCode(ErrCodeRequestIncomplete))
-		return nil, fmt.Errorf("http3: failed to read response headers: %w", err)
+		return nil, fmt.Errorf("http3: failed to read response headers: %w", maybeReplaceError(err))
 	}
 	decodeFn := s.decoder.Decode(headerBlock)
 	var hfs []qpack.HeaderField

--- a/integrationtests/self/http_datagram_test.go
+++ b/integrationtests/self/http_datagram_test.go
@@ -196,9 +196,7 @@ loop:
 
 	select {
 	case err := <-errChan:
-		var serr *quic.StreamError
-		require.ErrorAs(t, err, &serr)
-		require.Equal(t, quic.StreamErrorCode(42), serr.ErrorCode)
+		require.ErrorIs(t, err, &http3.Error{ErrorCode: 42, Remote: true})
 	case <-time.After(time.Second):
 		t.Fatal("didn't receive error")
 	}
@@ -311,7 +309,7 @@ func TestHTTPDatagramStreamReset(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("didn't receive error")
 	}
-	require.Equal(t, &quic.StreamError{ErrorCode: 42, Remote: false}, resetErr)
+	require.Equal(t, &http3.Error{ErrorCode: 42, Remote: false}, resetErr)
 
 	var err error
 	require.Eventually(t, func() bool {
@@ -319,5 +317,5 @@ func TestHTTPDatagramStreamReset(t *testing.T) {
 		return err != nil
 	}, time.Second, 10*time.Millisecond)
 	// make sure we can't send anymore
-	require.Equal(t, &quic.StreamError{ErrorCode: 42, Remote: true}, err)
+	require.Equal(t, &http3.Error{ErrorCode: 42, Remote: true}, err)
 }

--- a/integrationtests/self/http_stream_error_test.go
+++ b/integrationtests/self/http_stream_error_test.go
@@ -1,0 +1,80 @@
+package self_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Each case uses a fresh connection: either both peers cancel their write side or the client closes the connection.
+// Reads and writes must return *http3.Error with H3_EXCESSIVE_LOAD and Remote indicating whether the peer caused the error.
+func TestHTTPStreamErrors(t *testing.T) {
+	for _, errorType := range []string{"stream cancellation", "application close"} {
+		t.Run(errorType, func(t *testing.T) {
+			serverStreams := make(chan *http3.Stream, 1)
+			mux := http.NewServeMux()
+			mux.HandleFunc("/cancel", func(w http.ResponseWriter, _ *http.Request) {
+				serverStreams <- w.(http3.HTTPStreamer).HTTPStream()
+			})
+			port := startHTTPServer(t, mux)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			conn, err := quic.Dial(
+				ctx,
+				newUDPConnLocalhost(t),
+				&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port},
+				http3.ConfigureTLSConfig(getTLSClientConfigWithoutServerName()),
+				getQuicConfig(nil),
+			)
+			require.NoError(t, err)
+			defer conn.CloseWithError(0, "")
+			cc := (&http3.Transport{}).NewClientConn(conn)
+			clientStr, err := cc.OpenRequestStream(ctx)
+			require.NoError(t, err)
+			require.NoError(t, clientStr.SetDeadline(time.Now().Add(time.Second)))
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/cancel", port), nil)
+			require.NoError(t, err)
+			require.NoError(t, clientStr.SendRequestHeader(req))
+			_, err = clientStr.ReadResponse()
+			require.NoError(t, err)
+			serverStr := <-serverStreams
+			require.NoError(t, serverStr.SetDeadline(time.Now().Add(time.Second)))
+
+			switch errorType {
+			case "stream cancellation":
+				clientStr.CancelWrite(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
+
+				_, err = clientStr.Write([]byte{0})
+				require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeExcessiveLoad, Remote: false}, "RequestStream.Write")
+				_, err = serverStr.Read([]byte{0})
+				require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeExcessiveLoad, Remote: true}, "Stream.Read")
+
+				serverStr.CancelWrite(quic.StreamErrorCode(http3.ErrCodeExcessiveLoad))
+				_, err = serverStr.Write([]byte{0})
+				require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeExcessiveLoad, Remote: false}, "Stream.Write")
+				_, err = clientStr.Read([]byte{0})
+				require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeExcessiveLoad, Remote: true}, "RequestStream.Read")
+			case "application close":
+				require.NoError(t, conn.CloseWithError(quic.ApplicationErrorCode(http3.ErrCodeExcessiveLoad), ""))
+
+				_, err = clientStr.Write([]byte{0})
+				require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeExcessiveLoad, Remote: false}, "RequestStream.Write")
+				_, err = serverStr.Read([]byte{0})
+				require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeExcessiveLoad, Remote: true}, "Stream.Read")
+				_, err = serverStr.Write([]byte{0})
+				require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeExcessiveLoad, Remote: true}, "Stream.Write")
+				_, err = clientStr.Read([]byte{0})
+				require.ErrorIs(t, err, &http3.Error{ErrorCode: http3.ErrCodeExcessiveLoad, Remote: false}, "RequestStream.Read")
+			}
+		})
+	}
+}

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -823,7 +823,7 @@ func TestHTTPServeQUICConn(t *testing.T) {
 	require.NoError(t, cl.Transport.(io.Closer).Close())
 	select {
 	case err := <-errChan:
-		require.Error(t, err)
+		require.ErrorIs(t, err, &http3.Error{ErrorCode: 0, Remote: true})
 		require.ErrorContains(t, err, "accepting stream failed")
 	case <-time.After(time.Second):
 		t.Fatal("server didn't shut down")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in HTTP/3 error reporting across streams, requests, responses, and datagrams.
  * Cancellation, reset, connection, and stream-opening failures now preserve HTTP/3 error codes and correctly identify whether errors originated locally or remotely.
  * Trailer-writing failures now expose the appropriate HTTP/3 error details.

* **Documentation**
  * Expanded error documentation to clarify where HTTP/3 errors may be returned and how they are represented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return consistent `http3.Error` types from HTTP/3 stream and request APIs
> - Centralizes error conversion via `maybeReplaceError` across `http3.Stream` read/write/datagram methods, `http3.RequestStream` header/trailer/response methods, `http3.ClientConn` stream-open and round-trip paths, and `http3.Server.handleConn` stream-accept failures
> - Removes redundant local `maybeReplaceError` calls from `http3.body.Read`, `http3.hijackableBody.Read`, `http3.ClientConn.roundTrip`, and `http3.responseWriter.doWrite` now that the stream layer consistently converts errors
> - Updates integration tests to assert `http3.Error` values (with correct codes and `Remote` flags) instead of `quic.StreamError` for datagram resets, stream cancellation, application close, and server shutdown
> - Expands `http3.Error` and `http3.RequestStream` API docs to state that errors from stream and request-stream operations are returned as possibly-wrapped `http3.Error` values
> - Behavioral Change: callers that previously received raw `quic.StreamError` or other lower-level errors from `http3.Stream`, `http3.RequestStream`, `http3.ClientConn.OpenRequestStream`, or `http3.Server` stream-accept paths now receive `http3.Error` (or a wrapped variant); existing `errors.Is`/`errors.As` checks against `quic.StreamError` may need updating
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0db92a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->