### PR TITLE
use more specific require assertions in tests

### DIFF
--- a/buffer_pool_test.go
+++ b/buffer_pool_test.go
@@ -24,12 +24,12 @@ func TestBufferPoolRelease(t *testing.T) {
 	buf1 := getPacketBuffer()
 	buf1.Release()
 	// panics if released twice
-	require.Panics(t, func() { buf1.Release() })
+	require.PanicsWithValue(t, "negative packetBuffer refCount", func() { buf1.Release() })
 
 	// panics if wrong-sized buffers are passed
 	buf2 := getLargePacketBuffer()
 	buf2.Data = make([]byte, 10) // replace the underlying slice
-	require.Panics(t, func() { buf2.Release() })
+	require.PanicsWithValue(t, "putPacketBuffer called with packet of wrong size!", func() { buf2.Release() })
 }
 
 func TestBufferPoolSplitting(t *testing.T) {
@@ -40,5 +40,5 @@ func TestBufferPoolSplitting(t *testing.T) {
 	buf.Decrement()
 	buf.Decrement()
 	buf.Decrement()
-	require.Panics(t, func() { buf.Decrement() })
+	require.PanicsWithValue(t, "negative packetBuffer refCount", func() { buf.Decrement() })
 }

--- a/config_test.go
+++ b/config_test.go
@@ -163,8 +163,8 @@ func TestConfigClone(t *testing.T) {
 	t.Run("returns a copy", func(t *testing.T) {
 		c1 := &Config{MaxIncomingStreams: 100}
 		c2 := c1.Clone()
-		c2.MaxIncomingStreams = 200
-		require.EqualValues(t, 100, c1.MaxIncomingStreams)
+		require.NotNil(t, c2)
+		require.NotSame(t, c1, c2)
 	})
 }
 

--- a/conn_id_generator_test.go
+++ b/conn_id_generator_test.go
@@ -246,16 +246,11 @@ func testConnIDGeneratorReplaceWithClosed(t *testing.T, hasInitialClientDestConn
 	require.Len(t, added, protocol.MaxIssuedConnectionIDs+1)
 
 	g.ReplaceWithClosed([]byte("foobar"), time.Second)
+	expected := append([]protocol.ConnectionID{protocol.ParseConnectionID([]byte{1, 1, 1, 1})}, added...)
 	if hasInitialClientDestConnID {
-		require.Len(t, replaced, protocol.MaxIssuedConnectionIDs+3)
-		require.Contains(t, replaced, *initialClientDestConnID)
-	} else {
-		require.Len(t, replaced, protocol.MaxIssuedConnectionIDs+2)
+		expected = append(expected, *initialClientDestConnID)
 	}
-	for _, id := range added {
-		require.Contains(t, replaced, id)
-	}
-	require.Contains(t, replaced, protocol.ParseConnectionID([]byte{1, 1, 1, 1}))
+	require.ElementsMatch(t, expected, replaced)
 	require.Equal(t, []byte("foobar"), replacedWith)
 }
 
@@ -309,11 +304,10 @@ func TestConnIDGeneratorAddConnRunner(t *testing.T) {
 	// add the second runner - it should get all existing connection IDs
 	g.AddConnRunner(&packetHandlerMap{}, runner2)
 	require.Len(t, tracker1.added, 2) // unchanged
-	require.Len(t, tracker2.added, 4)
-	require.Contains(t, tracker2.added, initialConnID)
-	require.Contains(t, tracker2.added, clientDestConnID)
-	require.Contains(t, tracker2.added, tracker1.added[0])
-	require.Contains(t, tracker2.added, tracker1.added[1])
+	require.ElementsMatch(t,
+		[]protocol.ConnectionID{initialConnID, clientDestConnID, tracker1.added[0], tracker1.added[1]},
+		tracker2.added,
+	)
 
 	// adding the same transport again doesn't do anything
 	trCopy := tr
@@ -339,7 +333,7 @@ func TestConnIDGeneratorAddConnRunner(t *testing.T) {
 	require.Equal(t, []protocol.ConnectionID{clientDestConnID}, tracker2.removed)
 
 	g.ReplaceWithClosed([]byte("connection closed"), time.Second)
-	require.True(t, len(tracker1.replaced) > 0)
+	require.NotEmpty(t, tracker1.replaced)
 	require.Equal(t, tracker1.replaced, tracker2.replaced)
 
 	tracker1.removed = nil

--- a/frame_sorter_test.go
+++ b/frame_sorter_test.go
@@ -101,7 +101,7 @@ func TestFrameSorterGapHandling(t *testing.T) {
 	}
 
 	checkQueue := func(t *testing.T, s *frameSorter, m map[protocol.ByteCount][]byte) {
-		require.Equal(t, len(m), len(s.queue))
+		require.Len(t, s.queue, len(m))
 		for offset, data := range m {
 			require.Contains(t, s.queue, offset)
 			require.Equal(t, data, s.queue[offset].Data)

--- a/http3/headers_test.go
+++ b/http3/headers_test.go
@@ -56,7 +56,7 @@ func TestRequestHeaderParsing(t *testing.T) {
 			require.Equal(t, 3, req.ProtoMajor)
 			require.Zero(t, req.ProtoMinor)
 			require.Equal(t, int64(42), req.ContentLength)
-			require.Equal(t, 1, len(req.Header))
+			require.Len(t, req.Header, 1)
 			require.Equal(t, "42", req.Header.Get("Content-Length"))
 			require.Nil(t, req.Body)
 			require.Equal(t, "quic-go.net:443", req.Host)
@@ -551,7 +551,7 @@ func TestResponseHeaderParsing(t *testing.T) {
 	require.Equal(t, 3, rsp.ProtoMajor)
 	require.Zero(t, rsp.ProtoMinor)
 	require.Equal(t, int64(42), rsp.ContentLength)
-	require.Equal(t, 1, len(rsp.Header))
+	require.Len(t, rsp.Header, 1)
 	require.Equal(t, "42", rsp.Header.Get("Content-Length"))
 	require.Nil(t, rsp.Body)
 	require.Equal(t, 200, rsp.StatusCode)
@@ -635,7 +635,7 @@ func TestResponseTrailerFields(t *testing.T) {
 	}
 	var rsp http.Response
 	require.NoError(t, updateResponseFromHeaders(&rsp, decodeFromSlice(headers), math.MaxInt, nil))
-	require.Equal(t, 0, len(rsp.Header))
+	require.Empty(t, rsp.Header)
 	require.Equal(t, http.Header(map[string][]string{
 		"Trailer1": nil,
 		"Trailer2": nil,

--- a/http3/qlog/qlog_dir_test.go
+++ b/http3/qlog/qlog_dir_test.go
@@ -25,9 +25,7 @@ func TestQLOGDIRSet(t *testing.T) {
 	recorder := tracer.AddProducer()
 	recorder.Close()
 
-	_, err := os.Stat(qlogDir)
-	qlogDirCreated := !os.IsNotExist(err)
-	require.True(t, qlogDirCreated)
+	require.DirExists(t, qlogDir)
 
 	entries, err := os.ReadDir(qlogDir)
 	require.NoError(t, err)

--- a/http3/response_writer_test.go
+++ b/http3/response_writer_test.go
@@ -97,8 +97,8 @@ func newTestResponseWriter(t *testing.T) *testResponseWriter {
 
 func TestResponseWriterInvalidStatus(t *testing.T) {
 	rw := newTestResponseWriter(t)
-	require.Panics(t, func() { rw.WriteHeader(99) })
-	require.Panics(t, func() { rw.WriteHeader(1000) })
+	require.PanicsWithValue(t, "invalid WriteHeader code 99", func() { rw.WriteHeader(99) })
+	require.PanicsWithValue(t, "invalid WriteHeader code 1000", func() { rw.WriteHeader(1000) })
 }
 
 func TestResponseWriterHeader(t *testing.T) {
@@ -206,7 +206,7 @@ func TestResponseWriterEarlyHints(t *testing.T) {
 
 	// Early Hints must have been received
 	fields := rw.DecodeHeaders(t, 0)
-	require.Equal(t, 2, len(fields))
+	require.Len(t, fields, 2)
 	require.Equal(t, []string{"103"}, fields[":status"])
 	require.Equal(t,
 		[]string{"</style.css>; rel=preload; as=style", "</script.js>; rel=preload; as=script"},
@@ -215,7 +215,7 @@ func TestResponseWriterEarlyHints(t *testing.T) {
 
 	// headers sent in the informational response must also be included in the final response
 	fields = rw.DecodeHeaders(t, 1)
-	require.Equal(t, 4, len(fields))
+	require.Len(t, fields, 4)
 	require.Equal(t, []string{"200"}, fields[":status"])
 	require.Contains(t, fields, "date")
 	require.Contains(t, fields, "content-type")

--- a/http3/transport_test.go
+++ b/http3/transport_test.go
@@ -238,7 +238,7 @@ func TestTransportConnectionReuse(t *testing.T) {
 	cl.EXPECT().RoundTrip(req1).Return(&http.Response{Request: req1}, nil)
 	rsp, err := tr.RoundTrip(req1)
 	require.NoError(t, err)
-	require.Equal(t, req1, rsp.Request)
+	require.Same(t, req1, rsp.Request)
 	require.Equal(t, 1, dialCount)
 
 	// ... which is then used for the second request
@@ -246,7 +246,7 @@ func TestTransportConnectionReuse(t *testing.T) {
 	cl.EXPECT().RoundTrip(req2).Return(&http.Response{Request: req2}, nil)
 	rsp, err = tr.RoundTrip(req2)
 	require.NoError(t, err)
-	require.Equal(t, req2, rsp.Request)
+	require.Same(t, req2, rsp.Request)
 	require.Equal(t, 1, dialCount)
 }
 
@@ -366,7 +366,7 @@ func TestTransportRequestContextCancellation(t *testing.T) {
 	cl.EXPECT().RoundTrip(req1).Return(&http.Response{Request: req1}, nil)
 	rsp, err := tr.RoundTrip(req1)
 	require.NoError(t, err)
-	require.Equal(t, req1, rsp.Request)
+	require.Same(t, req1, rsp.Request)
 	require.Equal(t, 1, dialCount)
 
 	// the second request reuses the QUIC connection, and runs into the cancelled context
@@ -388,7 +388,7 @@ func TestTransportRequestContextCancellation(t *testing.T) {
 	cl.EXPECT().RoundTrip(req3).Return(&http.Response{Request: req3}, nil)
 	rsp, err = tr.RoundTrip(req3)
 	require.NoError(t, err)
-	require.Equal(t, req3, rsp.Request)
+	require.Same(t, req3, rsp.Request)
 	require.Equal(t, 1, dialCount)
 }
 
@@ -417,7 +417,7 @@ func TestTransportConnetionRedialHandshakeError(t *testing.T) {
 	cl.EXPECT().RoundTrip(req2).Return(&http.Response{Request: req2}, nil)
 	rsp, err := tr.RoundTrip(req2)
 	require.NoError(t, err)
-	require.Equal(t, req2, rsp.Request)
+	require.Same(t, req2, rsp.Request)
 	require.Equal(t, 2, dialCount)
 }
 

--- a/integrationtests/self/http_test.go
+++ b/integrationtests/self/http_test.go
@@ -747,7 +747,7 @@ func TestHTTPDeadlines(t *testing.T) {
 
 		body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 2 * deadlineDelay})
 		require.NoError(t, err)
-		require.True(t, time.Now().After(expectedEnd))
+		require.Greater(t, time.Now(), expectedEnd)
 		require.Equal(t, "ok", string(body))
 
 		select {
@@ -777,7 +777,7 @@ func TestHTTPDeadlines(t *testing.T) {
 
 		body, err := io.ReadAll(&readerWithTimeout{Reader: resp.Body, Timeout: 2 * deadlineDelay})
 		require.NoError(t, err)
-		require.True(t, time.Now().After(expectedEnd))
+		require.Greater(t, time.Now(), expectedEnd)
 		require.Contains(t, string(body), "aa")
 
 		select {
@@ -900,9 +900,7 @@ func TestHTTPConnContext(t *testing.T) {
 
 	select {
 	case ctx := <-connCtxChan:
-		serv, ok := ctx.Value(http3.ServerContextKey).(*http3.Server)
-		require.True(t, ok)
-		require.Equal(t, server, serv)
+		require.Same(t, server, ctx.Value(http3.ServerContextKey))
 	default:
 		t.Fatal("handler was not called")
 	}
@@ -913,9 +911,7 @@ func TestHTTPConnContext(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "bar", v)
 
-		serv, ok := ctx.Value(http3.ServerContextKey).(*http3.Server)
-		require.True(t, ok)
-		require.Equal(t, server, serv)
+		require.Same(t, server, ctx.Value(http3.ServerContextKey))
 	default:
 		t.Fatal("handler was not called")
 	}

--- a/integrationtests/self/http_trace_test.go
+++ b/integrationtests/self/http_trace_test.go
@@ -119,7 +119,7 @@ func TestHTTPClientTrace(t *testing.T) {
 		case "TLSHandshakeDone":
 			require.Nil(t, e.Args.(map[string]any)["err"])
 			state := e.Args.(map[string]any)["state"].(tls.ConnectionState)
-			require.Equal(t, 1, len(state.PeerCertificates))
+			require.Len(t, state.PeerCertificates, 1)
 			require.Equal(t, "localhost", state.PeerCertificates[0].DNSNames[0])
 		case "WroteHeaderField":
 			require.Equal(t, fmt.Sprintf("localhost:%d", port), e.Args.(string))

--- a/integrationtests/self/multiplex_test.go
+++ b/integrationtests/self/multiplex_test.go
@@ -336,7 +336,7 @@ func TestMultiplexingNonQUICPackets(t *testing.T) {
 		select {
 		case p := <-rcvdPackets:
 			require.Equal(t, tr1.Conn.LocalAddr(), p.addr, "non-QUIC packet received from wrong address")
-			require.Equal(t, packetLen, len(p.b), "non-QUIC packet incorrect length")
+			require.Len(t, p.b, packetLen, "non-QUIC packet incorrect length")
 			require.NoError(t, p.err, "error receiving non-QUIC packet")
 			counter++
 		case <-timeout:

--- a/integrationtests/self/qlog_dir_test.go
+++ b/integrationtests/self/qlog_dir_test.go
@@ -50,9 +50,7 @@ func TestQlogDirEnvironmentVariable(t *testing.T) {
 	server.Close()
 	<-serverStopped
 
-	_, err = os.Stat(qlogDir)
-	qlogDirCreated := !os.IsNotExist(err)
-	require.True(t, qlogDirCreated)
+	require.DirExists(t, qlogDir)
 
 	childs, err := os.ReadDir(qlogDir)
 	require.NoError(t, err)
@@ -70,6 +68,5 @@ func TestQlogDirEnvironmentVariable(t *testing.T) {
 	}
 
 	require.Equal(t, odcids[0], odcids[1])
-	require.Contains(t, vantagePoints, "client")
-	require.Contains(t, vantagePoints, "server")
+	require.ElementsMatch(t, []string{"client", "server"}, vantagePoints)
 }

--- a/integrationtests/tools/proxy/proxy_test.go
+++ b/integrationtests/tools/proxy/proxy_test.go
@@ -285,8 +285,8 @@ func TestPacketReordering(t *testing.T) {
 	expectDelay := func(startTime time.Time, numRTTs int) {
 		expectedReceiveTime := startTime.Add(time.Duration(numRTTs) * delay)
 		now := time.Now()
-		require.True(t, now.After(expectedReceiveTime) || now.Equal(expectedReceiveTime))
-		require.True(t, now.Before(expectedReceiveTime.Add(delay/2)))
+		require.GreaterOrEqual(t, now, expectedReceiveTime)
+		require.Less(t, now, expectedReceiveTime.Add(delay/2))
 	}
 
 	serverAddr, serverReceivedPackets := runServer(t)

--- a/internal/ackhandler/sent_packet_handler_test.go
+++ b/internal/ackhandler/sent_packet_handler_test.go
@@ -895,7 +895,7 @@ func testSentPacketHandlerPTO(t *testing.T, encLevel protocol.EncryptionLevel, p
 	require.Contains(t, packets.Acked, pns[8])
 
 	// The loss detection timer should be cancelled since there are no more outstanding packets.
-	require.True(t, sph.GetLossDetectionTimeout().IsZero())
+	require.Zero(t, sph.GetLossDetectionTimeout())
 	require.Equal(t,
 		[]qlogwriter.Event{
 			qlog.LossTimerUpdated{Type: qlog.LossTimerUpdateTypeCancelled},

--- a/internal/congestion/cubic_sender_test.go
+++ b/internal/congestion/cubic_sender_test.go
@@ -385,7 +385,7 @@ func TestCubicSenderMultipleLossesInOneWindow(t *testing.T) {
 	initialWindow := sender.sender.GetCongestionWindow()
 	sender.LosePacket(sender.ackedPacketNumber + 1)
 	postLossWindow := sender.sender.GetCongestionWindow()
-	require.True(t, initialWindow > postLossWindow)
+	require.Greater(t, initialWindow, postLossWindow)
 	sender.LosePacket(sender.ackedPacketNumber + 3)
 	require.Equal(t, postLossWindow, sender.sender.GetCongestionWindow())
 	sender.LosePacket(sender.packetNumber - 1)
@@ -393,7 +393,7 @@ func TestCubicSenderMultipleLossesInOneWindow(t *testing.T) {
 
 	// Lose a later packet and ensure the window decreases.
 	sender.LosePacket(sender.packetNumber)
-	require.True(t, postLossWindow > sender.sender.GetCongestionWindow())
+	require.Greater(t, postLossWindow, sender.sender.GetCongestionWindow())
 }
 
 func TestCubicSender1ConnectionCongestionAvoidanceAtEndOfRecovery(t *testing.T) {
@@ -535,8 +535,8 @@ func TestCubicSenderSlowStartsPacketSizeIncrease(t *testing.T) {
 		sender.OnPacketAcked(protocol.PacketNumber(i), packetSize, sender.GetCongestionWindow(), clock.Now())
 	}
 	const maxCwnd = protocol.MaxCongestionWindowPackets * packetSize
-	require.True(t, sender.GetCongestionWindow() > maxCwnd)
-	require.True(t, sender.GetCongestionWindow() <= maxCwnd+packetSize)
+	require.Greater(t, sender.GetCongestionWindow(), maxCwnd)
+	require.LessOrEqual(t, sender.GetCongestionWindow(), maxCwnd+packetSize)
 }
 
 func TestCubicSenderLimitCwndIncreaseInCongestionAvoidance(t *testing.T) {
@@ -570,7 +570,7 @@ func TestCubicSenderLimitCwndIncreaseInCongestionAvoidance(t *testing.T) {
 	for i := 1; i < numSent; i++ {
 		testSender.AckNPackets(1)
 	}
-	require.Equal(t, protocol.ByteCount(0), testSender.bytesInFlight)
+	require.Zero(t, testSender.bytesInFlight)
 
 	savedCwnd = sender.GetCongestionWindow()
 	testSender.SendAvailableSendWindow()

--- a/internal/utils/ringbuffer/ringbuffer_test.go
+++ b/internal/utils/ringbuffer/ringbuffer_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestPushPeekPop(t *testing.T) {
 	r := RingBuffer[int]{}
-	require.Equal(t, 0, len(r.ring))
+	require.Empty(t, r.ring)
 	require.Panics(t, func() { r.PopFront() })
 	r.PushBack(1)
 	r.PushBack(2)

--- a/internal/wire/ack_frame_test.go
+++ b/internal/wire/ack_frame_test.go
@@ -380,9 +380,9 @@ func testACKTruncate(t *testing.T, origACK AckFrame) {
 	ack := cloneACK()
 	l := ack.Length(protocol.Version1)
 	ack.Truncate(1000, protocol.Version1)
-	require.Equal(t, expectedRanges, len(ack.AckRanges))
+	require.Len(t, ack.AckRanges, expectedRanges)
 	ack.Truncate(l, protocol.Version1)
-	require.Equal(t, expectedRanges, len(ack.AckRanges))
+	require.Len(t, ack.AckRanges, expectedRanges)
 
 	maxLen := l
 	for {
@@ -608,5 +608,5 @@ func benchmarkACKSerialization(b *testing.B, f *AckFrame) {
 	}
 
 	// the frame should not have been truncated
-	require.Equal(b, numRanges, len(f.AckRanges))
+	require.Len(b, f.AckRanges, numRanges)
 }

--- a/internal/wire/crypto_frame_test.go
+++ b/internal/wire/crypto_frame_test.go
@@ -45,7 +45,7 @@ func TestWriteCryptoFrame(t *testing.T) {
 	expected = append(expected, encodeVarInt(6)...)        // length
 	expected = append(expected, []byte("foobar")...)
 	require.Equal(t, expected, b)
-	require.Equal(t, int(f.Length(protocol.Version1)), len(b))
+	require.Len(t, b, int(f.Length(protocol.Version1)))
 }
 
 func TestCryptoFrameMaxDataLength(t *testing.T) {
@@ -77,7 +77,7 @@ func TestCryptoFrameMaxDataLength(t *testing.T) {
 			frameOneByteTooSmallCounter++
 			continue
 		}
-		require.Equal(t, i, len(b))
+		require.Len(t, b, i)
 	}
 	require.Equal(t, 1, frameOneByteTooSmallCounter)
 }

--- a/internal/wire/new_connection_id_frame_test.go
+++ b/internal/wire/new_connection_id_frame_test.go
@@ -84,5 +84,5 @@ func TestWriteNewConnectionIDFrame(t *testing.T) {
 	expected = append(expected, []byte{1, 2, 3, 4, 5, 6}...)
 	expected = append(expected, token[:]...)
 	require.Equal(t, expected, b)
-	require.Equal(t, int(frame.Length(protocol.Version1)), len(b))
+	require.Len(t, b, int(frame.Length(protocol.Version1)))
 }

--- a/internal/wire/pool_test.go
+++ b/internal/wire/pool_test.go
@@ -14,7 +14,7 @@ func TestGetAndPutStreamFrames(t *testing.T) {
 func TestPanicOnPuttingStreamFrameWithWrongCapacity(t *testing.T) {
 	f := GetStreamFrame()
 	f.Data = []byte("foobar")
-	require.Panics(t, func() { putStreamFrame(f) })
+	require.PanicsWithValue(t, "wire.PutStreamFrame called with packet of wrong size!", func() { putStreamFrame(f) })
 }
 
 func TestAcceptStreamFramesNotFromBuffer(t *testing.T) {

--- a/internal/wire/stream_data_blocked_frame_test.go
+++ b/internal/wire/stream_data_blocked_frame_test.go
@@ -42,5 +42,5 @@ func TestWriteStreamDataBlocked(t *testing.T) {
 	expected = append(expected, encodeVarInt(uint64(f.StreamID))...)
 	expected = append(expected, encodeVarInt(uint64(f.MaximumStreamData))...)
 	require.Equal(t, expected, b)
-	require.Equal(t, int(f.Length(protocol.Version1)), len(b))
+	require.Len(t, b, int(f.Length(protocol.Version1)))
 }

--- a/internal/wire/stream_frame_test.go
+++ b/internal/wire/stream_frame_test.go
@@ -137,7 +137,7 @@ func TestWriteStreamFrameWithoutOffset(t *testing.T) {
 	expected = append(expected, encodeVarInt(0x1337)...) // stream ID
 	expected = append(expected, []byte("foobar")...)
 	require.Equal(t, expected, b)
-	require.Equal(t, int(f.Length(protocol.Version1)), len(b))
+	require.Len(t, b, int(f.Length(protocol.Version1)))
 }
 
 func TestWriteStreamFrameWithOffset(t *testing.T) {
@@ -153,7 +153,7 @@ func TestWriteStreamFrameWithOffset(t *testing.T) {
 	expected = append(expected, encodeVarInt(0x123456)...) // offset
 	expected = append(expected, []byte("foobar")...)
 	require.Equal(t, expected, b)
-	require.Equal(t, int(f.Length(protocol.Version1)), len(b))
+	require.Len(t, b, int(f.Length(protocol.Version1)))
 }
 
 func TestWriteStreamFrameWithFIN(t *testing.T) {
@@ -168,7 +168,7 @@ func TestWriteStreamFrameWithFIN(t *testing.T) {
 	expected = append(expected, encodeVarInt(0x1337)...)   // stream ID
 	expected = append(expected, encodeVarInt(0x123456)...) // offset
 	require.Equal(t, expected, b)
-	require.Equal(t, int(f.Length(protocol.Version1)), len(b))
+	require.Len(t, b, int(f.Length(protocol.Version1)))
 }
 
 func TestWriteStreamFrameWithDataLength(t *testing.T) {
@@ -184,7 +184,7 @@ func TestWriteStreamFrameWithDataLength(t *testing.T) {
 	expected = append(expected, encodeVarInt(6)...)      // data length
 	expected = append(expected, []byte("foobar")...)
 	require.Equal(t, expected, b)
-	require.Equal(t, int(f.Length(protocol.Version1)), len(b))
+	require.Len(t, b, int(f.Length(protocol.Version1)))
 }
 
 func TestWriteStreamFrameWithDataLengthAndOffset(t *testing.T) {
@@ -202,7 +202,7 @@ func TestWriteStreamFrameWithDataLengthAndOffset(t *testing.T) {
 	expected = append(expected, encodeVarInt(6)...)        // data length
 	expected = append(expected, []byte("foobar")...)
 	require.Equal(t, expected, b)
-	require.Equal(t, int(f.Length(protocol.Version1)), len(b))
+	require.Len(t, b, int(f.Length(protocol.Version1)))
 }
 
 func TestWriteStreamFrameEmptyFrameWithoutFIN(t *testing.T) {
@@ -235,7 +235,7 @@ func TestStreamMaxDataLength(t *testing.T) {
 		f.Data = data[:int(maxDataLen)]
 		b, err := f.Append(nil, protocol.Version1)
 		require.NoError(t, err)
-		require.Equal(t, i, len(b))
+		require.Len(t, b, i)
 	}
 }
 
@@ -269,7 +269,7 @@ func TestStreamMaxDataLengthWithDataLenPresent(t *testing.T) {
 			frameOneByteTooSmallCounter++
 			continue
 		}
-		require.Equal(t, i, len(b))
+		require.Len(t, b, i)
 	}
 	require.Equal(t, 1, frameOneByteTooSmallCounter)
 }

--- a/internal/wire/streams_blocked_frame_test.go
+++ b/internal/wire/streams_blocked_frame_test.go
@@ -100,7 +100,7 @@ func TestWriteStreamsBlockedFrameBidirectional(t *testing.T) {
 	expected := []byte{byte(FrameTypeBidiStreamBlocked)}
 	expected = append(expected, encodeVarInt(0xdeadbeefcafe)...)
 	require.Equal(t, expected, b)
-	require.Equal(t, int(f.Length(protocol.Version1)), len(b))
+	require.Len(t, b, int(f.Length(protocol.Version1)))
 }
 
 func TestWriteStreamsBlockedFrameUnidirectional(t *testing.T) {
@@ -113,5 +113,5 @@ func TestWriteStreamsBlockedFrameUnidirectional(t *testing.T) {
 	expected := []byte{byte(FrameTypeUniStreamBlocked)}
 	expected = append(expected, encodeVarInt(0xdeadbeefcafe)...)
 	require.Equal(t, expected, b)
-	require.Equal(t, int(f.Length(protocol.Version1)), len(b))
+	require.Len(t, b, int(f.Length(protocol.Version1)))
 }

--- a/packet_packer_test.go
+++ b/packet_packer_test.go
@@ -858,7 +858,7 @@ func TestPackShortHeaderPadToAtLeast4Bytes(t *testing.T) {
 	require.NoError(t, err)
 	payload := data[l:]
 	require.Equal(t, protocol.PacketNumberLen1, pnLen)
-	require.Equal(t, 4-1 /* packet number length */, len(payload))
+	require.Len(t, payload, 4-1 /* packet number length */)
 	// the first byte of the payload should be a PADDING frame...
 	require.Equal(t, byte(0), payload[0])
 

--- a/path_manager_outgoing_test.go
+++ b/path_manager_outgoing_test.go
@@ -44,7 +44,7 @@ func TestPathManagerOutgoingPathProbing(t *testing.T) {
 		require.False(t, enabled)
 		connID, f, tr, ok := pm.NextPathToProbe()
 		require.True(t, ok)
-		require.Equal(t, tr1, tr)
+		require.Same(t, tr1, tr)
 		require.Equal(t, protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}), connID)
 		require.IsType(t, &wire.PathChallengeFrame{}, f.Frame)
 		pc := f.Frame.(*wire.PathChallengeFrame)
@@ -104,7 +104,7 @@ func TestPathManagerOutgoingPathProbing(t *testing.T) {
 		require.EqualError(t, p.Close(), "cannot close active path")
 		switchToTransport, ok := pm.ShouldSwitchPath()
 		require.True(t, ok)
-		require.Equal(t, tr1, switchToTransport)
+		require.Same(t, tr1, switchToTransport)
 	})
 }
 

--- a/path_manager_test.go
+++ b/path_manager_test.go
@@ -55,7 +55,7 @@ func TestPathManagerIntentionalMigration(t *testing.T) {
 		false,
 	)
 	require.Zero(t, connID)
-	require.Len(t, frames, 0)
+	require.Empty(t, frames)
 	require.False(t, shouldSwitch)
 
 	// receiving a packet for a different path triggers another PATH_CHALLENGE

--- a/qlog/qlog_dir_test.go
+++ b/qlog/qlog_dir_test.go
@@ -38,9 +38,7 @@ func testQLOGDIRSet(t *testing.T, qlogDir string, tracer qlogwriter.Trace, expec
 	recorder := tracer.AddProducer()
 	recorder.Close()
 
-	_, err := os.Stat(qlogDir)
-	qlogDirCreated := !os.IsNotExist(err)
-	require.True(t, qlogDirCreated)
+	require.DirExists(t, qlogDir)
 
 	entries, err := os.ReadDir(qlogDir)
 	require.NoError(t, err)

--- a/quicvarint/io_test.go
+++ b/quicvarint/io_test.go
@@ -43,13 +43,13 @@ var _ io.Writer = &nopWriter{}
 func TestReaderPassesThroughUnchanged(t *testing.T) {
 	b := bytes.NewReader([]byte{0})
 	r := NewReader(b)
-	require.Equal(t, b, r)
+	require.Same(t, b, r)
 }
 
 func TestReaderWrapsIOReader(t *testing.T) {
 	n := &nopReader{}
 	r := NewReader(n)
-	require.NotEqual(t, n, r)
+	require.NotSame(t, n, r)
 }
 
 func TestReaderFailure(t *testing.T) {
@@ -101,13 +101,13 @@ func TestReaderHandlesEmptyRead(t *testing.T) {
 func TestWriterPassesThroughUnchanged(t *testing.T) {
 	b := &bytes.Buffer{}
 	w := NewWriter(b)
-	require.Equal(t, b, w)
+	require.Same(t, b, w)
 }
 
 func TestWriterWrapsIOWriter(t *testing.T) {
 	n := &nopWriter{}
 	w := NewWriter(n)
-	require.NotEqual(t, n, w)
+	require.NotSame(t, n, w)
 }
 
 func TestWriterFailure(t *testing.T) {

--- a/quicvarint/varint_test.go
+++ b/quicvarint/varint_test.go
@@ -165,19 +165,20 @@ func TestAppendWithLen(t *testing.T) {
 
 func TestAppendWithLenFailures(t *testing.T) {
 	tests := []struct {
-		name   string
-		value  uint64
-		length int
+		name          string
+		value         uint64
+		length        int
+		expectedPanic string
 	}{
-		{"invalid length", 25, 3},
-		{"too short for 2 bytes", maxVarInt1 + 1, 1},
-		{"too short for 4 bytes", maxVarInt2 + 1, 2},
-		{"too short for 8 bytes", maxVarInt4 + 1, 4},
+		{"invalid length", 25, 3, "invalid varint length"},
+		{"too short for 2 bytes", maxVarInt1 + 1, 1, "cannot encode 64 in 1 bytes"},
+		{"too short for 4 bytes", maxVarInt2 + 1, 2, "cannot encode 16384 in 2 bytes"},
+		{"too short for 8 bytes", maxVarInt4 + 1, 4, "cannot encode 1073741824 in 4 bytes"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Panics(t, func() {
+			require.PanicsWithValue(t, tt.expectedPanic, func() {
 				AppendWithLen(nil, tt.value, tt.length)
 			})
 		})

--- a/receive_stream_test.go
+++ b/receive_stream_test.go
@@ -533,7 +533,7 @@ func TestReceiveStreamImmediateFINs(t *testing.T) {
 	// peeking returns the EOF
 	n, err := (&peekerWithTimeout{Peeker: str, Timeout: time.Second}).Peek(make([]byte, 4))
 	require.ErrorIs(t, err, io.EOF)
-	require.Equal(t, 0, n)
+	require.Zero(t, n)
 
 	// and so does reading
 	n, err = (&readerWithTimeout{Reader: str, Timeout: time.Second}).Read(make([]byte, 4))

--- a/sni_test.go
+++ b/sni_test.go
@@ -131,7 +131,7 @@ func shuffleClientHelloExtensions(t testing.TB, clientHello []byte) []byte {
 
 	// Extract the 3-byte length (24-bit integer) and validate total length
 	length := uint32(clientHello[1])<<16 | uint32(clientHello[2])<<8 | uint32(clientHello[3])
-	require.Equal(t, 4+int(length), len(clientHello))
+	require.Len(t, clientHello, 4+int(length))
 
 	// Body is everything after type and length
 	body := clientHello[4 : 4+length]
@@ -164,7 +164,7 @@ func shuffleClientHelloExtensions(t testing.TB, clientHello []byte) []byte {
 	}
 	extensionsLen := int(body[pos])<<8 | int(body[pos+1])
 	pos += 2
-	require.Equal(t, pos+extensionsLen, len(body)) // extensions length doesn't match remaining data
+	require.Len(t, body, pos+extensionsLen) // extensions length doesn't match remaining data
 	extensionsData := body[pos : pos+extensionsLen]
 
 	// parse extensions into a slice of byte slices

--- a/streams_map_outgoing_test.go
+++ b/streams_map_outgoing_test.go
@@ -44,7 +44,7 @@ func testStreamsMapOutgoingOpenAndDelete(t *testing.T, perspective protocol.Pers
 	require.Equal(t, firstStream, str1.id)
 	s, err := m.GetStream(firstStream)
 	require.NoError(t, err)
-	require.Equal(t, s, str1)
+	require.Same(t, str1, s)
 
 	str2, err := m.OpenStream()
 	require.NoError(t, err)

--- a/sys_conn_test.go
+++ b/sys_conn_test.go
@@ -18,7 +18,7 @@ func TestBasicConn(t *testing.T) {
 	addr := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1234}
 	c.EXPECT().ReadFrom(gomock.Any()).DoAndReturn(func(b []byte) (int, net.Addr, error) {
 		data := []byte("foobar")
-		require.Equal(t, protocol.MaxPacketBufferSize, len(b))
+		require.Len(t, b, protocol.MaxPacketBufferSize)
 		return copy(b, data), addr, nil
 	})
 

--- a/testutils/simnet/simlink_test.go
+++ b/testutils/simnet/simlink_test.go
@@ -2,7 +2,6 @@ package simnet
 
 import (
 	"fmt"
-	"math"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -81,22 +80,14 @@ func TestLatency(t *testing.T) {
 
 				observedLatency := recvStartTime.Sub(sendStartTime)
 				// Uplink is now instant (no latency), only downlink has latency
-				var expectedLatency time.Duration
 				if testUpload {
 					// Uplink test: expect near-zero latency
-					expectedLatency = 0
 					t.Logf("observed latency: %s (uplink is instant)", observedLatency)
-					if observedLatency > 5*time.Millisecond {
-						t.Fatalf("observed latency %s is too high for instant uplink", observedLatency)
-					}
+					require.LessOrEqual(t, observedLatency, 5*time.Millisecond)
 				} else {
 					// Downlink test: expect configured latency
-					expectedLatency = downlinkLatency
-					percentErrorLatency := math.Abs(observedLatency.Seconds()-expectedLatency.Seconds()) / expectedLatency.Seconds()
-					t.Logf("observed latency: %s, expected latency: %s, percent error: %f", observedLatency, expectedLatency, percentErrorLatency)
-					if percentErrorLatency > 0.20 {
-						t.Fatalf("observed latency %s is wrong", observedLatency)
-					}
+					t.Logf("observed latency: %s, expected latency: %s", observedLatency, downlinkLatency)
+					require.InEpsilon(t, downlinkLatency, observedLatency, 0.20)
 				}
 			})
 		})
@@ -146,8 +137,6 @@ func TestMTUEnforcement(t *testing.T) {
 		link.Close()
 
 		// Only packets within MTU should be received (2 packets: 1 from SendPacket, 1 from RecvPacket)
-		if packetsReceived.Load() != 2 {
-			t.Fatalf("expected 2 packets to be received, got %d", packetsReceived.Load())
-		}
+		require.Equal(t, uint32(2), packetsReceived.Load())
 	})
 }

--- a/testutils/simnet/simnet_synctest_test.go
+++ b/testutils/simnet/simnet_synctest_test.go
@@ -1,7 +1,6 @@
 package simnet
 
 import (
-	"math"
 	"net"
 	"testing"
 	"testing/synctest"
@@ -49,11 +48,7 @@ func TestSimpleSimNet(t *testing.T) {
 		observedLatency := time.Since(start)
 
 		// Only downlink has latency now (uplink is instant)
-		expectedLatency := latency
-		percentDiff := math.Abs(float64(observedLatency-expectedLatency) / float64(expectedLatency))
-		t.Logf("observed latency: %v, expected latency: %v, percent diff: %v", observedLatency, expectedLatency, percentDiff)
-		if percentDiff > 0.30 {
-			t.Fatalf("latency is wrong: %v. percent off: %v", observedLatency, percentDiff)
-		}
+		t.Logf("observed latency: %v, expected latency: %v", observedLatency, latency)
+		require.InEpsilon(t, latency, observedLatency, 0.30)
 	})
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace generic test checks with specific `require` assertions across test suite
- Replaces boolean comparisons and manual checks with type-specific assertions (e.g. `require.Len`, `require.Empty`, `require.Same`, `require.Zero`, `require.Equal`, `require.NotSame`) throughout the test suite
- Adds exact panic-value checks to panic tests in [buffer_pool_test.go](https://github.com/quic-go/quic-go/pull/5855/files#diff-a7a6afee9552b484bc808d01f33dc11d71a594e566379cf0fb5342bf375f2c78), [http3/response_writer_test.go](https://github.com/quic-go/quic-go/pull/5855/files#diff-fcf3c3eb6b20c1ce988d95e98fcfe610373457e0cdbbf71b9292a46028afcc1a), [internal/wire/pool_test.go](https://github.com/quic-go/quic-go/pull/5855/files#diff-922cdd60798f98b1f5260d936be886862d633542b9dc2e6f85fa81c0d109ca86), and [quicvarint/varint_test.go](https://github.com/quic-go/quic-go/pull/5855/files#diff-777541962f6ec79068a751a0adfb9e51bc3b460817f387da3b06a1a699a27a5b)
- Replaces manual `os.Stat` directory checks with `require.DirExists` in qlog directory tests
- Removes `math`-based percentage calculations in [testutils/simnet/simlink_test.go](https://github.com/quic-go/quic-go/pull/5855/files#diff-7e1f600b8a47a83fb19443d6312a1c2f5520a04bc223f1df976122683a2a045e) and [testutils/simnet/simnet_synctest_test.go](https://github.com/quic-go/quic-go/pull/5855/files#diff-35c3016446319de926e0c898b22d95e5ff5238718335c38718586321b9f9a65f), using assertion helpers instead
- Risk: none — all changes are test-only; tests now enforce stricter expected values (exact panic messages, pointer identity, directory existence) which may surface latent mismatches if those expectations are incorrect

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58bcb09.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test precision by validating exact panic messages and object identity where applicable.
  - Standardized assertions for lengths, empty values, ranges, timing, and collection contents.
  - Strengthened checks for configuration cloning, connection tracking, transport reuse, stream lookup, and qlog directory creation.
  - Simplified several timing, latency, packet, and network simulation validations without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->